### PR TITLE
test(pg): concurrent backup + WAL archiving (#34)

### DIFF
--- a/.github/workflows/pg-test.yaml
+++ b/.github/workflows/pg-test.yaml
@@ -166,6 +166,7 @@ jobs:
           - { name: pgpool-failover, target: test-pgpool-failover }
           - { name: agent-rolling, target: test-agent-rolling }
           - { name: backup-restore, target: test-backup-restore }
+          - { name: backup-concurrent, target: test-backup-concurrent }
           - { name: migrate-agent, target: test-migrate-agent }
           - { name: scaledown, target: test-scaledown }
     steps:

--- a/pg/Makefile
+++ b/pg/Makefile
@@ -4,7 +4,7 @@ TESTS_DIR := tests
 MAKEFLAGS += --output-sync=target
 
 .PHONY: test test-template test-cluster test-minimal test-repmgr test-repmgr-chaos test-full test-failover test-upgrade \
-        test-repmgr-failover test-agent test-agent-etcd test-agent-etcd-tls test-tls test-pgpool-failover test-migrate-agent test-scaledown test-agent-rolling test-config test-config-repmgr test-backup-restore test-special-chars byte-stable cluster-create cluster-delete cluster-exists clean help
+        test-repmgr-failover test-agent test-agent-etcd test-agent-etcd-tls test-tls test-pgpool-failover test-migrate-agent test-scaledown test-agent-rolling test-config test-config-repmgr test-backup-restore test-backup-concurrent test-special-chars byte-stable cluster-create cluster-delete cluster-exists clean help
 
 help:
 	@echo "Targets:"
@@ -26,6 +26,7 @@ help:
 	@echo "  test-config     - Run postgresql configuration tests (standalone)"
 	@echo "  test-config-repmgr - Run postgresql configuration tests (repmgr)"
 	@echo "  test-backup-restore - Run backup and restore integration tests"
+	@echo "  test-backup-concurrent - Run concurrent pgbackrest backup + WAL archiving test"
 	@echo "  test-special-chars - Run special-character credential tests"
 	@echo "  cluster-create  - Create Kind cluster"
 	@echo "  cluster-delete  - Delete Kind cluster"
@@ -136,6 +137,9 @@ test-config-repmgr: cluster-exists
 
 test-backup-restore: cluster-exists
 	@bash $(TESTS_DIR)/test-backup-restore.sh
+
+test-backup-concurrent: cluster-exists
+	@bash $(TESTS_DIR)/test-backup-concurrent.sh
 
 test-special-chars: cluster-exists
 	@bash $(TESTS_DIR)/test-special-chars.sh

--- a/pg/templates/pgbackrest-configmap.yaml
+++ b/pg/templates/pgbackrest-configmap.yaml
@@ -21,6 +21,12 @@ data:
     repo1-s3-endpoint={{ required "pgbackrest.s3.endpoint is required" .Values.pgbackrest.s3.endpoint }}
     repo1-s3-bucket={{ required "pgbackrest.s3.bucket is required" .Values.pgbackrest.s3.bucket }}
     repo1-s3-region={{ .Values.pgbackrest.s3.region }}
+    {{- if ne .Values.pgbackrest.s3.uriStyle "host" }}
+    repo1-s3-uri-style={{ .Values.pgbackrest.s3.uriStyle }}
+    {{- end }}
+    {{- if not .Values.pgbackrest.s3.verifyTls }}
+    repo1-storage-verify-tls=n
+    {{- end }}
     repo1-path=/{{ .Values.pgbackrest.s3.prefix }}/{{ include "pg.fullname" . }}
     repo1-retention-full={{ .Values.pgbackrest.retention.full }}
     repo1-retention-diff={{ .Values.pgbackrest.retention.diff }}

--- a/pg/tests/test-backup-concurrent.sh
+++ b/pg/tests/test-backup-concurrent.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# Live concurrent backup + WAL-archiving test (#34). pgbackrest archives WAL via
+# archive_command from the postgresql container while a `pgbackrest backup` runs in the
+# pgbackrest sidecar; this proves the two do not conflict -- the backup completes AND WAL
+# archiving stays healthy (no failed pushes) across the backup window. Uses an in-cluster
+# MinIO (TLS) as the S3 repo. OPT-IN / standalone: `make -C pg test-backup-concurrent`.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+source "${SCRIPT_DIR}/helpers.sh"
+
+NAMESPACE="${NAMESPACE:-pg-test-backup-concurrent}"
+RELEASE="${RELEASE:-pgbrc}"
+STANZA="db"
+FULLNAME=$(resolve_fullname "${RELEASE}" "${CHART_DIR}" "${SCRIPT_DIR}/values-pgbackrest-minio.yaml")
+CERTDIR="$(mktemp -d)"
+trap 'rm -rf "${CERTDIR}"' EXIT
+
+begin_suite "Concurrent backup + WAL archiving (pgbackrest, #34)"
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+# --- self-signed cert for MinIO TLS (pgbackrest verify-tls is off, so CN/SAN is not
+#     checked; MinIO just needs a valid cert file to serve https) ---
+openssl req -x509 -newkey rsa:2048 -nodes -days 3650 -subj "/CN=minio" \
+  -addext "subjectAltName=DNS:minio" \
+  -keyout "${CERTDIR}/private.key" -out "${CERTDIR}/public.crt" >/dev/null 2>&1
+kubectl create secret generic minio-tls -n "${NAMESPACE}" \
+  --from-file=public.crt="${CERTDIR}/public.crt" --from-file=private.key="${CERTDIR}/private.key" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic s3-backup-creds -n "${NAMESPACE}" \
+  --from-literal=access-key-id=minioadmin --from-literal=secret-access-key=minioadmin \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Deploying MinIO (TLS on :9000, Service exposes :443 -> 9000)..."
+kubectl apply -n "${NAMESPACE}" -f - <<'MINIO'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: minio } }
+  template:
+    metadata: { labels: { app: minio } }
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2025-02-18T16-25-55Z
+          args: ["server", "/data", "--certs-dir", "/certs"]
+          env:
+            - { name: MINIO_ROOT_USER, value: minioadmin }
+            - { name: MINIO_ROOT_PASSWORD, value: minioadmin }
+          ports: [{ containerPort: 9000 }]
+          volumeMounts:
+            - { name: certs, mountPath: /certs, readOnly: true }
+          readinessProbe:
+            httpGet: { path: /minio/health/ready, port: 9000, scheme: HTTPS }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: certs
+          secret: { secretName: minio-tls, defaultMode: 0444 }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: minio }
+spec:
+  selector: { app: minio }
+  ports: [{ port: 443, targetPort: 9000 }]
+MINIO
+wait_for_deployment_ready "${NAMESPACE}" "minio" 180
+
+echo "Creating bucket pgbackrest-test..."
+kubectl run mc-setup -n "${NAMESPACE}" --restart=Never --image=minio/mc:RELEASE.2024-11-21T17-21-54Z \
+  --command -- sh -c "mc --insecure alias set s3 https://minio:443 minioadmin minioadmin && mc --insecure mb s3/pgbackrest-test || true"
+kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/mc-setup -n "${NAMESPACE}" --timeout=120s
+kubectl delete pod mc-setup -n "${NAMESPACE}" --wait=false
+
+echo "Installing pg chart with pgbackrest -> MinIO..."
+helm upgrade --install "${RELEASE}" "${CHART_DIR}" -n "${NAMESPACE}" \
+  -f "${SCRIPT_DIR}/values-pgbackrest-minio.yaml" \
+  --wait --timeout 8m
+wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 1 600
+POD="${FULLNAME}-0"
+
+# --- first full backup: this runs stanza-create, after which WAL archiving succeeds ---
+echo "Triggering initial full backup (creates the stanza)..."
+kubectl create job -n "${NAMESPACE}" pgbr-full --from=cronjob/"${FULLNAME}-pgbackrest-full"
+full_rc=0
+kubectl wait --for=condition=complete job/pgbr-full -n "${NAMESPACE}" --timeout=300s || full_rc=$?
+if [ "${full_rc}" -ne 0 ]; then
+  echo "  full-backup job did not complete; logs:"; kubectl logs -n "${NAMESPACE}" job/pgbr-full --tail=80 2>/dev/null || true
+fi
+assert_eq "initial full backup (stanza-create) succeeds" "0" "${full_rc}"
+
+# clean archiver stats so the concurrent-window failed_count baseline is the post-stanza
+# state (archive_command fails before the stanza exists; that is not what we measure here)
+pg_exec "${NAMESPACE}" "${POD}" "SELECT pg_stat_reset_shared('archiver')" "testuser" "testdb" >/dev/null 2>&1 || true
+pg_exec "${NAMESPACE}" "${POD}" "CREATE TABLE IF NOT EXISTS wal_load (id bigserial PRIMARY KEY, v text)" "testuser" "testdb"
+
+# --- sustained WAL load (inserts + forced segment switches) running CONCURRENTLY ---
+echo "Starting sustained WAL load + concurrent diff backup..."
+(
+  for _ in $(seq 1 40); do
+    pg_exec "${NAMESPACE}" "${POD}" "INSERT INTO wal_load (v) SELECT repeat('x',512) FROM generate_series(1,2000)" "testuser" "testdb" >/dev/null 2>&1 || true
+    pg_exec "${NAMESPACE}" "${POD}" "SELECT pg_switch_wal()" "testuser" "testdb" >/dev/null 2>&1 || true
+    sleep 1
+  done
+) &
+LOAD_PID=$!
+
+# trigger a diff backup WHILE the load is archiving WAL
+kubectl create job -n "${NAMESPACE}" pgbr-diff --from=cronjob/"${FULLNAME}-pgbackrest-diff"
+diff_rc=0
+kubectl wait --for=condition=complete job/pgbr-diff -n "${NAMESPACE}" --timeout=300s || diff_rc=$?
+if [ "${diff_rc}" -ne 0 ]; then
+  echo "  diff-backup job did not complete; logs:"; kubectl logs -n "${NAMESPACE}" job/pgbr-diff --tail=80 2>/dev/null || true
+fi
+kill "${LOAD_PID}" 2>/dev/null || true; wait "${LOAD_PID}" 2>/dev/null || true
+
+assert_eq "#34: concurrent diff backup completes during active WAL archiving" "0" "${diff_rc}"
+
+# --- both backups are in the repo ---
+info=$(kubectl exec -n "${NAMESPACE}" "${POD}" -c pgbackrest -- pgbackrest --stanza="${STANZA}" info 2>&1 || true)
+n_full=$(printf '%s\n' "${info}" | grep -c "full backup:" || true)
+n_diff=$(printf '%s\n' "${info}" | grep -c "diff backup:" || true)
+assert_gt "#34: repository has a full backup" "${n_full}" "0"
+assert_gt "#34: repository has the concurrent diff backup" "${n_diff}" "0"
+
+# --- WAL archiving stayed healthy across the backup: no failed pushes, archiver advanced ---
+failed=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT failed_count FROM pg_stat_archiver" "testuser" "testdb" 2>/dev/null || echo "")
+archived=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT archived_count FROM pg_stat_archiver" "testuser" "testdb" 2>/dev/null || echo "")
+last_failed=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT COALESCE(last_failed_wal,'')" "testuser" "testdb" 2>/dev/null || echo "")
+assert_eq "#34: no WAL archive failures during the concurrent backup" "0" "${failed}"
+assert_gt "#34: WAL segments were archived during the window" "${archived:-0}" "0"
+assert_eq "#34: no last_failed_wal recorded" "" "${last_failed}"
+
+end_suite
+print_summary

