### PR TITLE
fix(pgvector): add missing postgresql-configmap.yaml symlink

### DIFF
--- a/pgvector/templates/postgresql-configmap.yaml
+++ b/pgvector/templates/postgresql-configmap.yaml
@@ -1,0 +1,1 @@
+../../pg/templates/postgresql-configmap.yaml


### PR DESCRIPTION
## Summary

The `pgvector` chart shares all of its templates with the `pg` chart via symlinks under `pgvector/templates/`. One symlink was missing: `postgresql-configmap.yaml`. This PR adds it. No template content changes, no values schema changes — a one-line addition to bring `pgvector/templates/` to parity with `pg/templates/` and with the other 15 symlinks already in `pgvector/templates/`.

## The bug

`pgvector/templates/statefulset.yaml` is a symlink to `pg/templates/statefulset.yaml`. At line 31 it has:

```gotpl
{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.podAnnotations }}
      annotations:
{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled }}
        checksum/postgresql-config: {{ include (print $.Template.BasePath "/postgresql-configmap.yaml") . | sha256sum }}
{{- end }}
```

The same template is also referenced at:

- line 339-340 — `volumeMount` at `/etc/postgresql/conf.d`
- line 507-510 — `volume` definition: `configMap: { name: {{ include "pg.fullname" . }}-postgresql-config }`

For the `pg` chart, this resolves to `pg/templates/postgresql-configmap.yaml`, which is present and correct.

For the `pgvector` chart, `$.Template.BasePath` resolves to `pgvector/templates`, and there is **no** `pgvector/templates/postgresql-configmap.yaml` (neither a real file nor a symlink to `pg/templates/postgresql-configmap.yaml`), while every other ConfigMap template in the same directory (`backup-configmap.yaml`, `pgbackrest-configmap.yaml`, `pgpool-configmap.yaml`, `prometheus-exporter-configmap.yaml`, `service-updater-configmap.yaml`) is symlinked. This looks like an oversight when the `pgvector` symlink fan-out was set up — the pattern is otherwise consistent.

### Reproduction

```bash
helm repo add cagriekin https://cagriekin.github.io/charts
helm pull cagriekin/pgvector --version 0.6.55 --untar
helm template test ./pgvector --set pgbackrest.enabled=true --set pgbackrest.existingSecret.name=test-secret
```

Result on current `master` and on every released `pgvector` tag from `0.6.51` through `0.6.55`:

```
Error: template: no template "pgvector/charts/pgvector/templates/postgresql-configmap.yaml" associated with template "gotpl"
```

The same `--set pgbackrest.enabled=true …` invocation works against the `pg` chart, which makes the symlink hypothesis straightforward to confirm.

Triggered by either:
- `postgresql.configuration` set to a non-empty map, or
- `pgbackrest.enabled: true`

(both are guarded by the same `or` in `statefulset.yaml`).

## Where this hit us

We package `cagriekin/pgvector` v0.6.55 as a Helm dependency inside an umbrella chart that provisions Postgres + pgvector clusters across multiple Kubernetes clusters. The first env that wired `pgbackrest.enabled: true` with a Huawei OBS-backed S3 endpoint failed at `helm template` time with the error above, before ArgoCD could even attempt a sync. Without this PR, pgBackRest cannot be enabled at all — the chart fails to render.

## Workaround we deployed in the meantime

Because Helm pools every `{{ define ... }}` block from the parent chart and all subcharts into a single named-template namespace, a missing subchart template can be satisfied from the parent chart. We added a file to our umbrella chart that:

1. Defines the named template the subchart's `include` is looking up:
   ```gotpl
   {{- define "pgvector/charts/pgvector/templates/postgresql-configmap.yaml" -}}{{- end }}
   ```
   This is an empty body — only there to satisfy the `include`. The `checksum` annotation then hashes the empty string and `helm template` succeeds.
2. Emits the actual `{{ include "pg.fullname" . }}-postgresql-config` ConfigMap that the subchart's volumeMount and volume reference, so the StatefulSet's pods can actually mount `/etc/postgresql/conf.d` and start. We also include `max_connections = 200` there to lift Postgres above the 100 default and accommodate PGPool's `numInitChildren × maxPool` ceiling.

This works but is fragile — it duplicates information the chart already encodes, and breaks the moment the subchart's `pg.fullname` helper output changes. Once this PR lands and we bump the dependency version, that workaround template can be deleted in a single commit on our side.

## The fix

```
pgvector/templates/postgresql-configmap.yaml -> ../../pg/templates/postgresql-configmap.yaml
```

A single symlink, byte-identical pattern to the other 15 symlinks in `pgvector/templates/`. `pg/templates/postgresql-configmap.yaml` already produces:

- `custom.conf` — quoted `key = 'value'` lines from `.Values.postgresql.configuration` when non-empty
- `pgbackrest-archive.conf` — `archive_mode = on`, `archive_command = 'pgbackrest --stanza=... archive-push %p'`, `wal_level = replica`, `max_wal_senders = 10` when `.Values.pgbackrest.enabled`

…both guarded by the same `or` condition that `statefulset.yaml` uses for the `include`, so the ConfigMap exists exactly when the StatefulSet needs it.

### Verification

After the symlink is in place:

```bash
helm template test ./pgvector \
  --set pgbackrest.enabled=true \
  --set pgbackrest.existingSecret.name=test-secret
# renders cleanly; ConfigMap test-pgvector-postgresql-config is present
# with pgbackrest-archive.conf entry

diff pg/templates/postgresql-configmap.yaml pgvector/templates/postgresql-configmap.yaml
# empty (symlink resolves to the same file)
```

No regression risk — the symlink only adds a file that other templates were already trying to reference.

## Out of scope

Deliberately not touching:

- `pg/templates/postgresql-configmap.yaml` content
- The other 15 `pgvector/templates/*` symlinks
- Anything in `values.yaml`, `Chart.yaml`, or release version

Happy to follow up with a separate PR if maintainers want to audit the symlink set for other gaps, but this PR keeps the surface area minimal.