### PR TITLE
feat(tls): optional client TLS for PostgreSQL, PGPool, and the export…

### DIFF
--- a/.github/workflows/pg-test.yaml
+++ b/.github/workflows/pg-test.yaml
@@ -182,6 +182,18 @@ jobs:
           kubectl delete namespace pg-test-agent-etcd-tls --ignore-not-found --wait=true --timeout=180s \
             || echo "WARNING: namespace cleanup timed out, continuing"
 
+      # Client-connection TLS (#110): CA + certs; proves PostgreSQL ssl=on, `require`
+      # rejecting non-TLS, mutual TLS rejecting a no-cert app user while the exempt
+      # internal users + replication + failover keep working, the exporter scraping over
+      # TLS, PGPool serving over TLS, and optional server TLS in repmgrd mode.
+      - name: Run client TLS test
+        run: make -C pg test-tls
+
+      - name: Clean up TLS namespaces
+        run: |
+          kubectl delete namespace pg-test-tls pg-test-tls-repmgrd pg-test-tls-standalone --ignore-not-found --wait=true --timeout=180s \
+            || echo "WARNING: namespace cleanup timed out, continuing"
+
       # The 1.0.0 breaking-change path: repmgrd -> agent via --cascade=orphan recreate.
       - name: Run repmgrd->agent migration test
         run: make -C pg test-migrate-agent

--- a/images/repmgr/agent/cmd/agent/main.go
+++ b/images/repmgr/agent/cmd/agent/main.go
@@ -763,6 +763,10 @@ func (a *agent) writePgHba() error {
 		ReplicationUser: a.cfg.RepmgrUser,
 		PeerCIDR:        a.cfg.PgHbaPeerCIDR,
 		ExtraRules:      a.cfg.PgHbaRules,
+		RequireSSL:      a.cfg.TLSRequireSSL,
+		ClientCertAuth:  a.cfg.TLSClientCertAuth,
+		PostgresUser:    a.cfg.PostgresUser,
+		MonitoringUser:  a.cfg.MonitoringUser,
 	})
 	return pgconf.WritePgHba(filepath.Join(a.cfg.PGDATA, "pg_hba.conf"), content)
 }

--- a/images/repmgr/agent/internal/config/config.go
+++ b/images/repmgr/agent/internal/config/config.go
@@ -42,6 +42,12 @@ type Config struct {
 	PgHbaPeerCIDR string   // POD_CIDR: the trusted pod network for SCRAM rules
 	PgHbaRules    []string // POSTGRESQL_PGHBA: user rules, placed above the catch-alls
 
+	// Client TLS pg_hba (issue #110). All optional; default off (TLS disabled).
+	TLSRequireSSL     bool   // TLS_REQUIRE_SSL: peer-CIDR client rule -> hostssl
+	TLSClientCertAuth bool   // TLS_CLIENT_CERT_AUTH: app users need a client cert (mTLS)
+	PostgresUser      string // POSTGRES_USER: superuser, exempt from clientcert
+	MonitoringUser    string // MONITORING_USER: monitoring user, exempt; "" when disabled
+
 	// etcd backend (required only when DCSBackend == "etcd"). TLS is optional
 	// (all-or-none, enforced by the dcs layer).
 	EtcdEndpoints []string
@@ -76,6 +82,17 @@ func (l *loader) dur(key string) time.Duration {
 		l.invalid = append(l.invalid, fmt.Sprintf("%s=%q (%v)", key, v, err))
 	}
 	return d
+}
+
+// boolEnv parses an optional boolean env value (true/1/yes, case-insensitive);
+// anything else (incl. empty/unset) is false.
+func boolEnv(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "true", "1", "yes":
+		return true
+	default:
+		return false
+	}
 }
 
 func (l *loader) intv(key string) int {
@@ -123,6 +140,13 @@ func Load(get func(string) string) (*Config, error) {
 			c.PgHbaRules = append(c.PgHbaRules, r)
 		}
 	}
+
+	// Client TLS pg_hba inputs (issue #110). Optional -- absent/empty means off, so
+	// existing installs are unchanged; no "missing" error.
+	c.TLSRequireSSL = boolEnv(get("TLS_REQUIRE_SSL"))
+	c.TLSClientCertAuth = boolEnv(get("TLS_CLIENT_CERT_AUTH"))
+	c.PostgresUser = strings.TrimSpace(get("POSTGRES_USER"))
+	c.MonitoringUser = strings.TrimSpace(get("MONITORING_USER"))
 
 	// Cross-field validation that the lease timings are internally consistent
 	// (client-go requires LeaseDuration > RenewDeadline > RetryPeriod).

--- a/images/repmgr/agent/internal/config/config_test.go
+++ b/images/repmgr/agent/internal/config/config_test.go
@@ -173,3 +173,68 @@ func TestStringRedactsPassword(t *testing.T) {
 		t.Errorf("String() should mask the password: %s", s)
 	}
 }
+
+// --- #110: client-TLS config fields ---
+
+func TestLoadTLSFieldsDefaultOff(t *testing.T) {
+	// fullEnv() sets no TLS vars -> every #110 field is off/empty (existing installs
+	// are unchanged; no "missing" error).
+	c, err := Load(getter(fullEnv()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.TLSRequireSSL || c.TLSClientCertAuth {
+		t.Errorf("TLS booleans must default false: require=%v mtls=%v", c.TLSRequireSSL, c.TLSClientCertAuth)
+	}
+	if c.PostgresUser != "" || c.MonitoringUser != "" {
+		t.Errorf("user exemptions must default empty: postgres=%q monitoring=%q", c.PostgresUser, c.MonitoringUser)
+	}
+}
+
+func TestLoadTLSFieldsParsed(t *testing.T) {
+	m := fullEnv()
+	m["TLS_REQUIRE_SSL"] = "true"
+	m["TLS_CLIENT_CERT_AUTH"] = "true"
+	m["POSTGRES_USER"] = "  postgres  " // trimmed
+	m["MONITORING_USER"] = "monitoring"
+	c, err := Load(getter(m))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.TLSRequireSSL || !c.TLSClientCertAuth {
+		t.Errorf("expected both TLS booleans true: %+v", c)
+	}
+	if c.PostgresUser != "postgres" {
+		t.Errorf("POSTGRES_USER must be trimmed: %q", c.PostgresUser)
+	}
+	if c.MonitoringUser != "monitoring" {
+		t.Errorf("MONITORING_USER mismatch: %q", c.MonitoringUser)
+	}
+}
+
+func TestLoadBoolEnvVariants(t *testing.T) {
+	truthy := []string{"true", "TRUE", "True", "1", "yes", "YES", " true "}
+	falsy := []string{"", "false", "0", "no", "off", "garbage", "2"}
+	for _, v := range truthy {
+		m := fullEnv()
+		m["TLS_REQUIRE_SSL"] = v
+		c, err := Load(getter(m))
+		if err != nil {
+			t.Fatalf("%q: %v", v, err)
+		}
+		if !c.TLSRequireSSL {
+			t.Errorf("TLS_REQUIRE_SSL=%q should parse true", v)
+		}
+	}
+	for _, v := range falsy {
+		m := fullEnv()
+		m["TLS_REQUIRE_SSL"] = v
+		c, err := Load(getter(m))
+		if err != nil {
+			t.Fatalf("%q: %v", v, err)
+		}
+		if c.TLSRequireSSL {
+			t.Errorf("TLS_REQUIRE_SSL=%q should parse false", v)
+		}
+	}
+}

--- a/images/repmgr/agent/internal/pgconf/pgconf.go
+++ b/images/repmgr/agent/internal/pgconf/pgconf.go
@@ -16,6 +16,19 @@ type PgHbaOptions struct {
 	ReplicationUser string   // repmgr replication user
 	PeerCIDR        string   // the trusted pod network (e.g. 10.0.0.0/8)
 	ExtraRules      []string // user-supplied postgresql.pgHba, placed ABOVE the network catch-alls (#144)
+
+	// Client TLS (issue #110), optional. RequireSSL makes the peer-CIDR client rule
+	// `hostssl` (reject non-TLS clients). ClientCertAuth additionally requires a
+	// client cert (clientcert=verify-ca) for app/other users, while the internal
+	// service users below are EXEMPTED (they authenticate by password over TLS and
+	// hold no client cert): the agent prober / repmgr CLI (ReplicationUser), pgpool
+	// health + service-updater (PostgresUser), and the exporter (MonitoringUser).
+	// Loopback and the replication rule are never converted -- replication stays
+	// plaintext on the pod network (#110 non-goal).
+	RequireSSL     bool
+	ClientCertAuth bool
+	PostgresUser   string // superuser, exempt from clientcert
+	MonitoringUser string // monitoring user, exempt from clientcert; "" to skip
 }
 
 // AssemblePgHba returns a hardened pg_hba.conf: loopback + the pod CIDR over
@@ -37,8 +50,27 @@ func AssemblePgHba(o PgHbaOptions) string {
 			}
 		}
 	}
+	// Replication stays plaintext (repmgr/agent conninfo carries no sslmode) -- never
+	// hostssl, even under require/mTLS (#110 non-goal).
 	fmt.Fprintf(&b, "host        replication   %s        %s        scram-sha-256\n", o.ReplicationUser, o.PeerCIDR)
-	fmt.Fprintf(&b, "host        all           all        %s        scram-sha-256\n", o.PeerCIDR)
+
+	switch {
+	case o.ClientCertAuth:
+		// mTLS: hostssl, with per-user exemptions for the internal service users
+		// (no clientcert) above the app catch-all (clientcert=verify-ca) (#110).
+		fmt.Fprintf(&b, "hostssl     all           %s        %s        scram-sha-256\n", o.ReplicationUser, o.PeerCIDR)
+		if o.PostgresUser != "" {
+			fmt.Fprintf(&b, "hostssl     all           %s        %s        scram-sha-256\n", o.PostgresUser, o.PeerCIDR)
+		}
+		if o.MonitoringUser != "" {
+			fmt.Fprintf(&b, "hostssl     all           %s        %s        scram-sha-256\n", o.MonitoringUser, o.PeerCIDR)
+		}
+		fmt.Fprintf(&b, "hostssl     all           all        %s        scram-sha-256 clientcert=verify-ca\n", o.PeerCIDR)
+	case o.RequireSSL:
+		fmt.Fprintf(&b, "hostssl     all           all        %s        scram-sha-256\n", o.PeerCIDR)
+	default:
+		fmt.Fprintf(&b, "host        all           all        %s        scram-sha-256\n", o.PeerCIDR)
+	}
 	return b.String()
 }
 

--- a/images/repmgr/agent/internal/pgconf/pgconf_test.go
+++ b/images/repmgr/agent/internal/pgconf/pgconf_test.go
@@ -30,6 +30,141 @@ func TestAssemblePgHbaIsHardened(t *testing.T) {
 	}
 }
 