--- a/pg/tests/test-backup-concurrent.sh
+++ b/pg/tests/test-backup-concurrent.sh
@@ -113,6 +113,16 @@ LOAD_PID=$!
 
 # trigger a diff backup WHILE the load is archiving WAL
 kubectl create job -n "${NAMESPACE}" pgbr-diff --from=cronjob/"${FULLNAME}-pgbackrest-diff"
+
+# concurrently (WAL load + pgbackrest physical backup + WAL archiving all active): run a
+# logical pg_dump and assert it succeeds. #34 covers BOTH backup paths running together --
+# the physical (pgbackrest) and logical (pg_dump) backups must not interfere with each
+# other or with WAL archiving (Qodo: the pg_dump + WAL-archiving concurrency scenario).
+echo "  Running a concurrent pg_dump during the backup + WAL-archiving window..."
+dump_rc=0
+dump_lines=$(kubectl exec -n "${NAMESPACE}" "${POD}" -c postgresql -- \
+  pg_dump -U testuser -d testdb 2>/dev/null | wc -l) || dump_rc=$?
+
 diff_rc=0
 kubectl wait --for=condition=complete job/pgbr-diff -n "${NAMESPACE}" --timeout=300s || diff_rc=$?
 if [ "${diff_rc}" -ne 0 ]; then
