### PR TITLE
fix(pg,pgvector): monitoring user /probe DSN missing dbname → pg_up=0

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Fixed
+
+- **The least-privilege monitoring user (#28) broke the multi-target `/probe`
+  scrape — every per-target `pg_up` was 0.** The exporter `auth_modules` DSN (used
+  by `/probe`, unlike `DATA_SOURCE_NAME`) carried no database, so libpq defaulted
+  `dbname` to the username `monitoring` and connected to a non-existent `monitoring`
+  database (`pq: database "monitoring" does not exist`). It worked under the old
+  superuser only because `dbname` then defaulted to the always-present `postgres`.
+  The probe DSN now pins `dbname` to the configured database (substituted from
+  `POSTGRES_DATABASE`, the same source as `DATA_SOURCE_NAME` and the only database
+  the monitoring role is granted `CONNECT` on). No values or default changes.
+
 ## 1.1.4 - 2026-06-19
 
 Bundled-etcd security (#184). Bundles `etcd` 0.1.3; image moves to

--- a/pg/templates/_helpers.tpl
+++ b/pg/templates/_helpers.tpl
@@ -247,7 +247,8 @@ initContainers:
         # corrupts values containing / & or \).
         SUB_USER=$(printf '%s' "$POSTGRES_USER" | sed "s/'/''/g")
         SUB_PASS=$(printf '%s' "$POSTGRES_PASSWORD" | sed "s/'/''/g")
-        export SUB_USER SUB_PASS
+        SUB_DB=$(printf '%s' "$POSTGRES_DATABASE" | sed "s/'/''/g")
+        export SUB_USER SUB_PASS SUB_DB
         awk '
           function splice(s, ph, val,   out, i) {
             out = ""
@@ -256,6 +257,7 @@ initContainers:
           }
           { $0 = splice($0, "__POSTGRES_USER__", ENVIRON["SUB_USER"])
             $0 = splice($0, "__POSTGRES_PASSWORD__", ENVIRON["SUB_PASS"])
+            $0 = splice($0, "__POSTGRES_DB__", ENVIRON["SUB_DB"])
             print }
         ' /config/postgres_exporter.yml > /etc/postgres_exporter/postgres_exporter.yml
         # URI userinfo cannot carry @ : / etc. raw and Kubernetes $(VAR)

--- a/pg/templates/prometheus-exporter-configmap.yaml
+++ b/pg/templates/prometheus-exporter-configmap.yaml
@@ -20,6 +20,10 @@ data:
           password: '__POSTGRES_PASSWORD__'
         options:
           sslmode: disable
+          # The /probe builds its DSN from this auth module (not DATA_SOURCE_NAME);
+          # without an explicit dbname libpq defaults it to the username, so the
+          # monitoring user would hit a non-existent "monitoring" database (#28).
+          dbname: '__POSTGRES_DB__'
   queries.yaml: |
     # The exporter's built-in replication collector already serves
     # pg_replication_lag_seconds and pg_replication_is_replica; reusing the

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Monitoring user (#28) multi-target `/probe` scrape returned `pg_up=0` on every
+  target.** The exporter `auth_modules` probe DSN had no database, so libpq used the
+  username `monitoring` as the dbname (`database "monitoring" does not exist`). The
+  probe now pins `dbname` to the configured database. Shared fix with the pg chart
+  (templates are symlinked); see the pg CHANGELOG for detail.
+
 ## 1.1.4 - 2026-06-19
 
 Bundled-etcd security (#184). Bundles `etcd` 0.1.3; image moves to


### PR DESCRIPTION
## Summary
The least-privilege monitoring user (#28) breaks the multi-target `/probe` scrape: every per-target `pg_up` is 0.

## Root cause
The exporter has two connection paths:
- `DATA_SOURCE_NAME` (default scrape), built in `_helpers.tpl` with the database (`.../5432/${ENC_DB}?sslmode=disable`) → works.
- `auth_modules` in `prometheus-exporter-configmap.yaml`, used by the multi-target `/probe` (the ServiceMonitor scrapes `/probe?target=...`). Its `options` set only `sslmode`, **no database**.

With no `dbname`, libpq defaults it to the username. Under the monitoring user that is `monitoring`, which is not a database, so every per-target probe fails:
```
source=probe.go:81 ... err="error querying postgresql version: pq: database \"monitoring\" does not exist"
dsn="postgresql://monitoring:***@<pod>:5432?sslmode=disable"
```
It worked before #28 only because the superuser path defaulted `dbname` to the always-present `postgres`. The monitoring role is also granted `CONNECT` only on the configured database (`monitoring-user-job.yaml`), so the probe must target that database.

## Fix
Pin the auth_module `dbname` to the configured database, substituted at runtime from `POSTGRES_DATABASE` (the same source as `DATA_SOURCE_NAME`) via the existing placeholder/awk-splice mechanism. No values or default changes; fixes both monitoring-user and superuser modes. pg and pgvector share these templates (symlinks).

## Evidence (downstream)
Per-target `pg_up{job=...-postgresql}` was a steady 1 under the pre-#28 exporter and dropped to 0 the moment the monitoring-user exporter started; the exporter's own `pg_up` (DATA_SOURCE_NAME) stayed 1.

## Verification
`helm template pg`/`pgvector` with `prometheusExporter.enabled=true,prometheusExporter.monitoringUser.enabled=true` renders `dbname: '__POSTGRES_DB__'` in the configmap and the matching `SUB_DB` substitution in the init container. Recommend adding a kind assertion that `/probe` `pg_up == 1` with the monitoring user enabled.