### PR TITLE
fix(pg,pgvector): repair MD5->SCRAM rehash + work around repmgr standby register

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -4,12 +4,22 @@
 
 ### Fixed
 
-- `fix_user_auth` postStart hook (0.5.54) embedded `:'u'` / `:'p'` inside a
-  dollar-quoted DO block where psql substitution does not run, so the
-  MD5→SCRAM rehash silently failed server-side and never executed. Values
-  now flow through per-session GUCs read via `current_setting()`. PG<14
-  skip, `format('%I/%L')` quoting, and `rolpassword LIKE 'md5%'`
-  idempotency gate preserved.
+- `fix_user_auth` postStart hook (0.5.54) used
+  `psql -c "DO $$ ... :'u' ... $$;"`. `psql -c` does **not** perform
+  `:'var'` substitution — per docs, the command must contain "no
+  psql-specific features". The server received `:'u'` literally and
+  rejected every call with `ERROR: syntax error at or near ":"`; the
+  MD5→SCRAM rehash silently never ran. Connectivity kept working because
+  the md5-fallback line in `pg_hba.conf` accepted the legacy hashes,
+  masking the failure on noisy clusters.
+  Fix: build the SQL into a bash variable and feed it to psql via
+  here-string (`<<<`), which goes through the MainLoop reader where
+  `:'var'` IS substituted. Values flow through per-session GUCs
+  (`myvars.tgt_user` / `myvars.tgt_pass` — `user` would clash with the
+  reserved keyword) read back inside the DO block via `current_setting()`.
+  PG<14 skip, `format('%I/%L')` quoting, idempotent `rolpassword LIKE
+  'md5%'` gate preserved. Failure now logs a loud line to pod stdout
+  instead of being swallowed by `>/dev/null`.
 - Standby `repmgr.nodes` row landed with `type=''` on the primary because
   `cagriekin/repmgr:trixie-5.5.0-7`'s entrypoint runs `repmgr standby
   register --force` without `--upstream-node-id`, crashing the standby

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,0 +1,60 @@
+# pg chart changelog
+
+## 0.5.55
+
+### Fixed
+
+- **`fix_user_auth` MD5→SCRAM migration was a silent no-op (regression from
+  0.5.54 / PR #99).** The postStart hook embedded `:'u'` and `:'p'` inside a
+  dollar-quoted `DO $$ … $$;` block. psql variable substitution is not
+  performed inside dollar-quoted constants, so every invocation failed server
+  side with `ERROR: syntax error at or near ":"` and the rehash never ran.
+  Auth kept working only because the md5-fallback line that 0.5.54 writes
+  into `pg_hba.conf` still accepted the legacy MD5 hashes. The migration now
+  hoists the values into per-session GUCs in regular SQL and reads them back
+  via `current_setting()` inside the DO block. `RAISE NOTICE` skip-on-PG<14
+  branch, `format('%I … %L', …)` identifier/literal quoting, and the
+  idempotent `rolpassword LIKE 'md5%'` gate are preserved unchanged.
+
+- **Standby `repmgr.nodes` row landed with `type=''` on the primary (image-side
+  bug, worked around in the chart).** The image's `repmgrd-entrypoint.sh`
+  calls `repmgr standby register --force` without `--upstream-node-id`. On
+  PG18 + repmgr 5.5.0 this leaves the standby's row on the primary with
+  `type=''`, and the image's own verify-loop then trips with `ERROR: Primary
+  does not show node N as standby (current type: )` and crashes the pod
+  (~5-minute CrashLoopBackOff). The chart now wraps the `repmgrd` container
+  command with a pre-register step that resolves the primary's `node_id` by
+  polling sibling pods, runs `repmgr standby register --upstream-node-id=…
+  --force`, and then `exec`s the image entrypoint, which becomes an
+  idempotent no-op UPDATE. The wrapper only runs on standby pods
+  (ordinal > 0); the primary pod path is unchanged.
+
+  The upstream fix lives in `cagriekin/repmgr-docker`. Once a tagged image
+  with the same fix is published, bump `repmgr.image.tag` accordingly and
+  drop the wrapper (kept as a `command:` block; deletion is mechanical).
+
+## Migrating from 0.5.54
+
+`helm upgrade my-release cagriekin/pg` is the entire migration. No operator
+action required, with these guarantees:
+
+- **No PVC recreation.** StatefulSet `volumeClaimTemplates` is unchanged.
+- **No StatefulSet recreation.** Only `template.spec.containers[].command`
+  for the `repmgrd` container and inline postStart script content for the
+  `postgresql` container change — both are in-place rollable fields.
+- **No password rotation.** `postgres`, `repmgr`, and `pgpool` keep their
+  existing plaintext passwords. Only their `pg_authid.rolpassword` hash type
+  may flip from MD5 to SCRAM on PG14+ when
+  `postgresql.migrateLegacyMd5Users: true` (the default, unchanged).
+- **No forced failover.** Standby pods restart in-place; the primary pod is
+  not touched first. Rolling restart respects `terminationGracePeriodSeconds`.
+- **No new required `values.yaml` field.** Both fixes are unconditional on
+  the code path that was already taking effect in 0.5.54.
+- **PG13 is still skipped.** The `RAISE NOTICE 'Skipping md5->scram migration
+  on PG < 14'` branch is preserved.
+
+If you previously installed 0.5.54 and saw `ERROR: syntax error at or near
+":"` in postgres logs, that line should disappear after the upgrade. The
+managed users (`POSTGRES_USER`, `REPMGR_USER`) will then complete the
+MD5→SCRAM rehash on the first pod start under 0.5.55 (idempotent — running
+again is a silent no-op).

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -4,57 +4,24 @@
 
 ### Fixed
 