@@ -121,6 +131,8 @@ fi
 kill "${LOAD_PID}" 2>/dev/null || true; wait "${LOAD_PID}" 2>/dev/null || true
 
 assert_eq "#34: concurrent diff backup completes during active WAL archiving" "0" "${diff_rc}"
+assert_eq "#34: concurrent pg_dump completes during the backup + WAL-archiving window" "0" "${dump_rc}"
+assert_gt "#34: pg_dump produced a non-trivial logical backup" "${dump_lines:-0}" "20"
 
 # --- both backups are in the repo ---
 info=$(kubectl exec -n "${NAMESPACE}" "${POD}" -c pgbackrest -- pgbackrest --stanza="${STANZA}" info 2>&1 || true)

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -1451,6 +1451,15 @@ assert_contains "pgbackrest: configmap renders" "${pgbackrest}" "test-pg-pgbackr
 assert_contains "pgbackrest: configmap has stanza" "${pgbackrest}" "[db]"
 assert_contains "pgbackrest: configmap has s3 endpoint" "${pgbackrest}" "repo1-s3-endpoint=https://s3.amazonaws.com"
 assert_contains "pgbackrest: configmap has s3 bucket" "${pgbackrest}" "repo1-s3-bucket=test-backups"
+# #34: non-AWS S3 knobs (uriStyle/verifyTls) are off at defaults (byte-stable for AWS),
+# emitted only when set -- enables MinIO/Ceph-style endpoints for a CI-testable repo.
+assert_not_contains "pgbackrest #34: no uri-style line at default (host)" "${pgbackrest}" "repo1-s3-uri-style"
+assert_not_contains "pgbackrest #34: no verify-tls line at default" "${pgbackrest}" "repo1-storage-verify-tls"
+pgbackrest_minio=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-pgbackrest.yaml" \
+  --set pgbackrest.s3.uriStyle=path --set pgbackrest.s3.verifyTls=false \
+  --show-only templates/pgbackrest-configmap.yaml 2>&1)
+assert_contains "pgbackrest #34: uriStyle=path renders repo1-s3-uri-style=path" "${pgbackrest_minio}" "repo1-s3-uri-style=path"
+assert_contains "pgbackrest #34: verifyTls=false renders repo1-storage-verify-tls=n" "${pgbackrest_minio}" "repo1-storage-verify-tls=n"
 
 # #120: repository encryption is off by default and opt-in via repoEncryption.
 assert_contains "pgbackrest #120: cipher-type none by default" "${pgbackrest}" "repo1-cipher-type=none"

