### PR TITLE
ci: PR-only — drop redundant push:master test runs

### DIFF
--- a/.github/workflows/kafka-test.yaml
+++ b/.github/workflows/kafka-test.yaml
@@ -1,12 +1,6 @@
 name: Test kafka chart
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'kafka/**'
-      - '.github/workflows/kafka-test.yaml'
   # No paths filter: the `gate` job must report on EVERY PR so it can be required
   # without blocking PRs that do not touch kafka. The `changes` job skips the heavy
   # work when kafka is untouched.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,17 +4,6 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - '**/Chart.yaml'
-      - '**/Chart.lock'
-      - '**/values.yaml'
-      - '**/templates/**'
-      - '**/charts/*.tgz'
-      - 'scripts/**'
-      - '.github/workflows/lint.yaml'
   # No paths filter: lint is global (it lints every chart) and fast, so it runs on
   # EVERY PR -- which lets it be a required status check without blocking PRs that
   # happen not to touch a chart path.

--- a/.github/workflows/pg-test.yaml
+++ b/.github/workflows/pg-test.yaml
@@ -4,14 +4,6 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'pg/**'
-      - 'images/repmgr/**'
-      - 'etcd/**'
-      - '.github/workflows/pg-test.yaml'
   # No paths filter on pull_request: the `gate` job must report a status on EVERY PR
   # so it can be a required check without blocking PRs that do not touch pg. The
   # `changes` job below skips the heavy work when pg is untouched.

--- a/.github/workflows/redis-test.yaml
+++ b/.github/workflows/redis-test.yaml
@@ -1,12 +1,6 @@
 name: Test redis chart
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'redis/**'
-      - '.github/workflows/redis-test.yaml'
   # No paths filter: the `gate` job must report on EVERY PR so it can be required
   # without blocking PRs that do not touch redis. The `changes` job skips the heavy
   # work when redis is untouched.

--- a/.github/workflows/repmgr-image-test.yaml
+++ b/.github/workflows/repmgr-image-test.yaml
@@ -4,12 +4,6 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'images/repmgr/**'
-      - '.github/workflows/repmgr-image-test.yaml'
   pull_request:
     paths:
       - 'images/repmgr/**'


### PR DESCRIPTION
Follows the move to PRs-as-single-source-of-truth (branch protection: strict + enforce_admins, required per-chart gates). Removes the redundant `push: master` trigger from the test workflows (pg-test, redis-test, kafka-test, lint, repmgr-image-test) — they run on `pull_request` only. Tag-triggered release/publish workflows are unaffected.

**Release process change:** version-bump commits now land via PR (gated); tags are pushed after merge to trigger release/publish (tags aren't blocked by branch protection). Emergency direct pushes require temporarily relaxing protection.

Trade-off: master-scoped CI caches age out → PRs repopulate base-image/buildx caches on first run. Acceptable for this cadence.