### PR TITLE
fix(pgvector): use $POSTGRES_USER instead of hardcoded 'postgres' in postStart hook

### DIFF
--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with pgvector extension and optional PGPool-II
 type: application
-version: 0.6.56
+version: 0.6.57
 appVersion: "18.1"
 dependencies:
   - name: common

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -95,7 +95,7 @@ postgresql:
   lifecycle:
     postStart:
       additionalCommands: |
-        psql -U postgres -d "$POSTGRES_DB" -c "CREATE EXTENSION IF NOT EXISTS vector;" > /dev/null 2>&1
+        psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "CREATE EXTENSION IF NOT EXISTS vector;" > /dev/null 2>&1
 
 repmgr:
   image:


### PR DESCRIPTION
## Summary

The default `postgresql.lifecycle.postStart.additionalCommands` block in `pgvector/values.yaml` hardcodes the superuser as `postgres`:

```yaml
lifecycle:
  postStart:
    additionalCommands: |
      psql -U postgres -d "$POSTGRES_DB" -c "CREATE EXTENSION IF NOT EXISTS vector;" > /dev/null 2>&1
```

This PR replaces the literal `postgres` with the `$POSTGRES_USER` env var that the chart already injects into the postgres container.

## Why this change

The chart supports overriding the superuser via either `postgresql.username` or `postgresql.existingSecret.usernameKey`. When operators set a non-default name (e.g. `myadmin`), the StatefulSet starts the postgres container with `POSTGRES_USER=myadmin` and the role `postgres` never exists in the cluster.

The hardcoded `psql -U postgres ...` then fails on every container start with:

```
FATAL: role "postgres" does not exist
```

## What happens without this fix

- `psql` FATAL is a connection-level failure, so the postgres process itself keeps running and the pod becomes Ready.
- `CREATE EXTENSION vector` is **never executed**.
- pgvector is effectively unusable until an operator manually connects to the database and runs `CREATE EXTENSION vector;`.
- The failure is silent: nothing in the chart's events or pod status surfaces it; the only signal is a single FATAL line in the postgres logs that is easy to miss.

## How to reproduce

```bash
helm install test cagriekin/pgvector \
  --set postgresql.username=myadmin \
  --set postgresql.database=mydb

kubectl logs test-pgvector-0 -c postgresql | grep -i 'role "postgres"'
# FATAL: role "postgres" does not exist

kubectl exec test-pgvector-0 -c postgresql -- \
  psql -U myadmin -d mydb -c "SELECT * FROM pg_extension WHERE extname='vector';"
# (0 rows)
```

## The fix

```diff
-        psql -U postgres -d "$POSTGRES_DB" -c "CREATE EXTENSION IF NOT EXISTS vector;" > /dev/null 2>&1
+        psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "CREATE EXTENSION IF NOT EXISTS vector;" > /dev/null 2>&1
```

`POSTGRES_USER` is already exported into the postgres container by the StatefulSet (from the chart-managed Secret or the user-provided `existingSecret`), so no template changes are needed.

## Backward compatibility

With the default `username: postgres`, `$POSTGRES_USER` resolves to `postgres` — identical behavior. No breaking change for existing installations.

## Version bump

- `pgvector/Chart.yaml`: `0.6.56` → `0.6.57` (patch).
- `pg/Chart.yaml` is **not** bumped: the `pg` chart's own `values.yaml` ships `additionalCommands: ""`, so the bug only affects `pgvector/values.yaml` (which is a regular file, not a symlink to `pg/`).