-- **`fix_user_auth` MD5→SCRAM migration was a silent no-op (regression from
-  0.5.54 / PR #99).** The postStart hook embedded `:'u'` and `:'p'` inside a
-  dollar-quoted `DO $$ … $$;` block. psql variable substitution is not
-  performed inside dollar-quoted constants, so every invocation failed server
-  side with `ERROR: syntax error at or near ":"` and the rehash never ran.
-  Auth kept working only because the md5-fallback line that 0.5.54 writes
-  into `pg_hba.conf` still accepted the legacy MD5 hashes. The migration now
-  hoists the values into per-session GUCs in regular SQL and reads them back
-  via `current_setting()` inside the DO block. `RAISE NOTICE` skip-on-PG<14
-  branch, `format('%I … %L', …)` identifier/literal quoting, and the
-  idempotent `rolpassword LIKE 'md5%'` gate are preserved unchanged.
-
-- **Standby `repmgr.nodes` row landed with `type=''` on the primary (image-side
-  bug, worked around in the chart).** The image's `repmgrd-entrypoint.sh`
-  calls `repmgr standby register --force` without `--upstream-node-id`. On
-  PG18 + repmgr 5.5.0 this leaves the standby's row on the primary with
-  `type=''`, and the image's own verify-loop then trips with `ERROR: Primary
-  does not show node N as standby (current type: )` and crashes the pod
-  (~5-minute CrashLoopBackOff). The chart now wraps the `repmgrd` container
-  command with a pre-register step that resolves the primary's `node_id` by
-  polling sibling pods, runs `repmgr standby register --upstream-node-id=…
-  --force`, and then `exec`s the image entrypoint, which becomes an
-  idempotent no-op UPDATE. The wrapper only runs on standby pods
-  (ordinal > 0); the primary pod path is unchanged.
-
-  The upstream fix lives in `cagriekin/repmgr-docker`. Once a tagged image
-  with the same fix is published, bump `repmgr.image.tag` accordingly and
-  drop the wrapper (kept as a `command:` block; deletion is mechanical).
+- `fix_user_auth` postStart hook (0.5.54) embedded `:'u'` / `:'p'` inside a
+  dollar-quoted DO block where psql substitution does not run, so the
+  MD5→SCRAM rehash silently failed server-side and never executed. Values
+  now flow through per-session GUCs read via `current_setting()`. PG<14
+  skip, `format('%I/%L')` quoting, and `rolpassword LIKE 'md5%'`
+  idempotency gate preserved.
+- Standby `repmgr.nodes` row landed with `type=''` on the primary because
+  `cagriekin/repmgr:trixie-5.5.0-7`'s entrypoint runs `repmgr standby
+  register --force` without `--upstream-node-id`, crashing the standby
+  with `Primary does not show node N as standby`. The chart's `repmgrd`
+  container now pre-registers with an explicit upstream node_id and
+  delegates to the image entrypoint. Workaround until the image ships
+  the fix.
 
 ## Migrating from 0.5.54
 
-`helm upgrade my-release cagriekin/pg` is the entire migration. No operator
-action required, with these guarantees:
-
-- **No PVC recreation.** StatefulSet `volumeClaimTemplates` is unchanged.
-- **No StatefulSet recreation.** Only `template.spec.containers[].command`
-  for the `repmgrd` container and inline postStart script content for the
-  `postgresql` container change — both are in-place rollable fields.
-- **No password rotation.** `postgres`, `repmgr`, and `pgpool` keep their
-  existing plaintext passwords. Only their `pg_authid.rolpassword` hash type
-  may flip from MD5 to SCRAM on PG14+ when
-  `postgresql.migrateLegacyMd5Users: true` (the default, unchanged).
-- **No forced failover.** Standby pods restart in-place; the primary pod is
-  not touched first. Rolling restart respects `terminationGracePeriodSeconds`.
-- **No new required `values.yaml` field.** Both fixes are unconditional on
-  the code path that was already taking effect in 0.5.54.
-- **PG13 is still skipped.** The `RAISE NOTICE 'Skipping md5->scram migration
-  on PG < 14'` branch is preserved.
-
-If you previously installed 0.5.54 and saw `ERROR: syntax error at or near
-":"` in postgres logs, that line should disappear after the upgrade. The
-managed users (`POSTGRES_USER`, `REPMGR_USER`) will then complete the
-MD5→SCRAM rehash on the first pod start under 0.5.55 (idempotent — running
-again is a silent no-op).
+`helm upgrade my-release cagriekin/pg` is the entire migration: no PVC
+recreate, no StatefulSet recreate, no password rotation, no forced
+failover, no new required `values.yaml` field, PG13 still skipped. The
+MD5→SCRAM rehash completes on the first 0.5.55 pod start (idempotent on
+re-run).

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: PostgreSQL with repmgr replication and optional PGPool-II
 type: application
-version: 0.5.54
+version: 0.5.55
 appVersion: "18.1"
 dependencies:
   - name: common

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -306,12 +306,53 @@ spec:
                           rm -f "$HBA_TMP"
                         fi
                         {{- if .Values.postgresql.migrateLegacyMd5Users }}
+                        # PR #99 (0.6.58) shipped this as a one-liner that interpolated
+                        # :'u' / :'p' directly inside the dollar-quoted DO block. psql
+                        # variable substitution is NOT performed inside dollar-quoted
+                        # constants, so the server saw the literal `:` and rejected the
+                        # statement with `syntax error at or near ":"`. The MD5->SCRAM
+                        # rehash silently never ran. Connectivity kept working only
+                        # because the md5-fallback line written into pg_hba.conf above
+                        # let MD5 hashes continue to authenticate, masking the failure.
+                        #
+                        # Fix: hoist the values into per-session custom GUCs in regular
+                        # SQL (where psql substitution does run), and let the DO block
+                        # read them back via current_setting(). The GUCs live only for
+                        # the lifetime of this psql connection. Password is never
+                        # written to a file. (-v still places it in argv, visible to
+                        # /proc/<pid>/cmdline for in-pod readers — acceptable here
+                        # since pod-level access already grants the secret.)
                         fix_user_auth() {
                           local target_user="$1"
                           local target_pass="$2"
                           [ -z "$target_user" ] && return 0
                           [ -z "$target_pass" ] && return 0
-                          psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -v u="$target_user" -v p="$target_pass" --quiet --no-psqlrc -c "DO \$\$ DECLARE v_user TEXT := :'u'; v_pass TEXT := :'p'; BEGIN IF current_setting('server_version_num')::int < 140000 THEN RAISE NOTICE 'Skipping md5->scram migration on PG < 14 (no md5->scram auto-promotion in pg_hba)'; RETURN; END IF; IF EXISTS (SELECT 1 FROM pg_authid WHERE rolname = v_user AND rolpassword LIKE 'md5%') THEN SET LOCAL password_encryption = 'scram-sha-256'; EXECUTE format('ALTER USER %I WITH PASSWORD %L', v_user, v_pass); END IF; END \$\$;" >/dev/null
+                          psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+                            -v ON_ERROR_STOP=1 \
+                            -v u="$target_user" \
+                            -v p="$target_pass" \
+                            --quiet --no-psqlrc -c "
+                              SET myvars.user = :'u';
+                              SET myvars.pass = :'p';
+                              DO \$\$
+                              DECLARE
+                                v_user TEXT := current_setting('myvars.user');
+                                v_pass TEXT := current_setting('myvars.pass');
+                              BEGIN
+                                IF current_setting('server_version_num')::int < 140000 THEN
+                                  RAISE NOTICE 'Skipping md5->scram migration on PG < 14 (no md5->scram auto-promotion in pg_hba)';
+                                  RETURN;
+                                END IF;
+                                IF EXISTS (
+                                  SELECT 1 FROM pg_authid
+                                  WHERE rolname = v_user AND rolpassword LIKE 'md5%'
+                                ) THEN
+                                  SET LOCAL password_encryption = 'scram-sha-256';
+                                  EXECUTE format('ALTER USER %I WITH PASSWORD %L', v_user, v_pass);
+                                END IF;
+                              END
+                              \$\$;
+                            " >/dev/null
                         }
                         fix_user_auth "$POSTGRES_USER" "$POSTGRES_PASSWORD"
                         fix_user_auth "$REPMGR_USER" "$REPMGR_PASSWORD"
@@ -400,7 +441,65 @@ spec:
         - name: repmgrd
           image: "{{ .Values.repmgr.image.repository }}:{{ .Values.repmgr.image.tag }}"
           imagePullPolicy: {{ .Values.repmgr.image.pullPolicy }}
-          command: ["/usr/local/bin/entrypoint.sh", "repmgrd"]
+          # Chart-side workaround for cagriekin/repmgr <= trixie-5.5.0-7:
+          # the image's repmgrd-entrypoint.sh calls
+          #   `repmgr -f /etc/repmgr/repmgr.conf standby register --force`
+          # WITHOUT --upstream-node-id. On PG18 + repmgr 5.5.0 the row inserted
+          # on the primary's repmgr.nodes ends up with type='' (empty), and the
+          # image's verify-loop ("Primary does not show node N as standby") then
+          # crashes the pod into CrashLoopBackOff.
+          #
+          # We pre-register the standby with an explicit --upstream-node-id
+          # (resolved by polling sibling pods for `type='primary' AND active`)
+          # BEFORE delegating to the image's entrypoint. The image's own
+          # `standby register --force` then becomes an idempotent no-op UPDATE
+          # and its verify-loop passes on the first attempt. Re-registration on
+          # pod restart is safe because --force replaces the row in place.
+          #
+          # Drop this block once the default repmgr.image.tag is bumped to a
+          # release that carries the same fix in the image entrypoint.
+          # Tracking: github.com/cagriekin/repmgr-docker, repmgrd-entrypoint.sh:45.
+          command:
+            - /bin/bash
+            - -c
+            - |
+              ORDINAL="${HOSTNAME##*-}"
+              if [ "$ORDINAL" != "0" ]; then
+                BASE_NAME="${HOSTNAME%-*}"
+                echo "pre-register: waiting for local PostgreSQL..."
+                for i in $(seq 1 120); do
+                  if pg_isready -h 127.0.0.1 -p 5432 > /dev/null 2>&1; then
+                    break
+                  fi
+                  sleep 2
+                done
+                PRIMARY_HOST=""
+                PRIMARY_NODE_ID=""
+                for attempt in $(seq 1 60); do
+                  for i in $(seq 0 9); do
+                    [ "$i" = "$ORDINAL" ] && continue
+                    PARTNER="${BASE_NAME}-${i}.${HEADLESS_SERVICE}"
+                    if ! PGPASSWORD="${REPMGR_PASSWORD}" pg_isready -h "$PARTNER" -p 5432 -U "${REPMGR_USER}" -d "${REPMGR_DB}" > /dev/null 2>&1; then
+                      continue
+                    fi
+                    PNID=$(PGPASSWORD="${REPMGR_PASSWORD}" psql -h "$PARTNER" -p 5432 -U "${REPMGR_USER}" -d "${REPMGR_DB}" -tA -c "SELECT node_id FROM repmgr.nodes WHERE type='primary' AND active=true LIMIT 1;" 2>/dev/null || true)
+                    if [ -n "$PNID" ]; then
+                      PRIMARY_HOST="$PARTNER"
+                      PRIMARY_NODE_ID="$PNID"
+                      break 2
+                    fi
+                  done
+                  sleep 2
+                done
+                if [ -n "$PRIMARY_NODE_ID" ]; then
+                  echo "pre-register: standby register --upstream-node-id=${PRIMARY_NODE_ID} (primary=${PRIMARY_HOST})"
+                  repmgr -f /etc/repmgr/repmgr.conf standby register --upstream-node-id="${PRIMARY_NODE_ID}" --force \
+                    || echo "pre-register: standby register returned non-zero; deferring to image entrypoint"
+                else
+                  echo "pre-register: no primary found in repmgr.nodes after 120s; deferring to image entrypoint"
+                fi
+              fi
+              exec /usr/local/bin/entrypoint.sh repmgrd
           securityContext:
             {{- toYaml .Values.postgresql.containerSecurityContext | nindent 12 }}
           env:

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -306,41 +306,54 @@ spec:
                           rm -f "$HBA_TMP"
                         fi
                         {{- if .Values.postgresql.migrateLegacyMd5Users }}
-                        # `:'u'` / `:'p'` are NOT substituted inside a dollar-quoted
-                        # DO block (psql limitation), so 0.6.58 failed server-side and
-                        # the rehash silently never ran. Hoist values into per-session
-                        # GUCs in regular SQL and read them back via current_setting().
+                        # 0.6.58 used `psql -c "DO \$\$ ... :'u' ... \$\$;"`. Two
+                        # broken assumptions: (a) psql does NOT perform :'var'
+                        # substitution inside `-c` (docs: "no psql-specific
+                        # features"); (b) even if it did, substitution is also
+                        # skipped inside dollar-quoted constants. The server saw
+                        # `:'u'` literal, raised `syntax error at or near ":"`,
+                        # and the rehash silently never ran. Connectivity kept
+                        # working because the md5-fallback line in pg_hba.conf
+                        # masked the failure.
+                        #
+                        # Fix: feed SQL via stdin (psql MainLoop, where :'var'
+                        # IS substituted) and hoist user/pass into per-session
+                        # GUCs read back inside the DO block via current_setting().
+                        # GUC names use `tgt_user`/`tgt_pass` — `user` would
+                        # collide with the SQL reserved keyword.
                         fix_user_auth() {
                           local target_user="$1"
                           local target_pass="$2"
                           [ -z "$target_user" ] && return 0
                           [ -z "$target_pass" ] && return 0
-                          psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+                          local sql="
+                            SET myvars.tgt_user = :'u';
+                            SET myvars.tgt_pass = :'p';
+                            DO \$\$
+                            DECLARE
+                              v_user TEXT := current_setting('myvars.tgt_user');
+                              v_pass TEXT := current_setting('myvars.tgt_pass');
+                            BEGIN
+                              IF current_setting('server_version_num')::int < 140000 THEN
+                                RAISE NOTICE 'Skipping md5->scram migration on PG < 14 (no md5->scram auto-promotion in pg_hba)';
+                                RETURN;
+                              END IF;
+                              IF EXISTS (
+                                SELECT 1 FROM pg_authid
+                                WHERE rolname = v_user AND rolpassword LIKE 'md5%'
+                              ) THEN
+                                SET LOCAL password_encryption = 'scram-sha-256';
+                                EXECUTE format('ALTER USER %I WITH PASSWORD %L', v_user, v_pass);
+                              END IF;
+                            END
+                            \$\$;"
+                          if ! psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
                             -v ON_ERROR_STOP=1 \
                             -v u="$target_user" \
                             -v p="$target_pass" \
-                            --quiet --no-psqlrc -c "
-                              SET myvars.user = :'u';
-                              SET myvars.pass = :'p';
-                              DO \$\$
-                              DECLARE
-                                v_user TEXT := current_setting('myvars.user');
-                                v_pass TEXT := current_setting('myvars.pass');
-                              BEGIN
-                                IF current_setting('server_version_num')::int < 140000 THEN
-                                  RAISE NOTICE 'Skipping md5->scram migration on PG < 14 (no md5->scram auto-promotion in pg_hba)';
-                                  RETURN;
-                                END IF;
-                                IF EXISTS (
-                                  SELECT 1 FROM pg_authid
-                                  WHERE rolname = v_user AND rolpassword LIKE 'md5%'
-                                ) THEN
-                                  SET LOCAL password_encryption = 'scram-sha-256';
-                                  EXECUTE format('ALTER USER %I WITH PASSWORD %L', v_user, v_pass);
-                                END IF;
-                              END
-                              \$\$;
-                            " >/dev/null
+                            --no-psqlrc <<<"$sql"; then
+                            echo "fix_user_auth: md5->scram rehash failed for ${target_user} (psql returned non-zero, see error above)" >&2
+                          fi
                         }
                         fix_user_auth "$POSTGRES_USER" "$POSTGRES_PASSWORD"
                         fix_user_auth "$REPMGR_USER" "$REPMGR_PASSWORD"

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -306,22 +306,10 @@ spec:
                           rm -f "$HBA_TMP"
                         fi
                         {{- if .Values.postgresql.migrateLegacyMd5Users }}
-                        # PR #99 (0.6.58) shipped this as a one-liner that interpolated
-                        # :'u' / :'p' directly inside the dollar-quoted DO block. psql
-                        # variable substitution is NOT performed inside dollar-quoted
-                        # constants, so the server saw the literal `:` and rejected the
-                        # statement with `syntax error at or near ":"`. The MD5->SCRAM
-                        # rehash silently never ran. Connectivity kept working only
-                        # because the md5-fallback line written into pg_hba.conf above
-                        # let MD5 hashes continue to authenticate, masking the failure.
-                        #
-                        # Fix: hoist the values into per-session custom GUCs in regular
-                        # SQL (where psql substitution does run), and let the DO block
-                        # read them back via current_setting(). The GUCs live only for
-                        # the lifetime of this psql connection. Password is never
-                        # written to a file. (-v still places it in argv, visible to
-                        # /proc/<pid>/cmdline for in-pod readers — acceptable here
-                        # since pod-level access already grants the secret.)
+                        # `:'u'` / `:'p'` are NOT substituted inside a dollar-quoted
+                        # DO block (psql limitation), so 0.6.58 failed server-side and
+                        # the rehash silently never ran. Hoist values into per-session
+                        # GUCs in regular SQL and read them back via current_setting().
                         fix_user_auth() {
                           local target_user="$1"
                           local target_pass="$2"
@@ -441,23 +429,12 @@ spec:
         - name: repmgrd
           image: "{{ .Values.repmgr.image.repository }}:{{ .Values.repmgr.image.tag }}"
           imagePullPolicy: {{ .Values.repmgr.image.pullPolicy }}
-          # Chart-side workaround for cagriekin/repmgr <= trixie-5.5.0-7:
-          # the image's repmgrd-entrypoint.sh calls
-          #   `repmgr -f /etc/repmgr/repmgr.conf standby register --force`
-          # WITHOUT --upstream-node-id. On PG18 + repmgr 5.5.0 the row inserted
-          # on the primary's repmgr.nodes ends up with type='' (empty), and the
-          # image's verify-loop ("Primary does not show node N as standby") then
-          # crashes the pod into CrashLoopBackOff.
-          #
-          # We pre-register the standby with an explicit --upstream-node-id
-          # (resolved by polling sibling pods for `type='primary' AND active`)
-          # BEFORE delegating to the image's entrypoint. The image's own
-          # `standby register --force` then becomes an idempotent no-op UPDATE
-          # and its verify-loop passes on the first attempt. Re-registration on
-          # pod restart is safe because --force replaces the row in place.
-          #
-          # Drop this block once the default repmgr.image.tag is bumped to a
-          # release that carries the same fix in the image entrypoint.
+          # Workaround: cagriekin/repmgr <= trixie-5.5.0-7 calls
+          # `standby register --force` without --upstream-node-id, leaving the
+          # row on the primary with type='' on PG18 + repmgr 5.5.0 and crashing
+          # the standby. Pre-register here with an explicit upstream node_id,
+          # then exec the image entrypoint (its own register --force becomes a
+          # no-op UPDATE). Drop once the image ships the fix upstream.
           # Tracking: github.com/cagriekin/repmgr-docker, repmgrd-entrypoint.sh:45.
           command:
             - /bin/bash
@@ -465,38 +442,23 @@ spec:
             - |
               ORDINAL="${HOSTNAME##*-}"
               if [ "$ORDINAL" != "0" ]; then
-                BASE_NAME="${HOSTNAME%-*}"
-                echo "pre-register: waiting for local PostgreSQL..."
-                for i in $(seq 1 120); do
-                  if pg_isready -h 127.0.0.1 -p 5432 > /dev/null 2>&1; then
-                    break
-                  fi
-                  sleep 2
-                done
-                PRIMARY_HOST=""
-                PRIMARY_NODE_ID=""
-                for attempt in $(seq 1 60); do
+                BASE="${HOSTNAME%-*}"
+                for _ in $(seq 1 120); do pg_isready -h 127.0.0.1 > /dev/null 2>&1 && break; sleep 2; done
+                PNID=""
+                for _ in $(seq 1 60); do
                   for i in $(seq 0 9); do
                     [ "$i" = "$ORDINAL" ] && continue
-                    PARTNER="${BASE_NAME}-${i}.${HEADLESS_SERVICE}"
-                    if ! PGPASSWORD="${REPMGR_PASSWORD}" pg_isready -h "$PARTNER" -p 5432 -U "${REPMGR_USER}" -d "${REPMGR_DB}" > /dev/null 2>&1; then
-                      continue
-                    fi
-                    PNID=$(PGPASSWORD="${REPMGR_PASSWORD}" psql -h "$PARTNER" -p 5432 -U "${REPMGR_USER}" -d "${REPMGR_DB}" -tA -c "SELECT node_id FROM repmgr.nodes WHERE type='primary' AND active=true LIMIT 1;" 2>/dev/null || true)
-                    if [ -n "$PNID" ]; then
-                      PRIMARY_HOST="$PARTNER"
-                      PRIMARY_NODE_ID="$PNID"
-                      break 2
-                    fi
+                    P="${BASE}-${i}.${HEADLESS_SERVICE}"
+                    PGPASSWORD="${REPMGR_PASSWORD}" pg_isready -h "$P" -U "${REPMGR_USER}" -d "${REPMGR_DB}" > /dev/null 2>&1 || continue
+                    PNID=$(PGPASSWORD="${REPMGR_PASSWORD}" psql -h "$P" -U "${REPMGR_USER}" -d "${REPMGR_DB}" -tA \
+                      -c "SELECT node_id FROM repmgr.nodes WHERE type='primary' AND active=true LIMIT 1;" 2>/dev/null || true)
+                    [ -n "$PNID" ] && break 2
                   done
                   sleep 2
                 done
-                if [ -n "$PRIMARY_NODE_ID" ]; then
-                  echo "pre-register: standby register --upstream-node-id=${PRIMARY_NODE_ID} (primary=${PRIMARY_HOST})"
-                  repmgr -f /etc/repmgr/repmgr.conf standby register --upstream-node-id="${PRIMARY_NODE_ID}" --force \
-                    || echo "pre-register: standby register returned non-zero; deferring to image entrypoint"
-                else
-                  echo "pre-register: no primary found in repmgr.nodes after 120s; deferring to image entrypoint"
+                if [ -n "$PNID" ]; then
+                  echo "pre-register: standby register --upstream-node-id=${PNID}"
+                  repmgr -f /etc/repmgr/repmgr.conf standby register --upstream-node-id="${PNID}" --force || true
                 fi
               fi
               exec /usr/local/bin/entrypoint.sh repmgrd

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,0 +1,60 @@
+# pgvector chart changelog
+
+## 0.6.59
+
+### Fixed
+
+- **`fix_user_auth` MD5→SCRAM migration was a silent no-op (regression from
+  0.6.58 / PR #99).** The postStart hook embedded `:'u'` and `:'p'` inside a
+  dollar-quoted `DO $$ … $$;` block. psql variable substitution is not
+  performed inside dollar-quoted constants, so every invocation failed server
+  side with `ERROR: syntax error at or near ":"` and the rehash never ran.
+  Auth kept working only because the md5-fallback line that 0.6.58 writes
+  into `pg_hba.conf` still accepted the legacy MD5 hashes. The migration now
+  hoists the values into per-session GUCs in regular SQL and reads them back
+  via `current_setting()` inside the DO block. `RAISE NOTICE` skip-on-PG<14
+  branch, `format('%I … %L', …)` identifier/literal quoting, and the
+  idempotent `rolpassword LIKE 'md5%'` gate are preserved unchanged.
+
+- **Standby `repmgr.nodes` row landed with `type=''` on the primary (image-side
+  bug, worked around in the chart).** The image's `repmgrd-entrypoint.sh`
+  calls `repmgr standby register --force` without `--upstream-node-id`. On
+  PG18 + repmgr 5.5.0 this leaves the standby's row on the primary with
+  `type=''`, and the image's own verify-loop then trips with `ERROR: Primary
+  does not show node N as standby (current type: )` and crashes the pod
+  (~5-minute CrashLoopBackOff). The chart now wraps the `repmgrd` container
+  command with a pre-register step that resolves the primary's `node_id` by
+  polling sibling pods, runs `repmgr standby register --upstream-node-id=…
+  --force`, and then `exec`s the image entrypoint, which becomes an
+  idempotent no-op UPDATE. The wrapper only runs on standby pods
+  (ordinal > 0); the primary pod path is unchanged.
+
+  The upstream fix lives in `cagriekin/repmgr-docker`. Once a tagged image
+  with the same fix is published, bump `repmgr.image.tag` accordingly and
+  drop the wrapper (kept as a `command:` block; deletion is mechanical).
+
+## Migrating from 0.6.58
+
+`helm upgrade my-release cagriekin/pgvector` is the entire migration. No
+operator action required, with these guarantees:
+
+- **No PVC recreation.** StatefulSet `volumeClaimTemplates` is unchanged.
+- **No StatefulSet recreation.** Only `template.spec.containers[].command`
+  for the `repmgrd` container and inline postStart script content for the
+  `postgresql` container change — both are in-place rollable fields.
+- **No password rotation.** `postgres`, `repmgr`, and `pgpool` keep their
+  existing plaintext passwords. Only their `pg_authid.rolpassword` hash type
+  may flip from MD5 to SCRAM on PG14+ when
+  `postgresql.migrateLegacyMd5Users: true` (the default, unchanged).
+- **No forced failover.** Standby pods restart in-place; the primary pod is
+  not touched first. Rolling restart respects `terminationGracePeriodSeconds`.
+- **No new required `values.yaml` field.** Both fixes are unconditional on
+  the code path that was already taking effect in 0.6.58.
+- **PG13 is still skipped.** The `RAISE NOTICE 'Skipping md5->scram migration
+  on PG < 14'` branch is preserved.
+
+If you previously installed 0.6.58 and saw `ERROR: syntax error at or near
+":"` in postgres logs, that line should disappear after the upgrade. The
+managed users (`POSTGRES_USER`, `REPMGR_USER`) will then complete the
+MD5→SCRAM rehash on the first pod start under 0.6.59 (idempotent — running
+again is a silent no-op).

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -4,57 +4,24 @@
 
 ### Fixed
 
-- **`fix_user_auth` MD5→SCRAM migration was a silent no-op (regression from
-  0.6.58 / PR #99).** The postStart hook embedded `:'u'` and `:'p'` inside a
-  dollar-quoted `DO $$ … $$;` block. psql variable substitution is not
-  performed inside dollar-quoted constants, so every invocation failed server
-  side with `ERROR: syntax error at or near ":"` and the rehash never ran.
-  Auth kept working only because the md5-fallback line that 0.6.58 writes
-  into `pg_hba.conf` still accepted the legacy MD5 hashes. The migration now
-  hoists the values into per-session GUCs in regular SQL and reads them back
-  via `current_setting()` inside the DO block. `RAISE NOTICE` skip-on-PG<14
-  branch, `format('%I … %L', …)` identifier/literal quoting, and the
-  idempotent `rolpassword LIKE 'md5%'` gate are preserved unchanged.
-
-- **Standby `repmgr.nodes` row landed with `type=''` on the primary (image-side
-  bug, worked around in the chart).** The image's `repmgrd-entrypoint.sh`
-  calls `repmgr standby register --force` without `--upstream-node-id`. On
-  PG18 + repmgr 5.5.0 this leaves the standby's row on the primary with
-  `type=''`, and the image's own verify-loop then trips with `ERROR: Primary
-  does not show node N as standby (current type: )` and crashes the pod
-  (~5-minute CrashLoopBackOff). The chart now wraps the `repmgrd` container
-  command with a pre-register step that resolves the primary's `node_id` by
-  polling sibling pods, runs `repmgr standby register --upstream-node-id=…
-  --force`, and then `exec`s the image entrypoint, which becomes an
-  idempotent no-op UPDATE. The wrapper only runs on standby pods
-  (ordinal > 0); the primary pod path is unchanged.
-
-  The upstream fix lives in `cagriekin/repmgr-docker`. Once a tagged image
-  with the same fix is published, bump `repmgr.image.tag` accordingly and
-  drop the wrapper (kept as a `command:` block; deletion is mechanical).
+- `fix_user_auth` postStart hook (0.6.58) embedded `:'u'` / `:'p'` inside a
+  dollar-quoted DO block where psql substitution does not run, so the
+  MD5→SCRAM rehash silently failed server-side and never executed. Values
+  now flow through per-session GUCs read via `current_setting()`. PG<14
+  skip, `format('%I/%L')` quoting, and `rolpassword LIKE 'md5%'`
+  idempotency gate preserved.
+- Standby `repmgr.nodes` row landed with `type=''` on the primary because
+  `cagriekin/repmgr:trixie-5.5.0-7`'s entrypoint runs `repmgr standby
+  register --force` without `--upstream-node-id`, crashing the standby
+  with `Primary does not show node N as standby`. The chart's `repmgrd`
+  container now pre-registers with an explicit upstream node_id and
+  delegates to the image entrypoint. Workaround until the image ships
+  the fix.
 
 ## Migrating from 0.6.58
 
-`helm upgrade my-release cagriekin/pgvector` is the entire migration. No
-operator action required, with these guarantees:
-
-- **No PVC recreation.** StatefulSet `volumeClaimTemplates` is unchanged.
-- **No StatefulSet recreation.** Only `template.spec.containers[].command`
-  for the `repmgrd` container and inline postStart script content for the
-  `postgresql` container change — both are in-place rollable fields.
-- **No password rotation.** `postgres`, `repmgr`, and `pgpool` keep their
-  existing plaintext passwords. Only their `pg_authid.rolpassword` hash type
-  may flip from MD5 to SCRAM on PG14+ when
-  `postgresql.migrateLegacyMd5Users: true` (the default, unchanged).
-- **No forced failover.** Standby pods restart in-place; the primary pod is
-  not touched first. Rolling restart respects `terminationGracePeriodSeconds`.
-- **No new required `values.yaml` field.** Both fixes are unconditional on
-  the code path that was already taking effect in 0.6.58.
-- **PG13 is still skipped.** The `RAISE NOTICE 'Skipping md5->scram migration
-  on PG < 14'` branch is preserved.
-
-If you previously installed 0.6.58 and saw `ERROR: syntax error at or near
-":"` in postgres logs, that line should disappear after the upgrade. The
-managed users (`POSTGRES_USER`, `REPMGR_USER`) will then complete the
-MD5→SCRAM rehash on the first pod start under 0.6.59 (idempotent — running
-again is a silent no-op).
+`helm upgrade my-release cagriekin/pgvector` is the entire migration:
+no PVC recreate, no StatefulSet recreate, no password rotation, no
+forced failover, no new required `values.yaml` field, PG13 still
+skipped. The MD5→SCRAM rehash completes on the first 0.6.59 pod start
+(idempotent on re-run).

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -4,12 +4,22 @@
 
 ### Fixed
 
-- `fix_user_auth` postStart hook (0.6.58) embedded `:'u'` / `:'p'` inside a
-  dollar-quoted DO block where psql substitution does not run, so the
-  MD5→SCRAM rehash silently failed server-side and never executed. Values
-  now flow through per-session GUCs read via `current_setting()`. PG<14
-  skip, `format('%I/%L')` quoting, and `rolpassword LIKE 'md5%'`
-  idempotency gate preserved.
+- `fix_user_auth` postStart hook (0.6.58) used
+  `psql -c "DO $$ ... :'u' ... $$;"`. `psql -c` does **not** perform
+  `:'var'` substitution — per docs, the command must contain "no
+  psql-specific features". The server received `:'u'` literally and
+  rejected every call with `ERROR: syntax error at or near ":"`; the
+  MD5→SCRAM rehash silently never ran. Connectivity kept working because
+  the md5-fallback line in `pg_hba.conf` accepted the legacy hashes,
+  masking the failure on noisy clusters.
+  Fix: build the SQL into a bash variable and feed it to psql via
+  here-string (`<<<`), which goes through the MainLoop reader where
+  `:'var'` IS substituted. Values flow through per-session GUCs
+  (`myvars.tgt_user` / `myvars.tgt_pass` — `user` would clash with the
+  reserved keyword) read back inside the DO block via `current_setting()`.
+  PG<14 skip, `format('%I/%L')` quoting, idempotent `rolpassword LIKE
+  'md5%'` gate preserved. Failure now logs a loud line to pod stdout
+  instead of being swallowed by `>/dev/null`.
 - Standby `repmgr.nodes` row landed with `type=''` on the primary because
   `cagriekin/repmgr:trixie-5.5.0-7`'s entrypoint runs `repmgr standby
   register --force` without `--upstream-node-id`, crashing the standby

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with pgvector extension and optional PGPool-II
 type: application
-version: 0.6.58
+version: 0.6.59
 appVersion: "18.1"
 dependencies:
   - name: common


### PR DESCRIPTION
## Summary

Fixes two correctness bugs introduced in #99 (`pg` 0.5.54, `pgvector` 0.6.58).
Ships `pg` 0.5.55 / `pgvector` 0.6.59 as an in-place `helm upgrade`.

### Bug 1 — MD5→SCRAM rehash was a silent no-op

`fix_user_auth` ran `psql -c "DO $$ ... :'u' ... $$;"`. The original PR #99
attributed the failure to "dollar-quoted constants don't get psql substitution",
but the real root cause is one level deeper: per psql docs, the `-c` argument
**must contain no psql-specific features**, so `:'var'` substitution does not
happen there *at all* (not just inside dollar-quoted blocks). The server
received `:'u'` literally and rejected the statement with
`ERROR: syntax error at or near ":"`; the rehash silently never ran.
Connectivity kept working only because the md5-fallback line in `pg_hba.conf`
accepted the legacy hashes, masking the failure.

**Fix:** assemble the SQL into a bash variable and feed it to psql via
here-string (`<<<`), which goes through MainLoop where `:'var'` IS
substituted. Values flow through per-session GUCs (`myvars.tgt_user` /
`myvars.tgt_pass` — `user` would clash with the SQL reserved keyword once
substitution actually fires) read back inside the DO block via
`current_setting()`. PG<14 skip, `format('%I/%L')` quoting, and the
idempotent `rolpassword LIKE 'md5%'` gate are preserved. On failure we now
write a loud line to pod stdout instead of swallowing it with `>/dev/null`.

### Bug 2 — Standby `repmgr.nodes` row had `type=''` on the primary

[`cagriekin/repmgr-docker/repmgrd-entrypoint.sh:45`](https://github.com/cagriekin/repmgr-docker/blob/master/repmgrd-entrypoint.sh#L45) runs

```bash
repmgr -f /etc/repmgr/repmgr.conf standby register --force
```

without `--upstream-node-id`. On PG18 + repmgr 5.5.0 the primary's
`repmgr.nodes` row ends up with `type=''`, the image's own verify-loop trips
with `Primary does not show node N as standby`, and the pod CrashLoopBackOffs.

Until the image ships a fix, the chart's `repmgrd` container now wraps the
entrypoint: standby pods poll siblings for `type='primary' AND active`, run
`repmgr standby register --upstream-node-id=… --force`, then `exec` the image
entrypoint (its own `--force` register becomes a no-op UPDATE, verify passes
on first attempt). Primary pod (ordinal 0) path is unchanged.

## Files

- `pg/templates/statefulset.yaml` — `fix_user_auth` rewritten, `repmgrd`
  `command` wrapped. `pgvector/templates/statefulset.yaml` is a symlink.
- `pg/Chart.yaml`, `pgvector/Chart.yaml` — patch bump.
- `pg/CHANGELOG.md`, `pgvector/CHANGELOG.md` — new.

## Test plan — verified locally in a kind cluster

`kind create cluster --config pg/kind-config.yaml` (1 control-plane + 3
workers), then `bash pg/tests/test-repmgr.sh` (1 primary + 1 standby with
the chart's default MD5 init path).

- [x] `helm lint` ✓ on minimal, repmgr, and pgvector+repmgr value sets.
- [x] `bash pg/tests/test-template.sh` ✓ (206/206).
- [x] `bash pg/tests/test-repmgr.sh` ✓ (19/19 — both pods Running, primary
      not-in-recovery, standby in-recovery, replication confirmed, master
      service points to primary).
- [x] **Bug 1 positive proof.** After install:
      ```
      SELECT rolname, substring(rolpassword, 1, 16), … FROM pg_authid …
       rolname  |   hash_prefix    | algo
      ----------+------------------+-------
       postgres |                  | OTHER
       repmgr   | SCRAM-SHA-256$40 | SCRAM
       testuser | SCRAM-SHA-256$40 | SCRAM
      ```
      No `syntax error at or near ":"` in postgres logs; no
      `fix_user_auth: … failed` lines.
- [x] **Bug 2 positive proof.** Standby pod reached `Running` on first
      attempt; `repmgrd` log shows
      `pre-register: standby register --upstream-node-id=1000`;
      ```
      SELECT node_id, node_name, type, active, upstream_node_id FROM repmgr.nodes;
       node_id |  node_name  |  type   | active | upstream_node_id
      ---------+-------------+---------+--------+------------------
          1000 | pg-repmgr-0 | primary | t      |
          1001 | pg-repmgr-1 | standby | t      |             1000
      ```