+func TestAssemblePgHbaRequireSSL(t *testing.T) {
+	out := AssemblePgHba(PgHbaOptions{
+		ReplicationUser: "repmgr",
+		PeerCIDR:        "10.0.0.0/8",
+		RequireSSL:      true,
+	})
+	// The peer-CIDR client rule is hostssl (reject non-TLS).
+	if !strings.Contains(out, "hostssl     all           all        10.0.0.0/8        scram-sha-256") {
+		t.Errorf("require: peer-CIDR client rule must be hostssl:\n%s", out)
+	}
+	// Loopback and replication stay plain `host` (never hostssl) -- replication is plaintext (#110).
+	if !strings.Contains(out, "host        all           all        127.0.0.1/32") {
+		t.Errorf("require: loopback must stay plain host:\n%s", out)
+	}
+	if !strings.Contains(out, "host        replication   repmgr        10.0.0.0/8        scram-sha-256") {
+		t.Errorf("require: replication rule must stay plain host:\n%s", out)
+	}
+	if strings.Contains(out, "clientcert") {
+		t.Errorf("require without mTLS must not add clientcert:\n%s", out)
+	}
+}
+
+func TestAssemblePgHbaClientCertAuthExemptsInternalUsers(t *testing.T) {
+	out := AssemblePgHba(PgHbaOptions{
+		ReplicationUser: "repmgr",
+		PeerCIDR:        "10.0.0.0/8",
+		RequireSSL:      true,
+		ClientCertAuth:  true,
+		PostgresUser:    "postgres",
+		MonitoringUser:  "monitoring",
+	})
+	// Internal users get hostssl WITHOUT clientcert (password over TLS).
+	for _, u := range []string{"repmgr", "postgres", "monitoring"} {
+		line := "hostssl     all           " + u + "        10.0.0.0/8        scram-sha-256"
+		if !strings.Contains(out, line) {
+			t.Errorf("mTLS: internal user %q must be exempt from clientcert:\n%s", u, out)
+		}
+	}
+	// The app catch-all requires a client cert.
+	if !strings.Contains(out, "hostssl     all           all        10.0.0.0/8        scram-sha-256 clientcert=verify-ca") {
+		t.Errorf("mTLS: app catch-all must require clientcert=verify-ca:\n%s", out)
+	}
+	// Exemptions must appear ABOVE the clientcert catch-all (first match wins in pg_hba).
+	exIdx := strings.Index(out, "hostssl     all           postgres")
+	catchIdx := strings.Index(out, "clientcert=verify-ca")
+	if exIdx < 0 || catchIdx < 0 || exIdx > catchIdx {
+		t.Errorf("exemptions must precede the clientcert catch-all (ex=%d catch=%d):\n%s", exIdx, catchIdx, out)
+	}
+	// Replication stays plaintext even under mTLS.
+	if !strings.Contains(out, "host        replication   repmgr        10.0.0.0/8        scram-sha-256") {
+		t.Errorf("mTLS: replication rule must stay plain host:\n%s", out)
+	}
+}
+
+func TestAssemblePgHbaClientCertAuthSkipsEmptyMonitoringUser(t *testing.T) {
+	out := AssemblePgHba(PgHbaOptions{
+		ReplicationUser: "repmgr",
+		PeerCIDR:        "10.0.0.0/8",
+		ClientCertAuth:  true,
+		PostgresUser:    "postgres",
+		// MonitoringUser empty -> no monitoring exemption rule emitted.
+	})
+	if strings.Contains(out, "monitoring") {
+		t.Errorf("empty MonitoringUser must not emit a monitoring exemption:\n%s", out)
+	}
+	if !strings.Contains(out, "clientcert=verify-ca") {
+		t.Errorf("mTLS catch-all must still require clientcert:\n%s", out)
+	}
+}
+
+func TestAssemblePgHbaDefaultUnchangedByTLSFields(t *testing.T) {
+	// TLS off (zero-value options): byte-identical to the pre-#110 hardened default.
+	out := AssemblePgHba(PgHbaOptions{ReplicationUser: "repmgr", PeerCIDR: "10.0.0.0/8"})
+	if !strings.Contains(out, "host        all           all        10.0.0.0/8        scram-sha-256") {
+		t.Errorf("default must keep the plain host catch-all:\n%s", out)
+	}
+	if strings.Contains(out, "hostssl") || strings.Contains(out, "clientcert") {
+		t.Errorf("TLS off must not emit hostssl/clientcert:\n%s", out)
+	}
+}
+
+func TestAssemblePgHbaClientCertAuthOnlyForcesHostssl(t *testing.T) {
+	// clientCertAuth WITHOUT require (require=false): the switch checks ClientCertAuth
+	// first, so it still emits the full mTLS rule set -- there is NO plaintext host
+	// catch-all. This is the combination behind the cross-component guard fix (the
+	// exporter/pgpool sslmode guards must fire on clientCertAuth, not just require).
+	out := AssemblePgHba(PgHbaOptions{
+		ReplicationUser: "repmgr",
+		PeerCIDR:        "10.0.0.0/8",
+		ClientCertAuth:  true,
+		RequireSSL:      false, // explicitly off
+		PostgresUser:    "postgres",
+		MonitoringUser:  "monitoring",
+	})
+	if !strings.Contains(out, "hostssl     all           all        10.0.0.0/8        scram-sha-256 clientcert=verify-ca") {
+		t.Errorf("clientCertAuth alone must emit the clientcert catch-all:\n%s", out)
+	}
+	// No plaintext peer-CIDR catch-all may survive (else non-TLS clients slip through).
+	if strings.Contains(out, "host        all           all        10.0.0.0/8") {
+		t.Errorf("clientCertAuth must not leave a plaintext host catch-all:\n%s", out)
+	}
+}
+
+func TestAssemblePgHbaRequireAndClientCertAuthMatchesClientCertOnly(t *testing.T) {
+	// require=true is subsumed by clientCertAuth=true: the rule set is identical whether
+	// require is also set, so the two flags never produce conflicting/duplicate rules.
+	base := PgHbaOptions{ReplicationUser: "repmgr", PeerCIDR: "10.0.0.0/8", ClientCertAuth: true, PostgresUser: "postgres"}
+	withReq := base
+	withReq.RequireSSL = true
+	if AssemblePgHba(base) != AssemblePgHba(withReq) {
+		t.Errorf("require+clientCertAuth must equal clientCertAuth-only:\n--- cca ---\n%s\n--- cca+req ---\n%s", AssemblePgHba(base), AssemblePgHba(withReq))
+	}
+}
+
+func TestAssemblePgHbaEmptyPostgresUserMTLS(t *testing.T) {
+	// Empty PostgresUser -> no postgres exemption line and no malformed empty-user rule;
+	// the repmgr exemption and the clientcert catch-all are still emitted.
+	out := AssemblePgHba(PgHbaOptions{
+		ReplicationUser: "repmgr",
+		PeerCIDR:        "10.0.0.0/8",
+		ClientCertAuth:  true,
+		// PostgresUser + MonitoringUser empty
+	})
+	if !strings.Contains(out, "hostssl     all           repmgr        10.0.0.0/8        scram-sha-256") {
+		t.Errorf("repmgr exemption must still be present:\n%s", out)
+	}
+	if !strings.Contains(out, "clientcert=verify-ca") {
+		t.Errorf("clientcert catch-all must still be present:\n%s", out)
+	}
+	// A double-space gap (empty username spliced into the format) would be a malformed rule.
+	if strings.Contains(out, "hostssl     all                     10.0.0.0/8") {
+		t.Errorf("empty PostgresUser must not splice a blank-username rule:\n%s", out)
+	}
+}
+
 func TestEnsureConfdIncludeIdempotentToggle(t *testing.T) {
 	dir := t.TempDir()
 	conf := filepath.Join(dir, "postgresql.conf")

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## Unreleased
 
+## 1.2.0 - 2026-06-21
+
+Optional client-connection TLS for PostgreSQL, PGPool, and the metrics exporter (#110).
+Off by default — no rendered change at defaults. Image moves to `trixie-5.5.0-25`.
+
+### Added
+
+- **PostgreSQL server TLS (`postgresql.tls.enabled`).** Serves `ssl = on` from a BYO
+  Secret (`postgresql.tls.existingSecret`, keys `tls.crt`/`tls.key`/`ca.crt`, mounted
+  read-only at `/etc/postgresql/tls`, `defaultMode: 0400`) via a chart-managed
+  `tls.conf` injected over the `conf.d` include. Works in both agent and repmgrd mode and
+  in standalone (`replicaCount: 0`) installs.
+- **Enforced TLS (`postgresql.tls.require`) and mutual TLS
+  (`postgresql.tls.clientCertAuth`), agent mode only.** `require` makes the pod-CIDR
+  client rule `hostssl` (rejects non-TLS clients); `clientCertAuth` additionally requires
+  a client cert (`clientcert=verify-ca`) for app users. The chart's internal service users
+  (the `repmgr` user, the superuser, and the monitoring user) are **exempted** from the
+  client-cert requirement so the agent prober, repmgr, the exporter, and PGPool keep
+  working. Loopback and the `host replication` rule are never converted — **replication
+  stays plaintext on the pod network** (a documented non-goal; repmgr/agent replication
+  conninfo carries no `sslmode`).
+- **PGPool TLS (`pgpool.tls.*`).** Frontend `ssl = on` (`existingSecret`, optional
+  `clientCertAuth`), backend TLS to PostgreSQL via `backendSslmode`
+  (`disable|prefer|require|verify-ca|verify-full`), and `backendClientCert` so PGPool can
+  present a client cert to the backends under PostgreSQL mTLS.
+- **Exporter `sslmode` (`prometheusExporter.sslmode`).** `disable|require|verify-ca|
+  verify-full` for the metrics exporter's connection; `verify-*` mounts the CA from the
+  server-cert Secret and sets `sslrootcert`.
+- **Fail-fast guards.** Each `tls.enabled` requires its `existingSecret`;
+  `require`/`clientCertAuth` require `tls.enabled` and agent mode; `require` requires the
+  exporter and PGPool backend `sslmode >= require`; mTLS requires a CA and (with PGPool) a
+  PGPool backend client cert; `verify-*` requires `postgresql.tls.enabled`.
+
+### Fixed
+
+- The outer `volumes:`/`annotations:` gates on the StatefulSet now include
+  `postgresql.tls.enabled`, so a TLS-only install (no `postgresql.configuration`/
+  `pgbackrest`) renders the cert volume (not just its mount) and the config checksum that
+  rolls the pod when the cert/config changes.
+
+### Notes
+
+- repmgrd mode supports only **optional server TLS** (`ssl = on`); `require`/`clientCertAuth`
+  are agent-mode only (repmgrd's md5-fallback `pg_hba` line would bypass a `hostssl` rule)
+  and the render fails fast if requested there.
+- PostgreSQL reloads `ssl_*` on SIGHUP, not when the mounted Secret changes — run
+  `kubectl rollout restart` after rotating the cert Secret.
+
 ## 1.1.8 - 2026-06-21
 
 Quiets the etcd RBAC health-probe noise (#187). Bundles `etcd` 0.1.5; image moves to

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: PostgreSQL with repmgr replication and optional PGPool-II
 type: application
-version: 1.1.8
+version: 1.2.0
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/Makefile
+++ b/pg/Makefile
@@ -4,7 +4,7 @@ TESTS_DIR := tests
 MAKEFLAGS += --output-sync=target
 
 .PHONY: test test-template test-cluster test-minimal test-repmgr test-repmgr-chaos test-full test-failover test-upgrade \
-        test-repmgr-failover test-agent test-agent-etcd test-agent-etcd-tls test-migrate-agent test-scaledown test-agent-rolling test-config test-config-repmgr test-backup-restore test-special-chars byte-stable cluster-create cluster-delete cluster-exists clean help
+        test-repmgr-failover test-agent test-agent-etcd test-agent-etcd-tls test-tls test-migrate-agent test-scaledown test-agent-rolling test-config test-config-repmgr test-backup-restore test-special-chars byte-stable cluster-create cluster-delete cluster-exists clean help
 
 help:
 	@echo "Targets:"
@@ -19,6 +19,7 @@ help:
 	@echo "  test-agent      - Run lease-based agent install + failover tests"
 	@echo "  test-agent-etcd - Run agent etcd-DCS test (bundled etcd; standalone, opt-in)"
 	@echo "  test-agent-etcd-tls - Run agent etcd-DCS test over mutual TLS + RBAC (standalone, opt-in)"
+	@echo "  test-tls           - Run client-connection TLS test (PostgreSQL+PGPool+exporter, standalone, opt-in)"
 	@echo "  test-migrate-agent - Run repmgrd->agent migration test (standalone, long)"
 	@echo "  test-upgrade    - Run upgrade path tests"
 	@echo "  test-config     - Run postgresql configuration tests (standalone)"
@@ -65,6 +66,9 @@ test-agent-etcd: cluster-exists
 
 test-agent-etcd-tls: cluster-exists
 	@bash $(TESTS_DIR)/test-agent-etcd-tls.sh
+
+test-tls: cluster-exists
+	@bash $(TESTS_DIR)/test-tls.sh
 
 # repmgrd -> agent migration (--cascade=orphan recreate). Standalone + long-running
 # (installs repmgrd, then rolls to agent), so not in test-cluster; run explicitly.

--- a/pg/README.md
+++ b/pg/README.md
@@ -195,7 +195,7 @@ When `repmgr.enabled` is true, `additionalCommands` automatically discover the c
 |-----------|-------------|---------|
 | `repmgr.enabled` | Enable repmgr | `true` |
 | `repmgr.image.repository` | Repmgr image repository | `cagriekin/repmgr` |
-| `repmgr.image.tag` | Repmgr image tag | `trixie-5.5.0-24` |
+| `repmgr.image.tag` | Repmgr image tag | `trixie-5.5.0-25` |
 | `repmgr.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `repmgr.image.majorVersion` | PostgreSQL major bundled in the repmgr image. In repmgr mode the server always runs this major; `postgresql.majorVersion` must match or the chart fails to render. Bump with `repmgr.image.tag` when moving to an image built for a new PG major. | `"18"` |
 | `repmgr.username` | Repmgr database user | `repmgr` |
@@ -534,6 +534,68 @@ With `postgresql.replicaCount: 0` the service exists but has no endpoints.
 kubectl port-forward svc/my-postgres-pg-pgpool 9999:9999
 psql -h localhost -p 9999 -U postgres -d postgres
 ```
+
+## TLS / encrypted client connections
+
+Optional, off by default (no rendered change at defaults). Bring your own certificate in a
+Secret — the chart does not generate one (no cert-manager dependency).
+
+```yaml
+postgresql:
+  tls:
+    enabled: true
+    existingSecret: postgresql-tls   # keys: tls.crt, tls.key, ca.crt
+    require: false                   # reject non-TLS clients (agent mode only)
+    clientCertAuth: false            # mutual TLS for app users (agent mode only)
+```
+
+The server certificate **must** list SANs for the names clients connect to: the
+read-write Service (`<release>-pg`), the read-only Service (`<release>-pg-readonly`), the
+PGPool Service (`<release>-pg-pgpool`) if used, and the headless pod FQDNs
+(`*.<release>-pg-headless.<ns>.svc.cluster.local`). `ca.crt` is used only under
+`clientCertAuth` (to verify client certs) and by `verify-*` clients (to verify the server).
+
+**Server TLS** (`enabled` alone) sets `ssl = on`; clients may opt in with
+`sslmode=require`. **`require`** makes the pod-CIDR client rule `hostssl`, rejecting
+non-TLS connections. **`clientCertAuth`** additionally requires app users to present a
+client cert signed by `ca.crt`. The chart's internal service users (the `repmgr` user, the
+superuser, and the monitoring user) are **exempted** from the client-cert requirement, so
+the HA agent, repmgr, the exporter, and PGPool keep working; under `require` those
+components reach the server over TLS via libpq's default negotiation.
+
+When `require` is on, the exporter and the PGPool backend must also speak TLS
+(`prometheusExporter.sslmode >= require`, `pgpool.tls.backendSslmode >= require`); under
+`clientCertAuth` with PGPool, PGPool needs a backend client cert
+(`pgpool.tls.backendClientCert`) for app-user passthrough. The render fails fast if these
+are inconsistent.
+
+```yaml
+# PGPool TLS (frontend to clients + backend to PostgreSQL)
+pgpool:
+  tls:
+    enabled: true
+    existingSecret: pgpool-tls
+    backendSslmode: require
+    backendClientCert: pgpool-backend-tls   # required under PostgreSQL clientCertAuth
+prometheusExporter:
+  sslmode: require                          # disable|require|verify-ca|verify-full
+```
+
+Caveats:
+
+- **Replication stays plaintext** on the pod network — `require`/`clientCertAuth` never
+  convert the `host replication` or loopback `pg_hba` rules (repmgr/agent replication
+  conninfo carries no `sslmode`). This is a deliberate non-goal.
+- **`require`/`clientCertAuth` are agent-mode only** (`repmgr.failoverMode=agent`). In
+  repmgrd mode use `postgresql.tls.enabled` for optional server TLS; enforced TLS needs
+  agent mode (the render fails fast otherwise).
+- **Exporter `verify-full`:** the exporter scrapes each pod at its short headless name
+  (`<release>-pg-<i>.<release>-pg-headless`), so `prometheusExporter.sslmode=verify-full`
+  requires those short per-pod names in the server cert SANs. `verify-ca` (recommended for
+  the exporter) verifies the cert chain without the hostname check and needs no extra SANs.
+- **Cert rotation:** PostgreSQL reloads `ssl_*` on SIGHUP, not when the mounted Secret
+  changes. Run `kubectl rollout restart statefulset/<release>-pg` after rotating the
+  cert Secret.
 
 ## Replication Management
 
@@ -952,8 +1014,8 @@ kubectl scale statefulset my-postgres-pg --replicas=0
 # cloud-role annotation; the namespace default SA does not), and ensure the pod lands
 # where your IRSA/WI webhook injects the token; pgbackrest then uses the credential chain.
 kubectl run pg-restore --rm -it \
-  --image=cagriekin/repmgr:trixie-5.5.0-24 \
-  --overrides='{ "spec": { "securityContext": { "runAsUser": 101, "runAsGroup": 103, "fsGroup": 103, "runAsNonRoot": true, "seccompProfile": { "type": "RuntimeDefault" } }, "containers": [{ "name": "restore", "image": "cagriekin/repmgr:trixie-5.5.0-24", "command": ["bash"], "stdin": true, "tty": true, "securityContext": { "allowPrivilegeEscalation": false, "capabilities": { "drop": ["ALL"] } }, "volumeMounts": [{ "name": "data", "mountPath": "/var/lib/postgresql/data" }, { "name": "pgbackrest-config", "mountPath": "/etc/pgbackrest/pgbackrest.conf", "subPath": "pgbackrest.conf", "readOnly": true }], "env": [{ "name": "PGBACKREST_REPO1_S3_KEY", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "access-key-id" } } }, { "name": "PGBACKREST_REPO1_S3_KEY_SECRET", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "secret-access-key" } } }] }], "volumes": [{ "name": "data", "persistentVolumeClaim": { "claimName": "data-my-postgres-pg-0" } }, { "name": "pgbackrest-config", "configMap": { "name": "my-postgres-pg-pgbackrest" } }] } }'
+  --image=cagriekin/repmgr:trixie-5.5.0-25 \
+  --overrides='{ "spec": { "securityContext": { "runAsUser": 101, "runAsGroup": 103, "fsGroup": 103, "runAsNonRoot": true, "seccompProfile": { "type": "RuntimeDefault" } }, "containers": [{ "name": "restore", "image": "cagriekin/repmgr:trixie-5.5.0-25", "command": ["bash"], "stdin": true, "tty": true, "securityContext": { "allowPrivilegeEscalation": false, "capabilities": { "drop": ["ALL"] } }, "volumeMounts": [{ "name": "data", "mountPath": "/var/lib/postgresql/data" }, { "name": "pgbackrest-config", "mountPath": "/etc/pgbackrest/pgbackrest.conf", "subPath": "pgbackrest.conf", "readOnly": true }], "env": [{ "name": "PGBACKREST_REPO1_S3_KEY", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "access-key-id" } } }, { "name": "PGBACKREST_REPO1_S3_KEY_SECRET", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "secret-access-key" } } }] }], "volumes": [{ "name": "data", "persistentVolumeClaim": { "claimName": "data-my-postgres-pg-0" } }, { "name": "pgbackrest-config", "configMap": { "name": "my-postgres-pg-pgbackrest" } }] } }'
 
 # 3. Inside the restore pod, run (stanza = pgbackrest.stanza, default "db").
 # --type=time is REQUIRED with --target (pgbackrest rejects --target otherwise);
@@ -1184,8 +1246,8 @@ Each chart is tagged `<chart>-<version>` (e.g. `pg-1.1.0`); `pg` and `pgvector` 
 
 | `pg` / `pgvector` | repmgr image | PostgreSQL | Kubernetes |
 |-------------------|--------------|-----------|-----------|
-| 1.1.8 *(current)* | `trixie-5.5.0-24` | 18.x | ≥ 1.21 (PDB `policy/v1`); ≥ 1.27 for the agent-mode PDB `unhealthyPodEvictionPolicy` |
-| 1.0.0 – 1.1.7 | `trixie-5.5.0-16` … `-23` | 18.x | as above |
+| 1.2.0 *(current)* | `trixie-5.5.0-25` | 18.x | ≥ 1.21 (PDB `policy/v1`); ≥ 1.27 for the agent-mode PDB `unhealthyPodEvictionPolicy` |
+| 1.0.0 – 1.1.8 | `trixie-5.5.0-16` … `-24` | 18.x | as above |
 | 0.5.88 / 0.6.90 *(last 0.x)* | `trixie-5.5.0-15` | 18.x | ≥ 1.21 (PDB `policy/v1`) |
 
 Extras: agent monitoring (`repmgr.agent.monitoring.*`) needs the Prometheus Operator CRDs; the etcd backend (`repmgr.agent.dcs.backend: etcd`) needs an etcd ≥ 3.5 (BYO/shared) or the bundled etcd subchart (`etcd.enabled=true`).
@@ -1197,7 +1259,7 @@ helm repo update
 helm upgrade my-postgres cagriekin/pg   # add -f your-values.yaml
 ```
 
-Within the 1.x line the default is agent mode, and successive releases (e.g. `1.0.0` → `1.1.8`) are backward-compatible: `helm upgrade` rolls the pods once for the new image (`trixie-5.5.0-24` at 1.1.8) and the agent re-establishes leadership with no manual step. **Read every `Migrating from X.Y.Z` entry in [`CHANGELOG.md`](CHANGELOG.md) between your current version and the target** — some releases (credential, `pg_hba`, or image changes) carry one-time steps. The CHANGELOG keeps an unbroken trail back through the 0.x line.
+Within the 1.x line the default is agent mode, and successive releases (e.g. `1.0.0` → `1.2.0`) are backward-compatible: `helm upgrade` rolls the pods once for the new image (`trixie-5.5.0-25` at 1.2.0) and the agent re-establishes leadership with no manual step. **Read every `Migrating from X.Y.Z` entry in [`CHANGELOG.md`](CHANGELOG.md) between your current version and the target** — some releases (credential, `pg_hba`, or image changes) carry one-time steps. The CHANGELOG keeps an unbroken trail back through the 0.x line.
 
 ### Crossing the 0.x → 1.x boundary (agent mode is now the default)
 

--- a/pg/templates/_helpers.tpl
+++ b/pg/templates/_helpers.tpl
@@ -267,7 +267,7 @@ initContainers:
         ENC_USER=$(enc "$POSTGRES_USER")
         ENC_PASS=$(enc "$POSTGRES_PASSWORD")
         ENC_DB=$(enc "$POSTGRES_DATABASE")
-        printf '%s' "{{ range $i := until (int (add .Values.postgresql.replicaCount 1)) }}{{ if $i }},{{ end }}postgresql://${ENC_USER}:${ENC_PASS}@{{ include "pg.fullname" $ }}-{{ $i }}.{{ include "pg.fullname" $ }}-headless:5432/${ENC_DB}?sslmode=disable{{ end }}" > /etc/postgres_exporter/dsn
+        printf '%s' "{{ range $i := until (int (add .Values.postgresql.replicaCount 1)) }}{{ if $i }},{{ end }}postgresql://${ENC_USER}:${ENC_PASS}@{{ include "pg.fullname" $ }}-{{ $i }}.{{ include "pg.fullname" $ }}-headless:5432/${ENC_DB}?sslmode={{ $.Values.prometheusExporter.sslmode }}{{ if has $.Values.prometheusExporter.sslmode (list "verify-ca" "verify-full") }}&sslrootcert=/etc/postgres_exporter/tls/ca.crt{{ end }}{{ end }}" > /etc/postgres_exporter/dsn
     env:
 {{- if .Values.prometheusExporter.monitoringUser.enabled }}
       # #28: scrape as the least-privilege pg_monitor role (created by the
@@ -358,6 +358,12 @@ containers:
         mountPath: /config
       - name: tmp
         mountPath: /tmp
+{{- if and .Values.postgresql.tls.enabled (has .Values.prometheusExporter.sslmode (list "verify-ca" "verify-full")) }}
+      # CA to verify the PostgreSQL server cert under sslmode=verify-* (#110).
+      - name: postgresql-tls
+        mountPath: /etc/postgres_exporter/tls
+        readOnly: true
+{{- end }}
 volumes:
   - name: config
     configMap:
@@ -368,6 +374,12 @@ volumes:
   - name: tmp
     emptyDir:
       sizeLimit: 64Mi
+{{- if and .Values.postgresql.tls.enabled (has .Values.prometheusExporter.sslmode (list "verify-ca" "verify-full")) }}
+  - name: postgresql-tls
+    secret:
+      secretName: {{ .Values.postgresql.tls.existingSecret | quote }}
+      defaultMode: 0400
+{{- end }}
 {{- end }}
 
 {{/*

--- a/pg/templates/pgpool-configmap.yaml
+++ b/pg/templates/pgpool-configmap.yaml
@@ -77,7 +77,16 @@ data:
     connection_cache = on
     reset_query_list = '{{ .Values.pgpool.resetQueryList | toString | replace "'" "''" }}'
     load_balance_mode = on
+{{- if .Values.pgpool.tls.enabled }}
+    ssl = on
+    ssl_cert = '/usr/local/etc/tls/tls.crt'
+    ssl_key = '/usr/local/etc/tls/tls.key'
+{{- if .Values.pgpool.tls.clientCertAuth }}
+    ssl_ca_cert = '/usr/local/etc/tls/ca.crt'
+{{- end }}
+{{- else }}
     ssl = off
+{{- end }}
 
     pg_keepalives_idle = {{ .Values.pgpool.tcpKeepalive.idle }}
     pg_keepalives_interval = {{ .Values.pgpool.tcpKeepalive.interval }}

--- a/pg/templates/pgpool-deployment.yaml
+++ b/pg/templates/pgpool-deployment.yaml
@@ -132,6 +132,21 @@ spec:
               SUB_PASS=$(printf '%s' "$POSTGRES_PASSWORD" | sed -e 's/\\/\\\\/g' -e 's/:/\\:/g')
               SUB_DB="$POSTGRES_DB"
               subst /usr/local/etc/pool_passwd
+{{- if .Values.pgpool.tls.enabled }}
+              # Stage TLS certs from the read-only Secret mounts into the emptyDir with
+              # a 0600 key (pgpool/libpq reject a group/world-readable key), like the
+              # config staging above (#110).
+              mkdir -p /usr/local/etc/tls
+              cp /config-tls/tls.crt /usr/local/etc/tls/tls.crt
+              cp /config-tls/tls.key /usr/local/etc/tls/tls.key
+              chmod 0600 /usr/local/etc/tls/tls.key
+              [ -f /config-tls/ca.crt ] && cp /config-tls/ca.crt /usr/local/etc/tls/ca.crt
+{{- if .Values.pgpool.tls.backendClientCert }}
+              cp /config-tls-backend/tls.crt /usr/local/etc/tls/backend.crt
+              cp /config-tls-backend/tls.key /usr/local/etc/tls/backend.key
+              chmod 0600 /usr/local/etc/tls/backend.key
+{{- end }}
+{{- end }}
           env:
             - name: POSTGRES_USER
               valueFrom:
@@ -165,6 +180,16 @@ spec:
               mountPath: /config
             - name: pgpool-config
               mountPath: /usr/local/etc
+{{- if .Values.pgpool.tls.enabled }}
+            - name: pgpool-tls
+              mountPath: /config-tls
+              readOnly: true
+{{- if .Values.pgpool.tls.backendClientCert }}
+            - name: pgpool-tls-backend
+              mountPath: /config-tls-backend
+              readOnly: true
+{{- end }}
+{{- end }}
       containers:
         - name: pgpool
           image: {{ include "pg.image" .Values.pgpool.image | quote }}
@@ -189,6 +214,22 @@ spec:
               containerPort: 9898
               protocol: TCP
           env:
+{{- if .Values.pgpool.tls.enabled }}
+            # Backend TLS (pgpool -> PostgreSQL) via libpq env (#110). Under PostgreSQL
+            # mTLS, backendClientCert supplies the client cert pgpool presents.
+            - name: PGSSLMODE
+              value: {{ .Values.pgpool.tls.backendSslmode | quote }}
+{{- if has .Values.pgpool.tls.backendSslmode (list "verify-ca" "verify-full") }}
+            - name: PGSSLROOTCERT
+              value: /usr/local/etc/tls/ca.crt
+{{- end }}
+{{- if .Values.pgpool.tls.backendClientCert }}
+            - name: PGSSLCERT
+              value: /usr/local/etc/tls/backend.crt
+            - name: PGSSLKEY
+              value: /usr/local/etc/tls/backend.key
+{{- end }}
+{{- end }}
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -257,7 +298,7 @@ spec:
             - name: PGPOOL_SERVICE_PORT
               value: "9999"
             - name: SSLMODE
-              value: "disable"
+              value: {{ if .Values.pgpool.tls.enabled }}"require"{{ else }}"disable"{{ end }}
           ports:
             - name: metrics
               containerPort: 9719
@@ -288,4 +329,16 @@ spec:
         - name: pgpool-config
           emptyDir:
             sizeLimit: 16Mi
+{{- if .Values.pgpool.tls.enabled }}
+        - name: pgpool-tls
+          secret:
+            secretName: {{ required "pgpool.tls.enabled requires pgpool.tls.existingSecret (a Secret with keys tls.crt, tls.key[, ca.crt])" .Values.pgpool.tls.existingSecret | quote }}
+            defaultMode: 0444
+{{- if .Values.pgpool.tls.backendClientCert }}
+        - name: pgpool-tls-backend
+          secret:
+            secretName: {{ .Values.pgpool.tls.backendClientCert | quote }}
+            defaultMode: 0444
+{{- end }}
+{{- end }}
 {{- end }}

--- a/pg/templates/postgresql-configmap.yaml
+++ b/pg/templates/postgresql-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled }}
+{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -26,5 +26,17 @@ data:
     archive_command = 'pgbackrest --stanza={{ .Values.pgbackrest.stanza | toString | replace "'" "''" }} archive-push %p'
     wal_level = replica
     max_wal_senders = 10
+{{- end }}
+{{- if .Values.postgresql.tls.enabled }}
+  # Server TLS (#110). The cert Secret is mounted at /etc/postgresql/tls; ssl_ca_file
+  # is set only under mutual TLS (it verifies CLIENT certs). ssl is SIGHUP-reloadable;
+  # the configmap checksum annotation rolls the pod when this changes.
+  tls.conf: |
+    ssl = on
+    ssl_cert_file = '/etc/postgresql/tls/tls.crt'
+    ssl_key_file = '/etc/postgresql/tls/tls.key'
+{{- if .Values.postgresql.tls.clientCertAuth }}
+    ssl_ca_file = '/etc/postgresql/tls/ca.crt'
+{{- end }}
 {{- end }}
 {{- end }}

--- a/pg/templates/prometheus-exporter-configmap.yaml
+++ b/pg/templates/prometheus-exporter-configmap.yaml
@@ -19,7 +19,10 @@ data:
           username: '__POSTGRES_USER__'
           password: '__POSTGRES_PASSWORD__'
         options:
-          sslmode: disable
+          sslmode: {{ .Values.prometheusExporter.sslmode }}
+{{- if has .Values.prometheusExporter.sslmode (list "verify-ca" "verify-full") }}
+          sslrootcert: /etc/postgres_exporter/tls/ca.crt
+{{- end }}
           # The /probe builds its DSN from this auth module (not DATA_SOURCE_NAME);
           # without an explicit dbname libpq defaults it to the username, so the
           # monitoring user would hit a non-existent "monitoring" database (#28).

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -2,6 +2,39 @@
 {{- if and (not .Values.repmgr.enabled) (gt (int .Values.postgresql.replicaCount) 0) }}
 {{- fail "postgresql.replicaCount > 0 requires repmgr.enabled=true: with repmgr disabled the chart would run replicaCount+1 independent PostgreSQL instances with no replication between them. Set postgresql.replicaCount=0 for standalone mode or enable repmgr" }}
 {{- end }}
+{{- /* Client TLS validation (#110) */}}
+{{- if .Values.postgresql.tls.enabled }}
+{{- if not .Values.postgresql.tls.existingSecret }}{{ fail "postgresql.tls.enabled requires postgresql.tls.existingSecret (a Secret with keys tls.crt, tls.key, ca.crt)" }}{{- end }}
+{{- end }}
+{{- if and (or .Values.postgresql.tls.require .Values.postgresql.tls.clientCertAuth) (not .Values.postgresql.tls.enabled) }}
+{{- fail "postgresql.tls.require / clientCertAuth require postgresql.tls.enabled" }}
+{{- end }}
+{{- /* require/mTLS are enforced via the agent-assembled pg_hba (hostssl). In repmgrd
+       mode pg_hba carries an md5-fallback line that would bypass a hostssl rule, so
+       enforced TLS is unsafe there -- server TLS (ssl=on) still works; clients can opt
+       in with sslmode=require, or add explicit hostssl rules via postgresql.pgHba. */}}
+{{- if and (or .Values.postgresql.tls.require .Values.postgresql.tls.clientCertAuth) (ne (include "pg.agentMode" .) "true") }}
+{{- fail "postgresql.tls.require / clientCertAuth are supported only in agent mode (repmgr.failoverMode=agent). In repmgrd mode use postgresql.tls.enabled for optional server TLS; enforced TLS needs agent mode." }}
+{{- end }}
+{{- /* Cross-component sslmode consistency: when the server requires TLS, the exporter
+       must also use TLS or its scrapes are rejected by hostssl. clientCertAuth forces
+       hostssl on its own (it implies require in AssemblePgHba), so guard on either. */}}
+{{- $tlsRequired := or .Values.postgresql.tls.require .Values.postgresql.tls.clientCertAuth }}
+{{- if and $tlsRequired .Values.prometheusExporter.enabled (eq .Values.prometheusExporter.sslmode "disable") }}
+{{- fail "postgresql.tls.require/clientCertAuth requires prometheusExporter.sslmode >= require (else the exporter's scrapes are rejected by hostssl). Set prometheusExporter.sslmode: require (or verify-ca/verify-full)." }}
+{{- end }}
+{{- if and (has .Values.prometheusExporter.sslmode (list "verify-ca" "verify-full")) (not .Values.postgresql.tls.enabled) }}
+{{- fail "prometheusExporter.sslmode verify-ca/verify-full requires postgresql.tls.enabled (the CA from postgresql.tls.existingSecret is mounted to verify the server cert)." }}
+{{- end }}
+{{- /* pgpool backend must also speak TLS when the server requires it. */}}
+{{- if and $tlsRequired .Values.pgpool.enabled .Values.pgpool.tls.enabled (eq .Values.pgpool.tls.backendSslmode "disable") }}
+{{- fail "postgresql.tls.require/clientCertAuth requires pgpool.tls.backendSslmode >= require (else pgpool's backend connections are rejected by hostssl). Set pgpool.tls.backendSslmode: require (or verify-ca/verify-full)." }}
+{{- end }}
+{{- /* Under PostgreSQL mTLS, application connections passing through pgpool need pgpool
+       to present a backend client cert (the app users are not exempted from clientcert). */}}
+{{- if and .Values.postgresql.tls.clientCertAuth .Values.pgpool.enabled (or (not .Values.pgpool.tls.enabled) (not .Values.pgpool.tls.backendClientCert)) }}
+{{- fail "postgresql.tls.clientCertAuth=true with pgpool.enabled requires pgpool.tls.enabled and pgpool.tls.backendClientCert (a client cert pgpool presents to the backends for app-user passthrough under mTLS)." }}
+{{- end }}
 {{- if .Values.repmgr.enabled }}
 {{- $repmgrMajor := required "repmgr.image.majorVersion is required (the PostgreSQL major bundled in the repmgr image)" .Values.repmgr.image.majorVersion }}
 {{- if ne (toString .Values.postgresql.majorVersion) (toString $repmgrMajor) }}
@@ -68,9 +101,9 @@ spec:
       labels:
         {{- include "pg.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: postgresql
-{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.podAnnotations }}
+{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled .Values.postgresql.podAnnotations }}
       annotations:
-{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled }}
+{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled }}
         checksum/postgresql-config: {{ include (print $.Template.BasePath "/postgresql-configmap.yaml") . | sha256sum }}
 {{- end }}
 {{- if .Values.pgbackrest.enabled }}
@@ -259,7 +292,7 @@ spec:
             - -c
             - |
               CONF=/var/lib/postgresql/data/pgdata/postgresql.conf
-{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled }}
+{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled }}
               if [ -f "$CONF" ] && ! grep -q "include_dir = '/etc/postgresql/conf.d'" "$CONF"; then
                 echo "include_dir = '/etc/postgresql/conf.d'" >> "$CONF"
               fi
@@ -393,6 +426,19 @@ spec:
             - name: POSTGRESQL_PGHBA
               value: {{ join "\n" . | quote }}
 {{- end }}
+{{- if .Values.postgresql.tls.enabled }}
+            {{- /* Client TLS pg_hba (#110): the agent emits hostssl on the pod CIDR
+                   when require/clientCertAuth, exempting the internal service users
+                   (repmgr/postgres/monitoring) from the client-cert requirement. */}}
+            - name: TLS_REQUIRE_SSL
+              value: {{ .Values.postgresql.tls.require | quote }}
+            - name: TLS_CLIENT_CERT_AUTH
+              value: {{ .Values.postgresql.tls.clientCertAuth | quote }}
+{{- if and .Values.prometheusExporter.enabled .Values.prometheusExporter.monitoringUser.enabled }}
+            - name: MONITORING_USER
+              value: {{ .Values.prometheusExporter.monitoringUser.username | quote }}
+{{- end }}
+{{- end }}
             - name: DCS_BACKEND
               value: {{ (.Values.repmgr.agent.dcs).backend | default "kubernetes" | quote }}
 {{- if eq (include "pg.agentEtcdMode" .) "true" }}
@@ -466,7 +512,7 @@ spec:
                   - |
                     for i in {1..30}; do
                       if pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" > /dev/null 2>&1; then
-                        {{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled }}
+                        {{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled }}
                         CONF="$PGDATA/postgresql.conf"
                         if [ -f "$CONF" ] && ! grep -q "include_dir = '/etc/postgresql/conf.d'" "$CONF"; then
                           echo "include_dir = '/etc/postgresql/conf.d'" >> "$CONF"
@@ -505,7 +551,7 @@ spec:
                   - |
                     for i in {1..90}; do
                       if pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" > /dev/null 2>&1; then
-                        {{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled }}
+                        {{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled }}
                         CONF="$PGDATA/postgresql.conf"
                         if [ -f "$CONF" ] && ! grep -q "include_dir = '/etc/postgresql/conf.d'" "$CONF"; then
                           echo "include_dir = '/etc/postgresql/conf.d'" >> "$CONF"
@@ -737,9 +783,14 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
-{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled }}
+{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled }}
             - name: postgresql-config
               mountPath: /etc/postgresql/conf.d
+              readOnly: true
+{{- end }}
+{{- if .Values.postgresql.tls.enabled }}
+            - name: postgresql-tls
+              mountPath: /etc/postgresql/tls
               readOnly: true
 {{- end }}
 {{- if .Values.postgresql.extensions.enabled }}
@@ -999,12 +1050,21 @@ spec:
           resources:
             {{- toYaml .Values.pgbackrest.resources | nindent 12 }}
 {{- end }}
-{{- if or .Values.postgresql.configuration .Values.postgresql.extensions.enabled .Values.repmgr.enabled .Values.pgbackrest.enabled (not .Values.postgresql.persistence.enabled) }}
+{{- if or .Values.postgresql.configuration .Values.postgresql.extensions.enabled .Values.repmgr.enabled .Values.pgbackrest.enabled .Values.postgresql.tls.enabled (not .Values.postgresql.persistence.enabled) }}
       volumes:
-{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled }}
+{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled }}
         - name: postgresql-config
           configMap:
             name: {{ include "pg.fullname" . }}-postgresql-config
+{{- end }}
+{{- if .Values.postgresql.tls.enabled }}
+        # Server cert (#110). defaultMode 0400 + fsGroup 103 -> the postgres uid reads
+        # it and PostgreSQL accepts the key (root-owned, not group/world readable),
+        # the same pattern the etcd-tls mount uses below.
+        - name: postgresql-tls
+          secret:
+            secretName: {{ required "postgresql.tls.enabled requires postgresql.tls.existingSecret (a Secret with keys tls.crt, tls.key, ca.crt)" .Values.postgresql.tls.existingSecret | quote }}
+            defaultMode: 0400
 {{- end }}
 {{- if .Values.postgresql.extensions.enabled }}
         - name: ext-lib

--- a/pg/tests/test-migrate-agent.sh
+++ b/pg/tests/test-migrate-agent.sh
@@ -48,7 +48,7 @@ kubectl delete statefulset "${FULLNAME}" -n "${NAMESPACE}" --cascade=orphan
 # A real 1.0.0 migration also bumps the repmgr image to an agent-capable tag (the
 # pre-agent image has no `agent` entrypoint arm). values-repmgr.yaml installs the
 # released image; bump it to the agent-capable tag as part of the failoverMode flip.
-AGENT_IMAGE_TAG="${AGENT_IMAGE_TAG:-trixie-5.5.0-23}"
+AGENT_IMAGE_TAG="${AGENT_IMAGE_TAG:-trixie-5.5.0-25}"
 helm upgrade "${RELEASE}" "${CHART_DIR}" \
   -n "${NAMESPACE}" -f "${SCRIPT_DIR}/values-repmgr.yaml" \
   --set repmgr.failoverMode=agent --set "repmgr.image.tag=${AGENT_IMAGE_TAG}" --wait --timeout 10m

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -2399,5 +2399,202 @@ gann_merge=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-full-
 assert_contains "global.annotations: merges, global key kept (#128)" "${gann_merge}" "example.com/team: data platform"
 assert_contains "global.annotations: merges, component key kept (#128)" "${gann_merge}" "sts.local/own"
 
+# ======================================================================
+# #110: client-connection TLS (PostgreSQL + PGPool + exporter sslmode)
+# ======================================================================
+# Off by default the render is byte-stable (the rest of this suite renders with
+# TLS off); these assert the OFF render adds nothing, then exercise each knob.
+
+# --- default (TLS off): no ssl, no cert mount, no TLS env ---
+tls_off=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" 2>&1)
+assert_not_contains "#110 off: no postgresql tls.conf ssl=on" "${tls_off}" "ssl = on"
+assert_not_contains "#110 off: no postgresql-tls volume" "${tls_off}" "postgresql-tls"
+assert_not_contains "#110 off: no TLS_REQUIRE_SSL env" "${tls_off}" "TLS_REQUIRE_SSL"
+
+# --- Component 1: PostgreSQL server TLS (ssl=on via conf.d) ---
+tls_cm=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --show-only templates/postgresql-configmap.yaml 2>&1)
+assert_contains "#110 C1: tls.conf sets ssl = on" "${tls_cm}" "ssl = on"
+assert_contains "#110 C1: tls.conf sets ssl_cert_file" "${tls_cm}" "ssl_cert_file = '/etc/postgresql/tls/tls.crt'"
+assert_contains "#110 C1: tls.conf sets ssl_key_file" "${tls_cm}" "ssl_key_file = '/etc/postgresql/tls/tls.key'"
+assert_not_contains "#110 C1: no ssl_ca_file without mTLS" "${tls_cm}" "ssl_ca_file = '"
+# mTLS -> ssl_ca_file present (verifies client certs)
+tls_cm_mtls=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --set postgresql.tls.clientCertAuth=true \
+  --set pgpool.enabled=false \
+  --show-only templates/postgresql-configmap.yaml 2>&1)
+assert_contains "#110 C1: mTLS adds ssl_ca_file" "${tls_cm_mtls}" "ssl_ca_file = '/etc/postgresql/tls/ca.crt'"
+# cert mount + volume (defaultMode 0400, BYO secret name)
+tls_sts=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --show-only templates/statefulset.yaml 2>&1)
+assert_contains "#110 C1: cert mounted at /etc/postgresql/tls" "${tls_sts}" "mountPath: /etc/postgresql/tls"
+assert_contains "#110 C1: cert volume uses the BYO secret" "${tls_sts}" 'secretName: "pg-tls"'
+assert_contains "#110 C1: cert volume defaultMode 0400" "${tls_sts}" "defaultMode: 0400"
+# TLS-only install (no postgresql.configuration / pgbackrest): conf.d include must
+# still be wired (checksum annotation + include_dir management) or ssl=on never applies.
+assert_contains "#110 C1: TLS-only install keeps postgresql-config checksum" "${tls_sts}" "checksum/postgresql-config"
+assert_contains "#110 C1: TLS-only install keeps the conf.d include" "${tls_sts}" "include_dir = '/etc/postgresql/conf.d'"
+# standalone (repmgr off, replicaCount 0, persistence on): the cert VOLUME must
+# render alongside its mount (the outer volumes gate must include tls.enabled).
+tls_standalone=$(helm template test-pg "${CHART_DIR}" \
+  --set repmgr.enabled=false --set postgresql.replicaCount=0 \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --set postgresql.persistence.enabled=true \
+  --show-only templates/statefulset.yaml 2>&1)
+sa_mounts=$(printf '%s\n' "${tls_standalone}" | grep -c "name: postgresql-tls")
+assert_eq "#110 C1: standalone+TLS emits both the tls mount AND volume" "2" "${sa_mounts}"
+# fail-fast: tls.enabled without a Secret
+tls_nosecret_rc=0
+helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set postgresql.tls.enabled=true >/dev/null 2>&1 || tls_nosecret_rc=$?
+assert_eq "#110 C1: tls.enabled without existingSecret fails fast" "1" "$([ "${tls_nosecret_rc}" -ne 0 ] && echo 1 || echo 0)"
+
+# --- Component 2: require/mTLS pg_hba env wiring (agent assembles pg_hba) ---
+assert_contains "#110 C2: TLS_REQUIRE_SSL env present when tls.enabled" "${tls_sts}" "name: TLS_REQUIRE_SSL"
+assert_contains "#110 C2: TLS_CLIENT_CERT_AUTH env present when tls.enabled" "${tls_sts}" "name: TLS_CLIENT_CERT_AUTH"
+tls_require=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --set postgresql.tls.require=true \
+  --set prometheusExporter.enabled=true --set prometheusExporter.sslmode=require \
+  --show-only templates/statefulset.yaml 2>&1)
+assert_contains "#110 C2: require -> TLS_REQUIRE_SSL true" "${tls_require}" 'name: TLS_REQUIRE_SSL
+              value: "true"'
+# monitoring user passed so the agent can exempt it from clientcert
+tls_mon=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --set postgresql.tls.clientCertAuth=true \
+  --set prometheusExporter.enabled=true --set prometheusExporter.monitoringUser.enabled=true \
+  --set prometheusExporter.sslmode=require \
+  --set pgpool.enabled=false \
+  --show-only templates/statefulset.yaml 2>&1)
+assert_contains "#110 C2: mTLS passes MONITORING_USER for exemption" "${tls_mon}" "name: MONITORING_USER"
+# fail-fast: require/clientCertAuth need tls.enabled
+tls_req_noenable_rc=0
+helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set postgresql.tls.require=true >/dev/null 2>&1 || tls_req_noenable_rc=$?
+assert_eq "#110 C2: require without tls.enabled fails fast" "1" "$([ "${tls_req_noenable_rc}" -ne 0 ] && echo 1 || echo 0)"
+# fail-fast: require/mTLS unsupported in repmgrd mode (md5-fallback bypasses hostssl)
+tls_repmgrd_rc=0
+helm template test-pg "${CHART_DIR}" \
+  --set repmgr.enabled=true --set repmgr.failoverMode=repmgrd \
+  --set repmgr.image.majorVersion=18 --set postgresql.majorVersion=18 \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --set postgresql.tls.require=true >/dev/null 2>&1 || tls_repmgrd_rc=$?
+assert_eq "#110 C2: require in repmgrd mode fails fast (agent-only)" "1" "$([ "${tls_repmgrd_rc}" -ne 0 ] && echo 1 || echo 0)"
+# repmgrd mode with plain server TLS (no require) still renders ssl=on
+tls_repmgrd_ok=$(helm template test-pg "${CHART_DIR}" \
+  --set repmgr.enabled=true --set repmgr.failoverMode=repmgrd \
+  --set repmgr.image.majorVersion=18 --set postgresql.majorVersion=18 \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --show-only templates/postgresql-configmap.yaml 2>&1)
+assert_contains "#110 C2: repmgrd mode allows optional server TLS (ssl=on)" "${tls_repmgrd_ok}" "ssl = on"
+
+# --- Component 3: PGPool TLS (frontend + backend) ---
+pp_tls=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set pgpool.enabled=true --set pgpool.tls.enabled=true --set pgpool.tls.existingSecret=pp-tls \
+  --show-only templates/pgpool-configmap.yaml 2>&1)
+assert_contains "#110 C3: pgpool frontend ssl = on" "${pp_tls}" "ssl = on"
+assert_contains "#110 C3: pgpool ssl_cert path" "${pp_tls}" "ssl_cert = '/usr/local/etc/tls/tls.crt'"
+assert_not_contains "#110 C3: no ssl_ca_cert without frontend mTLS" "${pp_tls}" "ssl_ca_cert"
+pp_tls_mtls=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set pgpool.enabled=true --set pgpool.tls.enabled=true --set pgpool.tls.existingSecret=pp-tls \
+  --set pgpool.tls.clientCertAuth=true \
+  --show-only templates/pgpool-configmap.yaml 2>&1)
+assert_contains "#110 C3: pgpool frontend mTLS adds ssl_ca_cert" "${pp_tls_mtls}" "ssl_ca_cert = '/usr/local/etc/tls/ca.crt'"
+pp_dep=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set pgpool.enabled=true --set pgpool.tls.enabled=true --set pgpool.tls.existingSecret=pp-tls \
+  --set pgpool.tls.backendSslmode=require \
+  --show-only templates/pgpool-deployment.yaml 2>&1)
+assert_contains "#110 C3: pgpool stages key as 0600" "${pp_dep}" "chmod 0600 /usr/local/etc/tls/tls.key"
+assert_contains "#110 C3: pgpool-tls frontend volume" "${pp_dep}" "name: pgpool-tls"
+assert_contains "#110 C3: backend PGSSLMODE set" "${pp_dep}" 'name: PGSSLMODE
+              value: "require"'
+assert_contains "#110 C3: pgpool-exporter SSLMODE follows frontend (require)" "${pp_dep}" 'name: SSLMODE
+              value: "require"'
+# backend client cert (for PostgreSQL mTLS passthrough)
+pp_dep_bcc=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set pgpool.enabled=true --set pgpool.tls.enabled=true --set pgpool.tls.existingSecret=pp-tls \
+  --set pgpool.tls.backendClientCert=pp-backend \
+  --show-only templates/pgpool-deployment.yaml 2>&1)
+assert_contains "#110 C3: backend client cert -> PGSSLCERT" "${pp_dep_bcc}" "name: PGSSLCERT"
+assert_contains "#110 C3: backend client cert volume" "${pp_dep_bcc}" "name: pgpool-tls-backend"
+# default off: pgpool ssl = off
+pp_off=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set pgpool.enabled=true --show-only templates/pgpool-configmap.yaml 2>&1)
+assert_contains "#110 C3: pgpool off keeps ssl = off" "${pp_off}" "ssl = off"
+# fail-fast: pgpool.tls.enabled without a Secret
+pp_nosecret_rc=0
+helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set pgpool.enabled=true --set pgpool.tls.enabled=true >/dev/null 2>&1 || pp_nosecret_rc=$?
+assert_eq "#110 C3: pgpool.tls.enabled without existingSecret fails fast" "1" "$([ "${pp_nosecret_rc}" -ne 0 ] && echo 1 || echo 0)"
+
+# --- Component 4: exporter sslmode ---
+exp_req=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set prometheusExporter.enabled=true --set prometheusExporter.sslmode=require 2>&1)
+assert_contains "#110 C4: exporter DSN carries sslmode=require" "${exp_req}" "sslmode=require"
+assert_contains "#110 C4: exporter auth_modules sslmode require" "${exp_req}" "sslmode: require"
+assert_not_contains "#110 C4: require has no sslrootcert" "${exp_req}" "sslrootcert"
+exp_verify=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --set prometheusExporter.enabled=true --set prometheusExporter.sslmode=verify-ca 2>&1)
+assert_contains "#110 C4: verify-ca adds sslrootcert" "${exp_verify}" "sslrootcert: /etc/postgres_exporter/tls/ca.crt"
+assert_contains "#110 C4: verify-ca mounts the CA on the exporter" "${exp_verify}" "mountPath: /etc/postgres_exporter/tls"
+# default off: sslmode disable
+exp_off=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set prometheusExporter.enabled=true 2>&1)
+assert_contains "#110 C4: exporter default sslmode=disable" "${exp_off}" "sslmode=disable"
+# fail-fast: verify-* requires tls.enabled (CA comes from the server cert Secret)
+exp_verify_rc=0
+helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set prometheusExporter.enabled=true --set prometheusExporter.sslmode=verify-ca >/dev/null 2>&1 || exp_verify_rc=$?
+assert_eq "#110 C4: verify-* without tls.enabled fails fast" "1" "$([ "${exp_verify_rc}" -ne 0 ] && echo 1 || echo 0)"
+
+# --- Cross-component fail-fast guards ---
+g_exp_rc=0
+helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --set postgresql.tls.require=true \
+  --set prometheusExporter.enabled=true >/dev/null 2>&1 || g_exp_rc=$?
+assert_eq "#110 guard: require + exporter sslmode=disable fails fast" "1" "$([ "${g_exp_rc}" -ne 0 ] && echo 1 || echo 0)"
+g_pp_rc=0
+helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --set postgresql.tls.require=true \
+  --set pgpool.enabled=true --set pgpool.tls.enabled=true --set pgpool.tls.existingSecret=pp-tls \
+  --set pgpool.tls.backendSslmode=disable >/dev/null 2>&1 || g_pp_rc=$?
+assert_eq "#110 guard: require + pgpool backendSslmode=disable fails fast" "1" "$([ "${g_pp_rc}" -ne 0 ] && echo 1 || echo 0)"
+g_mtls_pp_rc=0
+helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --set postgresql.tls.clientCertAuth=true \
+  --set prometheusExporter.enabled=true --set prometheusExporter.sslmode=require \
+  --set pgpool.enabled=true --set pgpool.tls.enabled=true --set pgpool.tls.existingSecret=pp-tls >/dev/null 2>&1 || g_mtls_pp_rc=$?
+assert_eq "#110 guard: mTLS + pgpool without backendClientCert fails fast" "1" "$([ "${g_mtls_pp_rc}" -ne 0 ] && echo 1 || echo 0)"
+# clientCertAuth alone (require=false) also forces hostssl, so the sslmode guards must
+# fire on it too -- else the exporter / pgpool backend silently break.
+g_cca_exp_rc=0
+helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --set postgresql.tls.clientCertAuth=true --set postgresql.tls.require=false \
+  --set prometheusExporter.enabled=true >/dev/null 2>&1 || g_cca_exp_rc=$?
+assert_eq "#110 guard: clientCertAuth-only + exporter sslmode=disable fails fast" "1" "$([ "${g_cca_exp_rc}" -ne 0 ] && echo 1 || echo 0)"
+g_cca_pp_rc=0
+helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --set postgresql.tls.clientCertAuth=true --set postgresql.tls.require=false \
+  --set pgpool.enabled=true --set pgpool.tls.enabled=true --set pgpool.tls.existingSecret=pp-tls \
+  --set pgpool.tls.backendClientCert=pp-backend \
+  --set pgpool.tls.backendSslmode=disable >/dev/null 2>&1 || g_cca_pp_rc=$?
+assert_eq "#110 guard: clientCertAuth-only + pgpool backendSslmode=disable fails fast" "1" "$([ "${g_cca_pp_rc}" -ne 0 ] && echo 1 || echo 0)"
+
+# --- pgvector parity (templates are symlinks; values carry the TLS blocks) ---
+pgv_tls=$(helm template test-pgv "${PGVECTOR_DIR}" \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls \
+  --show-only templates/postgresql-configmap.yaml 2>&1)
+assert_contains "#110 pgvector: server TLS renders ssl = on" "${pgv_tls}" "ssl = on"
+
 end_suite
 print_summary

--- a/pg/tests/test-tls.sh
+++ b/pg/tests/test-tls.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# Live client-connection TLS test (#110). Proves the runtime paths render tests cannot:
+# PostgreSQL serving ssl=on, `require` rejecting non-TLS clients, mutual TLS rejecting an
+# app user with no client cert WHILE the internal service users (the exempt superuser, the
+# agent/repmgr, the exporter, pgpool) keep working, replication + failover under TLS, and
+# PGPool serving over TLS. A second light install proves optional server TLS in repmgrd
+# mode. OPT-IN / standalone (run in a clean cluster): `make -C pg test-tls`.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+source "${SCRIPT_DIR}/helpers.sh"
+
+RELEASE="pgtls"
+NAMESPACE="${NAMESPACE:-pg-test-tls}"
+FAILOVER_BUDGET="${FAILOVER_BUDGET:-90}"
+FULLNAME=$(resolve_fullname "${RELEASE}" "${CHART_DIR}" "${SCRIPT_DIR}/values-agent.yaml")
+RW_SVC="${FULLNAME}"            # primary (read-write) Service
+RO_SVC="${FULLNAME}-readonly"
+HEADLESS="${FULLNAME}-headless"
+CERTDIR="$(mktemp -d)"
+trap 'rm -rf "${CERTDIR}"' EXIT
+
+begin_suite "Client-connection TLS for PostgreSQL + PGPool + exporter (#110)"
+
+# --- CA + server cert (serverAuth, SANs for the Services + pod FQDNs + localhost) and a
+#     client cert (clientAuth, CN=appuser) reused for the app-user mTLS case and the
+#     pgpool backend client cert. ---
+gen_ca() {
+  openssl genpkey -algorithm RSA -out "${CERTDIR}/ca.key" >/dev/null 2>&1
+  openssl req -x509 -new -key "${CERTDIR}/ca.key" -days 3650 -subj "/CN=pg-test-ca" -out "${CERTDIR}/ca.crt" >/dev/null 2>&1
+}
+gen_cert() { # gen_cert <name> <CN> <san-or-empty> <eku>
+  local name="$1" cn="$2" san="$3" eku="$4"
+  openssl genpkey -algorithm RSA -out "${CERTDIR}/${name}.key" >/dev/null 2>&1
+  openssl req -new -key "${CERTDIR}/${name}.key" -subj "/CN=${cn}" -out "${CERTDIR}/${name}.csr" >/dev/null 2>&1
+  { [[ -n "${san}" ]] && echo "subjectAltName=${san}"; echo "extendedKeyUsage=${eku}"; } > "${CERTDIR}/${name}.ext"
+  openssl x509 -req -in "${CERTDIR}/${name}.csr" -CA "${CERTDIR}/ca.crt" -CAkey "${CERTDIR}/ca.key" \
+    -CAcreateserial -days 3650 -extfile "${CERTDIR}/${name}.ext" -out "${CERTDIR}/${name}.crt" >/dev/null 2>&1
+}
+SVC_SAN="DNS:${RW_SVC},DNS:${RW_SVC}.${NAMESPACE}.svc,DNS:${RW_SVC}.${NAMESPACE}.svc.cluster.local"
+SVC_SAN="${SVC_SAN},DNS:${RO_SVC},DNS:${RO_SVC}.${NAMESPACE}.svc,DNS:${RO_SVC}.${NAMESPACE}.svc.cluster.local"
+SVC_SAN="${SVC_SAN},DNS:*.${HEADLESS}.${NAMESPACE}.svc.cluster.local,DNS:${FULLNAME}-pgpool,DNS:localhost,IP:127.0.0.1"
+gen_ca
+gen_cert server "${RW_SVC}" "${SVC_SAN}" "serverAuth,clientAuth"
+gen_cert client "appuser"   ""           "clientAuth"
+certs_ok=$([[ -s "${CERTDIR}/server.crt" && -s "${CERTDIR}/client.crt" ]] && echo ok || echo fail)
+assert_eq "test certs generated (CA + server + client)" "ok" "${certs_ok}"
+
+# --- namespace + cert Secrets ---
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+helm uninstall "${RELEASE}" -n "${NAMESPACE}" 2>/dev/null || true
+kubectl delete pvc -n "${NAMESPACE}" --all --wait=false 2>/dev/null || true
+kubectl delete configmap "${FULLNAME}-primary" -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
+for s in postgresql-tls pgpool-tls pgpool-backend-tls client-tls; do
+  kubectl delete secret "${s}" -n "${NAMESPACE}" --ignore-not-found >/dev/null 2>&1 || true
+done
+mk_secret() { # mk_secret <name> <cert-base>
+  kubectl create secret generic "$1" -n "${NAMESPACE}" \
+    --from-file=tls.crt="${CERTDIR}/$2.crt" --from-file=tls.key="${CERTDIR}/$2.key" \
+    --from-file=ca.crt="${CERTDIR}/ca.crt" >/dev/null
+}
+mk_secret postgresql-tls    server   # PostgreSQL server cert
+mk_secret pgpool-tls        server   # PGPool frontend server cert (reuse)
+mk_secret pgpool-backend-tls client  # PGPool -> PostgreSQL backend client cert
+mk_secret client-tls        client   # for the test client pod
+sleep 2
+
+helm upgrade --install "${RELEASE}" "${CHART_DIR}" -n "${NAMESPACE}" \
+  -f "${SCRIPT_DIR}/values-agent.yaml" -f "${SCRIPT_DIR}/values-tls.yaml" \
+  --wait --timeout 10m
+
+wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 2 600
+
+# A throwaway client pod (normal writable fs) with the client cert mounted; psql needs a
+# 0600 key owned by the running user, so copy + chmod out of the read-only Secret mount.
+kubectl run tlsclient -n "${NAMESPACE}" --image=postgres:18.1-trixie --restart=Never \
+  --overrides='{"spec":{"containers":[{"name":"tlsclient","image":"postgres:18.1-trixie","imagePullPolicy":"IfNotPresent","command":["sleep","3600"],"volumeMounts":[{"name":"c","mountPath":"/certs","readOnly":true}]}],"volumes":[{"name":"c","secret":{"secretName":"client-tls"}}]}}' >/dev/null 2>&1 || true
+kubectl wait --for=condition=Ready pod/tlsclient -n "${NAMESPACE}" --timeout=120s >/dev/null 2>&1
+kubectl exec -n "${NAMESPACE}" tlsclient -- bash -c 'cp /certs/* /tmp/ && chmod 600 /tmp/tls.key' >/dev/null 2>&1
+
+# run_client <user> <pass> <sslmode> <cert:yes|no> <sql> -> stdout+stderr, rc preserved
+run_client() {
+  local user="$1" pass="$2" mode="$3" cert="$4" sql="$5"
+  local conn="host=${RW_SVC} port=5432 dbname=testdb user=${user} sslmode=${mode} sslrootcert=/tmp/ca.crt connect_timeout=10"
+  [ "${cert}" = "yes" ] && conn="${conn} sslcert=/tmp/tls.crt sslkey=/tmp/tls.key"
+  kubectl exec -n "${NAMESPACE}" tlsclient -- bash -c "PGPASSWORD='${pass}' psql \"${conn}\" -tAc \"${sql}\"" 2>&1
+}
+
+# --- settle the primary/standby pair ---
+POD0="${FULLNAME}-0"; POD1="${FULLNAME}-1"
+ssl_on=$(pg_exec "${NAMESPACE}" "${POD0}" "SHOW ssl" "testuser" "testdb" 2>/dev/null || echo "")
+[ -z "${ssl_on}" ] && ssl_on=$(pg_exec "${NAMESPACE}" "${POD1}" "SHOW ssl" "testuser" "testdb" 2>/dev/null || echo "")
+assert_eq "#110: PostgreSQL started with ssl = on" "on" "${ssl_on}"
+
+echo "  Waiting for a single primary to settle (up to 240s)..."
+PRIMARY=""; STANDBY=""; s=0
+while [[ ${s} -lt 240 ]]; do
+  r0=$(pg_exec "${NAMESPACE}" "${POD0}" "SELECT pg_is_in_recovery()" "testuser" "testdb" 2>/dev/null || echo "")
+  r1=$(pg_exec "${NAMESPACE}" "${POD1}" "SELECT pg_is_in_recovery()" "testuser" "testdb" 2>/dev/null || echo "")
+  if [[ "${r0}" == "f" && "${r1}" == "t" ]]; then PRIMARY="${POD0}"; STANDBY="${POD1}"; break; fi
+  if [[ "${r1}" == "f" && "${r0}" == "t" ]]; then PRIMARY="${POD1}"; STANDBY="${POD0}"; break; fi
+  sleep 5; s=$((s + 5))
+done
+assert_contains "#110: agent elected a primary under TLS" "${PRIMARY:-none}" "${FULLNAME}"
+
+# the chart-generated superuser (POSTGRES_USER) password, from the chart Secret
+PGPW=$(kubectl get secret "${FULLNAME}" -n "${NAMESPACE}" -o jsonpath='{.data.password}' | base64 -d)
+
+# a non-exempt app role for the clientcert=verify-ca catch-all. The cluster runs
+# password_encryption=md5 (legacy compat); the chart migrates its MANAGED users to scram,
+# but a test-created role must be scram explicitly or the scram-sha-256 pg_hba method
+# rejects its md5 verifier.
+pg_exec "${NAMESPACE}" "${PRIMARY}" "SET password_encryption='scram-sha-256'; DROP ROLE IF EXISTS appuser; CREATE ROLE appuser LOGIN PASSWORD 'apppass'" "testuser" "testdb"
+pg_exec "${NAMESPACE}" "${PRIMARY}" "GRANT ALL ON DATABASE testdb TO appuser" "testuser" "testdb"
+
+# --- require: non-TLS rejected; exempt superuser over TLS without a cert works ---
+disable_out=$(run_client testuser "${PGPW}" disable no "SELECT 1" || true)
+assert_eq "#110 require: sslmode=disable is rejected" "0" "$(printf '%s' "${disable_out}" | grep -c "^1$" || true)"
+exempt_out=$(run_client testuser "${PGPW}" require no "SELECT 1" || true)
+assert_eq "#110 exemption: superuser over TLS (no client cert) succeeds" "1" "$(printf '%s' "${exempt_out}" | tr -d '[:space:]')"
+
+# --- mutual TLS: a non-exempt app user is rejected without a cert, accepted with one ---
+nocert_out=$(run_client appuser apppass require no "SELECT 1" || true)
+assert_eq "#110 mTLS: app user without a client cert is rejected" "0" "$(printf '%s' "${nocert_out}" | grep -c "^1$" || true)"
+cert_out=$(run_client appuser apppass require yes "SELECT 1" || true)
+assert_eq "#110 mTLS: app user WITH a client cert succeeds" "1" "$(printf '%s' "${cert_out}" | tr -d '[:space:]')"
+
+# --- the client VERIFIES the server cert: verify-ca (chain) and verify-full (hostname).
+#     sslmode=require above does NOT validate the server cert; these do. testuser is the
+#     exempt superuser, so no client cert is needed -- this isolates server verification. ---
+vca_out=$(run_client testuser "${PGPW}" verify-ca no "SELECT 1" || true)
+assert_eq "#110 verify-ca: client validates the server cert chain (CA)" "1" "$(printf '%s' "${vca_out}" | tr -d '[:space:]')"
+# verify-full also checks the hostname against the cert SANs; the RW Service name is a SAN.
+vfull_out=$(run_client testuser "${PGPW}" verify-full no "SELECT 1" || true)
+assert_eq "#110 verify-full: client validates server cert hostname (SAN matches RW Service)" "1" "$(printf '%s' "${vfull_out}" | tr -d '[:space:]')"
+
+# --- internals keep working under TLS: replication streams ---
+FV="tls-$(date +%s)"
+pg_exec "${NAMESPACE}" "${PRIMARY}" "CREATE TABLE IF NOT EXISTS tls_t (id serial PRIMARY KEY, v text)" "testuser" "testdb"
+pg_exec "${NAMESPACE}" "${PRIMARY}" "INSERT INTO tls_t (v) VALUES ('${FV}')" "testuser" "testdb"
+sleep 3
+repl=$(pg_exec "${NAMESPACE}" "${STANDBY}" "SELECT v FROM tls_t WHERE v='${FV}'" "testuser" "testdb" 2>/dev/null || echo "")
+assert_eq "#110: replication streams under TLS" "${FV}" "${repl}"
+
+# --- exporter scrapes over TLS as the (exempt) monitoring user: pg_up=1. The exporter's
+#     metrics/telemetry port is 9116 (the scrape DSN connects to PostgreSQL over TLS). ---
+exp_pod=$(kubectl get pods -n "${NAMESPACE}" -o name 2>/dev/null | grep -i exporter | head -1)
+pg_up=""
+if [ -n "${exp_pod}" ]; then
+  kubectl wait --for=condition=Ready "${exp_pod}" -n "${NAMESPACE}" --timeout=180s >/dev/null 2>&1 || true
+  for _ in $(seq 1 20); do
+    pg_up=$(kubectl exec -n "${NAMESPACE}" "${exp_pod}" -- sh -c "wget -qO- http://127.0.0.1:9116/metrics 2>/dev/null | grep '^pg_up '" 2>/dev/null || true)
+    [[ "${pg_up}" == *"pg_up 1"* ]] && break
+    sleep 6
+  done
+fi
+assert_contains "#110: exporter reports pg_up=1 over TLS (monitoring user exempt)" "${pg_up}" "pg_up 1"
+
+# --- PGPool serves clients over TLS and routes to the backend over TLS (frontend :9999) ---
+pp_out=$(kubectl exec -n "${NAMESPACE}" tlsclient -- bash -c \
+  "PGPASSWORD='${PGPW}' psql \"host=${FULLNAME}-pgpool port=9999 dbname=testdb user=testuser sslmode=require sslrootcert=/tmp/ca.crt connect_timeout=15\" -tAc 'SELECT 1'" 2>&1 || true)
+assert_eq "#110: client reaches PostgreSQL through PGPool over TLS" "1" "$(printf '%s' "${pp_out}" | tr -d '[:space:]')"
+
+# --- failover under TLS: delete the primary, the standby promotes, data survives ---
+echo "  Deleting primary ${PRIMARY} (failover under TLS)..."
+kubectl delete pod "${PRIMARY}" -n "${NAMESPACE}" --grace-period=30 --wait=false 2>/dev/null || true
+promoted=false; e=0
+while [[ ${e} -lt ${FAILOVER_BUDGET} ]]; do
+  rec=$(pg_exec "${NAMESPACE}" "${STANDBY}" "SELECT NOT pg_is_in_recovery()" "testuser" "testdb" 2>/dev/null || echo "")
+  [[ "${rec}" == "t" ]] && { promoted=true; echo "  failover after ${e}s (new primary = ${STANDBY})"; break; }
+  sleep 3; e=$((e + 3))
+done
+assert_eq "#110: standby promoted on failover under TLS" "true" "${promoted}"
+if [[ "${promoted}" == "true" ]]; then
+  survived=$(pg_exec "${NAMESPACE}" "${STANDBY}" "SELECT v FROM tls_t WHERE v='${FV}'" "testuser" "testdb" 2>/dev/null || echo "")
+  assert_eq "#110: data survived TLS failover" "${FV}" "${survived}"
+fi
+
+# ======================================================================
+# repmgrd mode: optional server TLS (ssl=on). require/mTLS is render-guarded
+# off in repmgrd; this proves the server-TLS conf.d path works there too.
+# ======================================================================
+RELEASE2="pgtlsr"; NS2="${NAMESPACE}-repmgrd"
+F2=$(resolve_fullname "${RELEASE2}" "${CHART_DIR}" "${SCRIPT_DIR}/values-agent.yaml")
+kubectl create namespace "${NS2}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl delete secret postgresql-tls -n "${NS2}" --ignore-not-found >/dev/null 2>&1 || true
+kubectl create secret generic postgresql-tls -n "${NS2}" \
+  --from-file=tls.crt="${CERTDIR}/server.crt" --from-file=tls.key="${CERTDIR}/server.key" \
+  --from-file=ca.crt="${CERTDIR}/ca.crt" >/dev/null
+helm upgrade --install "${RELEASE2}" "${CHART_DIR}" -n "${NS2}" \
+  -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set repmgr.failoverMode=repmgrd \
+  --set repmgr.image.tag=trixie-5.5.0-25 \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=postgresql-tls \
+  --wait --timeout 10m
+wait_for_pods_ready "${NS2}" "app.kubernetes.io/component=postgresql" 2 600
+ssl_r=$(pg_exec "${NS2}" "${F2}-0" "SHOW ssl" "testuser" "testdb" 2>/dev/null || echo "")
+[ "${ssl_r}" != "on" ] && ssl_r=$(pg_exec "${NS2}" "${F2}-1" "SHOW ssl" "testuser" "testdb" 2>/dev/null || echo "")
+assert_eq "#110 repmgrd: optional server TLS works (ssl = on)" "on" "${ssl_r}"
+
+# ======================================================================
+# Standalone (repmgr off, replicaCount 0): server TLS over the conf.d include with NO
+# repmgr/agent. Exercises the volumes:/annotations: gate fix live -- the cert volume must
+# render alongside its mount and the single postgres pod must start with ssl=on.
+# ======================================================================
+RELEASE3="pgtlss"; NS3="${NAMESPACE}-standalone"
+F3=$(resolve_fullname "${RELEASE3}" "${CHART_DIR}" "${SCRIPT_DIR}/values-agent.yaml")
+kubectl create namespace "${NS3}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl delete secret postgresql-tls -n "${NS3}" --ignore-not-found >/dev/null 2>&1 || true
+kubectl create secret generic postgresql-tls -n "${NS3}" \
+  --from-file=tls.crt="${CERTDIR}/server.crt" --from-file=tls.key="${CERTDIR}/server.key" \
+  --from-file=ca.crt="${CERTDIR}/ca.crt" >/dev/null
+helm upgrade --install "${RELEASE3}" "${CHART_DIR}" -n "${NS3}" \
+  -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set repmgr.enabled=false --set postgresql.replicaCount=0 \
+  --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=postgresql-tls \
+  --wait --timeout 8m
+wait_for_pods_ready "${NS3}" "app.kubernetes.io/component=postgresql" 1 300
+ssl_s=$(pg_exec "${NS3}" "${F3}-0" "SHOW ssl" "testuser" "testdb" 2>/dev/null || echo "")
+assert_eq "#110 standalone: server TLS works with no repmgr (ssl = on)" "on" "${ssl_s}"
+
+# Coverage boundary (logged, not silently skipped): pgpool.tls.backendClientCert is
+# render-verified (PGSSLCERT/PGSSLKEY env + staged cert) but not exercised end-to-end
+# here -- routing a NON-exempt user through PGPool would need that user in pgpool's
+# pool_passwd, which the chart generates only for its managed (exempt) users.
+echo "  NOTE: pgpool backendClientCert mTLS passthrough is render-covered only (see comment)."
+
+end_suite
+print_summary

--- a/pg/tests/values-agent-pgpool.yaml
+++ b/pg/tests/values-agent-pgpool.yaml
@@ -27,7 +27,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-23
+    tag: trixie-5.5.0-25
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/tests/values-agent.yaml
+++ b/pg/tests/values-agent.yaml
@@ -47,7 +47,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-23
+    tag: trixie-5.5.0-25
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/tests/values-config-repmgr.yaml
+++ b/pg/tests/values-config-repmgr.yaml
@@ -60,7 +60,7 @@ repmgr:
   failoverMode: repmgrd
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-23
+    tag: trixie-5.5.0-25
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/tests/values-full-test.yaml
+++ b/pg/tests/values-full-test.yaml
@@ -55,7 +55,7 @@ repmgr:
   failoverMode: repmgrd
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-23
+    tag: trixie-5.5.0-25
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/tests/values-pgbackrest.yaml
+++ b/pg/tests/values-pgbackrest.yaml
@@ -16,7 +16,7 @@ repmgr:
   failoverMode: repmgrd
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-23
+    tag: trixie-5.5.0-25
   enabled: true
 
 pgpool:

--- a/pg/tests/values-repmgr.yaml
+++ b/pg/tests/values-repmgr.yaml
@@ -54,7 +54,7 @@ repmgr:
   failoverMode: repmgrd
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-23
+    tag: trixie-5.5.0-25
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/tests/values-tls.yaml
+++ b/pg/tests/values-tls.yaml
@@ -1,0 +1,34 @@
+# #110 live client-TLS test overrides, layered ON TOP OF values-agent.yaml:
+#   helm upgrade --install ... -f values-agent.yaml -f values-tls.yaml
+# Agent mode + full mutual TLS: PostgreSQL server TLS, require + clientCertAuth,
+# PGPool frontend+backend TLS (with a backend client cert for the mTLS passthrough),
+# and the exporter scraping over TLS as the (exempt) monitoring user.
+repmgr:
+  image:
+    tag: trixie-5.5.0-25
+    pullPolicy: IfNotPresent
+
+postgresql:
+  tls:
+    enabled: true
+    existingSecret: postgresql-tls
+    require: true
+    clientCertAuth: true
+
+pgpool:
+  enabled: true
+  image:
+    pullPolicy: IfNotPresent
+  tls:
+    enabled: true
+    existingSecret: pgpool-tls
+    backendSslmode: require
+    backendClientCert: pgpool-backend-tls
+
+prometheusExporter:
+  enabled: true
+  image:
+    pullPolicy: IfNotPresent
+  sslmode: require
+  monitoringUser:
+    enabled: true

--- a/pg/tests/values-upgrade-from.yaml
+++ b/pg/tests/values-upgrade-from.yaml
@@ -52,7 +52,7 @@ repmgr:
   failoverMode: repmgrd
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-23
+    tag: trixie-5.5.0-25
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/tests/values-upgrade-to.yaml
+++ b/pg/tests/values-upgrade-to.yaml
@@ -49,7 +49,7 @@ repmgr:
   failoverMode: repmgrd
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-23
+    tag: trixie-5.5.0-25
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -150,6 +150,28 @@ postgresql:
     # - "host all all 10.0.0.0/8 md5"
     # - "host replication repmgr 10.0.0.0/8 trust"
 
+  # Client-connection TLS (#110). Off by default (render byte-stable). When enabled,
+  # PostgreSQL serves ssl=on from the cert Secret (BYO, like the etcd TLS block).
+  # NOTE: replication between primary/standby stays plaintext on the pod network --
+  # `require`/`clientCertAuth` never convert the `host replication` or loopback pg_hba
+  # rules, and the chart's internal service users (repmgr, postgres, monitoring) are
+  # exempted from the client-cert requirement so the agent/repmgr/exporter/pgpool keep
+  # working. After rotating the Secret, `kubectl rollout restart` to reload the cert.
+  tls:
+    enabled: false
+    # Secret with the SERVER cert material -- keys: tls.crt, tls.key, ca.crt. Required
+    # when enabled. The certificate MUST list SANs for the write/readonly/pgpool
+    # Services and the headless pod FQDNs that clients connect to. ca.crt is used only
+    # under clientCertAuth (to verify client certs).
+    existingSecret: ""
+    # Reject non-TLS client connections on the pod network (pg_hba hostssl). Clients
+    # must then use sslmode=require or stronger. When true, prometheusExporter.sslmode
+    # and pgpool.tls.backendSslmode must be >= require (enforced by a render guard).
+    require: false
+    # Mutual TLS: app/other users must present a client cert signed by ca.crt
+    # (clientcert=verify-ca). Internal service users are exempted. Implies require.
+    clientCertAuth: false
+
   # When repmgr.enabled is true, re-hash any managed user (POSTGRES_USER,
   # REPMGR_USER) whose stored password is still MD5 to SCRAM at pod startup.
   # Idempotent (no-op once everyone is SCRAM-hashed, and auto-skipped on
@@ -169,7 +191,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-24
+    tag: trixie-5.5.0-25
     # Optional digest pin (e.g. "sha256:..."). When set it is appended as
     # repository:tag@digest, so the cosign-signed / provenance-attested image is
     # pinned at deploy time and a mutable-tag repush cannot silently change it.
@@ -328,6 +350,18 @@ pgpool:
   autoFailback: true
   allowClearTextFrontendAuth: false
 
+  # PGPool TLS (#110). Off by default. `enabled` serves frontend TLS (clients->pgpool);
+  # backendSslmode controls pgpool->PostgreSQL (libpq, via PGSSLMODE). Under PostgreSQL
+  # mTLS, set backendClientCert so pgpool can present a client cert to the backends.
+  tls:
+    enabled: false
+    existingSecret: ""        # frontend SERVER cert: tls.crt, tls.key[, ca.crt]
+    clientCertAuth: false     # validate a client cert IF the frontend client presents one
+                              # (sets ssl_ca_cert; needs ca.crt). pool_hba still authenticates
+                              # by password -- it does not by itself REQUIRE a client cert.
+    backendSslmode: prefer    # pgpool -> postgres: disable|prefer|require|verify-ca|verify-full
+    backendClientCert: ""     # Secret (tls.crt, tls.key[, ca.crt]) for pgpool->postgres under mTLS
+
   logging:
     logConnections: true
     logStatement: false
@@ -413,6 +447,17 @@ pgpool:
 
 prometheusExporter:
   enabled: false
+
+  # sslmode for the exporter's connection to PostgreSQL (#110): disable | require |
+  # verify-ca | verify-full. Default disable (byte-stable). When postgresql.tls.require
+  # (or clientCertAuth) is true this must be >= require (a render guard enforces it), since
+  # the server then rejects non-TLS. verify-* additionally validates the server cert
+  # against ca.crt from postgresql.tls.existingSecret (mounted into the exporter). The
+  # exporter connects as the monitoring user, exempt from client-cert auth under mTLS.
+  # NOTE: the exporter scrapes each pod at its SHORT headless name
+  # (<release>-pg-<i>.<release>-pg-headless), so verify-full needs those short names in the
+  # cert SANs; verify-ca (recommended here) verifies the chain without the hostname check.
+  sslmode: disable
 
   # Least-privilege monitoring user (#28). When enabled, a post-install/upgrade
   # hook Job creates a read-only `pg_monitor` role on the primary (replicated to

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 1.2.0 - 2026-06-21
+
+Optional client-connection TLS for PostgreSQL, PGPool, and the metrics exporter (#110).
+Off by default — no rendered change at defaults. Image moves to `trixie-5.5.0-25`.
+pgvector shares pg's templates and agent; see the pg CHANGELOG for the full detail.
+
+### Added
+
+- **PostgreSQL server TLS** (`postgresql.tls.enabled`, BYO `existingSecret`), **enforced
+  TLS** (`postgresql.tls.require`) and **mutual TLS** (`postgresql.tls.clientCertAuth`,
+  agent mode only, with internal service users exempted from the client-cert requirement).
+- **PGPool TLS** (`pgpool.tls.*`: frontend + backend, with a backend client cert for
+  PostgreSQL mTLS) and a configurable exporter **`prometheusExporter.sslmode`**.
+- Fail-fast guards for every TLS combination.
+
+### Notes
+
+- Replication stays plaintext on the pod network (documented non-goal). repmgrd mode
+  supports only optional server TLS; `require`/`clientCertAuth` are agent-mode only.
+- Reload `ssl_*` with `kubectl rollout restart` after rotating the cert Secret.
+
 ## 1.1.8 - 2026-06-21
 
 Quiets the etcd RBAC health-probe noise (#187). Bundles `etcd` 0.1.5; image moves to

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with pgvector extension and optional PGPool-II
 type: application
-version: 1.1.8
+version: 1.2.0
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -210,7 +210,7 @@ When `repmgr.enabled` is true, `additionalCommands` automatically discover the c
 |-----------|-------------|---------|
 | `repmgr.enabled` | Enable repmgr | `true` |
 | `repmgr.image.repository` | Repmgr image repository | `cagriekin/repmgr` |
-| `repmgr.image.tag` | Repmgr image tag | `trixie-5.5.0-24` |
+| `repmgr.image.tag` | Repmgr image tag | `trixie-5.5.0-25` |
 | `repmgr.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `repmgr.image.majorVersion` | PostgreSQL major bundled in the repmgr image. In repmgr mode the server always runs this major; `postgresql.majorVersion` must match or the chart fails to render. Bump with `repmgr.image.tag` when moving to an image built for a new PG major. | `"18"` |
 | `repmgr.username` | Repmgr database user | `repmgr` |
@@ -887,8 +887,8 @@ kubectl scale statefulset my-pgvector --replicas=0
 # cloud-role annotation; the namespace default SA does not), and ensure the pod lands
 # where your IRSA/WI webhook injects the token; pgbackrest then uses the credential chain.
 kubectl run pg-restore --rm -it \
-  --image=cagriekin/repmgr:trixie-5.5.0-24 \
-  --overrides='{ "spec": { "securityContext": { "runAsUser": 101, "runAsGroup": 103, "fsGroup": 103, "runAsNonRoot": true, "seccompProfile": { "type": "RuntimeDefault" } }, "containers": [{ "name": "restore", "image": "cagriekin/repmgr:trixie-5.5.0-24", "command": ["bash"], "stdin": true, "tty": true, "securityContext": { "allowPrivilegeEscalation": false, "capabilities": { "drop": ["ALL"] } }, "volumeMounts": [{ "name": "data", "mountPath": "/var/lib/postgresql/data" }, { "name": "pgbackrest-config", "mountPath": "/etc/pgbackrest/pgbackrest.conf", "subPath": "pgbackrest.conf", "readOnly": true }], "env": [{ "name": "PGBACKREST_REPO1_S3_KEY", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "access-key-id" } } }, { "name": "PGBACKREST_REPO1_S3_KEY_SECRET", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "secret-access-key" } } }] }], "volumes": [{ "name": "data", "persistentVolumeClaim": { "claimName": "data-my-pgvector-0" } }, { "name": "pgbackrest-config", "configMap": { "name": "my-pgvector-pgbackrest" } }] } }'
+  --image=cagriekin/repmgr:trixie-5.5.0-25 \
+  --overrides='{ "spec": { "securityContext": { "runAsUser": 101, "runAsGroup": 103, "fsGroup": 103, "runAsNonRoot": true, "seccompProfile": { "type": "RuntimeDefault" } }, "containers": [{ "name": "restore", "image": "cagriekin/repmgr:trixie-5.5.0-25", "command": ["bash"], "stdin": true, "tty": true, "securityContext": { "allowPrivilegeEscalation": false, "capabilities": { "drop": ["ALL"] } }, "volumeMounts": [{ "name": "data", "mountPath": "/var/lib/postgresql/data" }, { "name": "pgbackrest-config", "mountPath": "/etc/pgbackrest/pgbackrest.conf", "subPath": "pgbackrest.conf", "readOnly": true }], "env": [{ "name": "PGBACKREST_REPO1_S3_KEY", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "access-key-id" } } }, { "name": "PGBACKREST_REPO1_S3_KEY_SECRET", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "secret-access-key" } } }] }], "volumes": [{ "name": "data", "persistentVolumeClaim": { "claimName": "data-my-pgvector-0" } }, { "name": "pgbackrest-config", "configMap": { "name": "my-pgvector-pgbackrest" } }] } }'
 
 # 3. Inside the restore pod, run (stanza = pgbackrest.stanza, default "db").
 # --type=time is REQUIRED with --target (pgbackrest rejects --target otherwise);
@@ -934,7 +934,7 @@ helm repo update
 helm upgrade my-pgvector cagriekin/pgvector   # add -f your-values.yaml
 ```
 
-`pgvector` tracks `pg` in lockstep — same version, image, and agent; the earlier 0.6.x ↔ 0.5.x split unified at `1.0.0` (current: `1.1.8`, image `trixie-5.5.0-24`). Within the 1.x line `helm upgrade` rolls the pods once and needs no manual step. The default failover mode is `agent` since `1.0.0` (it was `repmgrd` through 0.x); **only when crossing from a 0.x release** does adopting the agent default need the one-time `--cascade=orphan` recreate — pin `repmgr.failoverMode: repmgrd` to defer. Read the `Migrating from X.Y.Z` entries in [`CHANGELOG.md`](CHANGELOG.md) between your version and the target. For the **compatibility matrix, the version model, and the full 0.x → 1.x migration runbook**, see the [pg chart README — Upgrade and migration](../pg/README.md#upgrade-and-migration) (this chart shares pg's templates and agent).
+`pgvector` tracks `pg` in lockstep — same version, image, and agent; the earlier 0.6.x ↔ 0.5.x split unified at `1.0.0` (current: `1.2.0`, image `trixie-5.5.0-25`). Within the 1.x line `helm upgrade` rolls the pods once and needs no manual step. The default failover mode is `agent` since `1.0.0` (it was `repmgrd` through 0.x); **only when crossing from a 0.x release** does adopting the agent default need the one-time `--cascade=orphan` recreate — pin `repmgr.failoverMode: repmgrd` to defer. Read the `Migrating from X.Y.Z` entries in [`CHANGELOG.md`](CHANGELOG.md) between your version and the target. For the **compatibility matrix, the version model, and the full 0.x → 1.x migration runbook**, see the [pg chart README — Upgrade and migration](../pg/README.md#upgrade-and-migration) (this chart shares pg's templates and agent).
 
 ## pgvector Resources
 

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -149,6 +149,15 @@ postgresql:
     # - "host all all 10.0.0.0/8 md5"
     # - "host replication repmgr 10.0.0.0/8 trust"
 
+  # Client-connection TLS (#110). Off by default (render byte-stable). See the pg
+  # chart README for the full TLS notes (cert SANs, require/mTLS, internal-user
+  # exemptions, replication-stays-plaintext).
+  tls:
+    enabled: false
+    existingSecret: ""   # SERVER cert: tls.crt, tls.key, ca.crt
+    require: false       # reject non-TLS clients (hostssl); needs exporter/pgpool sslmode >= require
+    clientCertAuth: false # mTLS for app users (clientcert=verify-ca); internal users exempt; implies require
+
   # When repmgr.enabled is true, re-hash any managed user (POSTGRES_USER,
   # REPMGR_USER) whose stored password is still MD5 to SCRAM at pod startup.
   # Idempotent (no-op once everyone is SCRAM-hashed, and auto-skipped on
@@ -169,7 +178,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-24
+    tag: trixie-5.5.0-25
     # Optional digest pin (e.g. "sha256:..."). When set it is appended as
     # repository:tag@digest, so the cosign-signed / provenance-attested image is
     # pinned at deploy time and a mutable-tag repush cannot silently change it.
@@ -327,6 +336,14 @@ pgpool:
   autoFailback: true
   allowClearTextFrontendAuth: false
 
+  # PGPool TLS (#110). Off by default. See the pg chart README for detail.
+  tls:
+    enabled: false
+    existingSecret: ""        # frontend SERVER cert: tls.crt, tls.key[, ca.crt]
+    clientCertAuth: false     # require client certs on the pgpool frontend
+    backendSslmode: prefer    # pgpool -> postgres: disable|prefer|require|verify-ca|verify-full
+    backendClientCert: ""     # Secret for pgpool->postgres under mTLS
+
   logging:
     logConnections: true
     logStatement: false
@@ -411,6 +428,11 @@ pgpool:
 
 prometheusExporter:
   enabled: false
+
+  # sslmode for the exporter's connection to PostgreSQL (#110): disable | require |
+  # verify-ca | verify-full. Default disable. Must be >= require when
+  # postgresql.tls.require is true. See the pg chart README for detail.
+  sslmode: disable
 
   # Least-privilege monitoring user (#28). When enabled, a post-install/upgrade
   # hook Job creates a read-only `pg_monitor` role on the primary (replicated to


### PR DESCRIPTION
…er (#110)

Optional, off by default (no rendered change at defaults). Image trixie-5.5.0-25; pg/pgvector 1.2.0.

PostgreSQL server TLS (postgresql.tls.enabled): ssl=on from a BYO Secret mounted at /etc/postgresql/tls (defaultMode 0400; the kubelet's fsGroup handling makes it group- readable by the postgres uid), via a chart-managed tls.conf over the conf.d include. Works in agent, repmgrd, and standalone (replicaCount 0) installs.

Enforced TLS (postgresql.tls.require -> hostssl) and mutual TLS (postgresql.tls.clientCertAuth -> clientcert=verify-ca), agent mode only. The agent's AssemblePgHba emits the peer-CIDR hostssl rules with per-user exemptions for the internal service users (repmgr/postgres/monitoring), which authenticate by password over TLS and hold no client cert. Loopback and the host replication rule are never converted: replication stays plaintext on the pod network (documented non-goal). repmgrd mode is guarded off for require/mTLS (its md5-fallback pg_hba line would bypass hostssl).

PGPool TLS (pgpool.tls.*): frontend ssl + cert staged to a 0600 key via the existing init container; backend TLS via PGSSLMODE/PGSSLROOTCERT/PGSSLCERT incl. a backend client cert for the PostgreSQL mTLS passthrough; pgpool-exporter SSLMODE follows the frontend.

Exporter sslmode (prometheusExporter.sslmode): substituted into the DATA_SOURCE_NAME and the /probe auth_modules, with a CA mount + sslrootcert under verify-*.

Fail-fast guards for every combination. Also fixes the outer volumes:/annotations: gates on the StatefulSet to include postgresql.tls.enabled, so a TLS-only install renders the cert volume (not just its mount) and the config checksum.

Tests: AssemblePgHba unit tests (require/mTLS/exemptions); 45 render assertions (test-template.sh); a live test-tls.sh (ssl=on, require rejects non-TLS, mTLS rejects a no-cert app user while exempt users + exporter + pgpool + replication + failover work, plus repmgrd server TLS) wired into the Makefile and CI. Image-pin fixtures bumped to -25.