### PR TITLE
fix(agent): a running standby never had a timeline, so it could never promote

### DIFF
--- a/images/repmgr/agent/internal/pg/probe.go
+++ b/images/repmgr/agent/internal/pg/probe.go
@@ -153,6 +153,24 @@ func (p *Prober) StandbyReceiveLSN(ctx context.Context, ci ConnInfo) (recv LSN, 
 	return recv, true, nil
 }
 
+// StandbyTimeline reads a standby's current timeline from the control file
+// (pg_control_checkpoint), since pg_walfile_name(pg_current_wal_lsn()) is
+// primary-only -- without it a RUNNING standby has no timeline, so unsafeToServe's
+// "timeline unreadable" guard would refuse to ever promote it and failover would
+// livelock. The control-file timeline is printed decimal, like pg_controldata
+// (NOT the hex WAL-file timeline), so it is parsed base 10.
+func (p *Prober) StandbyTimeline(ctx context.Context, ci ConnInfo) (tl Timeline, ok bool, err error) {
+	out, err := p.psql(ctx, ci, "SELECT timeline_id FROM pg_control_checkpoint();")
+	if err != nil {
+		return 0, false, err
+	}
+	n, perr := strconv.ParseUint(strings.TrimSpace(out), 10, 32)
+	if perr != nil {
+		return 0, false, nil
+	}
+	return Timeline(n), true, nil
+}
+
 // Probe classifies a node by its actual role and reads the WAL position relevant
 // to that role. An unreachable node returns NodeState{Host, Reachable:false}.
 func (p *Prober) Probe(ctx context.Context, ci ConnInfo) NodeState {
@@ -166,6 +184,9 @@ func (p *Prober) Probe(ctx context.Context, ci ConnInfo) NodeState {
 		ns.Role = RoleStandby
 		if recv, ok, _ := p.StandbyReceiveLSN(ctx, ci); ok {
 			ns.WriteLSN, ns.LSNOK = recv, true
+		}
+		if tl, ok, _ := p.StandbyTimeline(ctx, ci); ok {
+			ns.Timeline, ns.TimelineOK = tl, true
 		}
 		return ns
 	}

--- a/images/repmgr/agent/internal/pg/probe_test.go
+++ b/images/repmgr/agent/internal/pg/probe_test.go
@@ -10,10 +10,11 @@ import (
 // fakeExec dispatches on a distinctive token in the SQL (the last arg) so each
 // probe query can be stubbed independently.
 type fakeExec struct {
-	role    string // pg_is_in_recovery output ("t"/"f"/"")
-	primary string // pg_walfile_name(...)|pg_current_wal_lsn() output
-	standby string // pg_last_wal_receive_lsn() output
-	err     error  // if set, every call fails (node unreachable)
+	role      string // pg_is_in_recovery output ("t"/"f"/"")
+	primary   string // pg_walfile_name(...)|pg_current_wal_lsn() output
+	standby   string // pg_last_wal_receive_lsn() output
+	standbyTL string // pg_control_checkpoint timeline_id output (decimal)
+	err       error  // if set, every call fails (node unreachable)
 }
 
 func (f fakeExec) Run(_ context.Context, _ []string, _ string, args ...string) (string, error) {
@@ -24,6 +25,8 @@ func (f fakeExec) Run(_ context.Context, _ []string, _ string, args ...string) (
 	switch {
 	case strings.Contains(sql, "pg_is_in_recovery"):
 		return f.role, nil
+	case strings.Contains(sql, "pg_control_checkpoint"):
+		return f.standbyTL, nil
 	case strings.Contains(sql, "pg_last_wal_receive_lsn"):
 		return f.standby, nil
 	case strings.Contains(sql, "pg_walfile_name"):
@@ -49,16 +52,28 @@ func TestProbePrimary(t *testing.T) {
 }
 
 func TestProbeStandby(t *testing.T) {
-	p := proberWith(fakeExec{role: "t", standby: "16/B374D840"})
+	p := proberWith(fakeExec{role: "t", standby: "16/B374D840", standbyTL: "7"})
 	ns := p.Probe(context.Background(), ConnInfo{Host: "pod-1"})
 	if !ns.Reachable || ns.Role != RoleStandby {
 		t.Fatalf("got reachable=%v role=%v", ns.Reachable, ns.Role)
 	}
-	if ns.TimelineOK {
-		t.Errorf("standby should not report a primary timeline")
+	// A running standby MUST report its timeline (control-file, decimal), else
+	// unsafeToServe would refuse to ever promote it and failover would livelock.
+	if !ns.TimelineOK || ns.Timeline != 7 {
+		t.Errorf("standby timeline = (%d, ok=%v), want 7", ns.Timeline, ns.TimelineOK)
 	}
 	if !ns.LSNOK || ns.WriteLSN.Hi != 0x16 || ns.WriteLSN.Lo != 0xB374D840 {
 		t.Errorf("receive LSN = (%+v, ok=%v)", ns.WriteLSN, ns.LSNOK)
+	}
+}
+
+// A standby whose control-file timeline is unreadable must report TimelineOK=false
+// (so the highwater guard fails closed), not a bogus 0.
+func TestProbeStandbyTimelineUnreadable(t *testing.T) {
+	p := proberWith(fakeExec{role: "t", standby: "16/B374D840", standbyTL: ""})
+	ns := p.Probe(context.Background(), ConnInfo{Host: "pod-1"})
+	if ns.TimelineOK {
+		t.Errorf("unreadable standby timeline must be TimelineOK=false, got %d", ns.Timeline)
 	}
 }
 


### PR DESCRIPTION
## Summary

**CRITICAL, pre-existing, and masked by the unit tests.** The SQL probe set `Timeline/TimelineOK` only on the *primary* branch, and `observe()` filled the timeline from `pg_controldata` only when the node was *stopped*. So a **running standby always had `TimelineOK=false`**, which trips `unsafeToServe`'s "local timeline unreadable (#173)" guard — a standby that wins the lease therefore **always** hits `ReleaseLease` and never reaches `Promote`. Failover livelocks (release → re-elect → release) and no standby is ever promoted.

The reconcile unit fixtures set `TimelineOK=true` for standbys — a state the real probe never produced — so the suite stayed green while production failover was broken.

## Fix

The probe reads a standby's current timeline from `pg_control_checkpoint()` (decimal control-file timeline, not the hex WAL-file timeline). A standby now reports a timeline, so `unsafeToServe` passes and a standby holder can promote. The standby probe test (which had asserted the buggy "no timeline" state) is corrected, and an unreadable-timeline case is added that must fail closed.

Standalone: only the probe changes — `observe()` consumes it for the local node, so no reconcile change is needed.

## Scope / stacking

This branch is cut from `pr2-chart-agent-mode` (the agent epic) so the fix can ship **independently of the recovery-mode work**, which is push-blocked pending live KinD verification of a repmgr-catalog interaction. The focused change here is the single commit `d917f50`. Base is `pr2-chart-agent-mode` (the agent epic is not yet on `master`).

## Validation

- `go build ./... && go vet ./...` clean
- `go test ./...` green (all 10 packages); `go test -race ./internal/pg` clean
- corrected `TestProbeStandby` + new `TestProbeStandbyTimelineUnreadable`

A live KinD failover test (PR3) will exercise the standby-promote path end to end.

## Migration

None — agent behavior fix only; the image tag is unchanged (`trixie-5.5.0-16`, unpublished).

🤖 Generated with [Claude Code](https://claude.com/claude-code)