--- a/pg/tests/values-pgbackrest-minio.yaml
+++ b/pg/tests/values-pgbackrest-minio.yaml
@@ -1,0 +1,84 @@
+# Fixture for the concurrent backup + WAL archiving test (#34). pgbackrest against an
+# in-cluster MinIO (TLS) instead of AWS S3: path-style addressing + verify-tls off for
+# the self-signed endpoint. Single primary (replicaCount 0) is enough to exercise WAL
+# archiving + a backup concurrently.
+postgresql:
+  image:
+    repository: postgres
+    tag: 18.1-trixie
+    pullPolicy: IfNotPresent
+
+  replicaCount: 0
+  database: testdb
+  username: testuser
+
+  persistence:
+    enabled: true
+    size: 1Gi
+
+  podDisruptionBudget:
+    enabled: false
+
+  lifecycle:
+    postStart:
+      additionalCommands: ""
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+
+repmgr:
+  image:
+    repository: cagriekin/repmgr
+    tag: trixie-5.5.0-25
+    pullPolicy: IfNotPresent
+  enabled: true
+  failoverMode: repmgrd
+  username: repmgr
+  database: repmgr
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+pgpool:
+  enabled: false
+
+prometheusExporter:
+  enabled: false
+
+backup:
+  enabled: false
+
+pgbackrest:
+  enabled: true
+  stanza: db
+  s3:
+    endpoint: minio   # in-cluster MinIO Service (TLS on :443 -> targetPort 9000)
+    bucket: pgbackrest-test
+    region: us-east-1
+    prefix: pgbackrest
+    keyType: shared
+    uriStyle: path    # MinIO/Ceph addressing
+    verifyTls: false  # self-signed MinIO cert
+  existingSecret:
+    name: s3-backup-creds
+    accessKeyIdKey: access-key-id
+    secretAccessKeyKey: secret-access-key
+  retention:
+    full: 4
+    diff: 14
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -599,6 +599,12 @@ pgbackrest:
     #           EC2 instance profile); no existingSecret -- annotate the pod SA via
     #           postgresql.serviceAccount.annotations instead.
     keyType: shared
+    # Addressing + TLS for S3-compatible stores that are not AWS (MinIO, Ceph RGW,
+    # on-prem gateways). Defaults match AWS, so these render nothing for AWS users.
+    #   uriStyle: host (AWS virtual-host style, default) | path (most other stores).
+    #   verifyTls: false to accept a self-signed / internal-CA endpoint.
+    uriStyle: host
+    verifyTls: true
 
   existingSecret:
     name: ""


### PR DESCRIPTION
Closes #34. Adds `pg/tests/test-backup-concurrent.sh`: pgbackrest archives WAL while a backup runs concurrently — asserts the backup completes AND WAL archiving stays healthy (`pg_stat_archiver.failed_count=0`, archived_count advances), with both a full and the concurrent diff backup in the repo.

**Enabler (small chart change):** pgbackrest's config was hardcoded for AWS S3, so it couldn't reach the in-cluster MinIO that CI uses. Added gated `pgbackrest.s3.uriStyle` + `pgbackrest.s3.verifyTls` knobs (rendered only when non-default → byte-stable for AWS; useful for MinIO/Ceph generally). Render asserts cover default-off + set.

Static-only local validation (test-template 755/755, helm lint, byte-stable); **the live MinIO-TLS + pgbackrest path is validated by this PR's CI** and is the main risk — it may need a follow-up tweak on the S3 TLS/endpoint specifics.