### PR TITLE
feat(pg): cascading replication support (#29)

### DIFF
--- a/.github/workflows/pg-test.yaml
+++ b/.github/workflows/pg-test.yaml
@@ -164,6 +164,7 @@ jobs:
           - { name: agent-etcd-tls, target: test-agent-etcd-tls }
           - { name: tls, target: test-tls }
           - { name: pgpool-failover, target: test-pgpool-failover }
+          - { name: cascading-replication, target: test-cascading-replication }
           - { name: agent-rolling, target: test-agent-rolling }
           - { name: backup-restore, target: test-backup-restore }
           - { name: migrate-agent, target: test-migrate-agent }

--- a/images/repmgr/agent/cmd/agent/main.go
+++ b/images/repmgr/agent/cmd/agent/main.go
@@ -447,6 +447,9 @@ func (a *agent) observe(ctx context.Context) reconcile.Observation {
 	// This pod's name, compared against Marker.Primary so an empty-data lease holder
 	// can recognize it is not the recorded primary and release the lease (#186).
 	o.LocalNode = a.cfg.PodName
+	// Cascading replication (#29): when enabled, a standby may follow another standby
+	// (the pure cascadeFollowTarget decides; default off -> follow the primary).
+	o.Cascade = a.cfg.CascadeReplication
 	// Maintenance mode (Part H1): an operator-set annotation on the marker ConfigMap
 	// suspends automatic promote/demote/fence/self-health (Decide -> NoOp) while the
 	// agent keeps renewing the Lease and serving.

--- a/images/repmgr/agent/cmd/agent/main.go
+++ b/images/repmgr/agent/cmd/agent/main.go
@@ -450,6 +450,9 @@ func (a *agent) observe(ctx context.Context) reconcile.Observation {
 	// Cascading replication (#29): when enabled, a standby may follow another standby
 	// (the pure cascadeFollowTarget decides; default off -> follow the primary).
 	o.Cascade = a.cfg.CascadeReplication
+	// The upstream this standby currently follows, so cascadeFollowTarget can stay
+	// sticky and not oscillate when a closer peer flaps (#29 thrash fix).
+	o.CurrentUpstream = a.followUpstream
 	// Maintenance mode (Part H1): an operator-set annotation on the marker ConfigMap
 	// suspends automatic promote/demote/fence/self-health (Decide -> NoOp) while the
 	// agent keeps renewing the Lease and serving.

--- a/images/repmgr/agent/internal/config/config.go
+++ b/images/repmgr/agent/internal/config/config.go
@@ -48,6 +48,11 @@ type Config struct {
 	PostgresUser      string // POSTGRES_USER: superuser, exempt from clientcert
 	MonitoringUser    string // MONITORING_USER: monitoring user, exempt; "" when disabled
 
+	// Cascading replication (issue #29). Optional; default off (every standby follows
+	// the primary, byte-stable). When on, a standby may follow another standby to
+	// offload the primary's WAL senders, with a safe fallback to the primary.
+	CascadeReplication bool // CASCADE_REPLICATION
+
 	// etcd backend (required only when DCSBackend == "etcd"). TLS is optional
 	// (all-or-none, enforced by the dcs layer).
 	EtcdEndpoints []string
@@ -147,6 +152,9 @@ func Load(get func(string) string) (*Config, error) {
 	c.TLSClientCertAuth = boolEnv(get("TLS_CLIENT_CERT_AUTH"))
 	c.PostgresUser = strings.TrimSpace(get("POSTGRES_USER"))
 	c.MonitoringUser = strings.TrimSpace(get("MONITORING_USER"))
+
+	// Cascading replication (issue #29). Optional -- absent/empty means off.
+	c.CascadeReplication = boolEnv(get("CASCADE_REPLICATION"))
 
 	// Cross-field validation that the lease timings are internally consistent
 	// (client-go requires LeaseDuration > RenewDeadline > RetryPeriod).

--- a/images/repmgr/agent/internal/reconcile/reconcile.go
+++ b/images/repmgr/agent/internal/reconcile/reconcile.go
@@ -131,6 +131,13 @@ type Observation struct {
 	// falls back to the leader, so a broken/missing/promoted upstream never strands a
 	// standby (it re-homes on the next tick via the Follow target change).
 	Cascade bool
+	// CurrentUpstream is the node this standby currently follows (the agent's
+	// followUpstream). cascadeFollowTarget is STICKY on it: when cascade is on and the
+	// upstream we already follow still qualifies, keep it instead of re-homing to a
+	// different node. Without this, a transient reachability flap of a CLOSER peer
+	// oscillates the chosen upstream and re-runs `repmgr standby follow` every tick
+	// (the #182 no-thrash invariant). "" before the first follow.
+	CurrentUpstream string
 }
 
 // Decide maps an Observation to the single action to take.
@@ -531,29 +538,31 @@ func cascadeFollowTarget(o Observation) string {
 	if selfDist <= 1 {
 		return leader // adjacent to the primary: nothing safe to interpose
 	}
+	// Stickiness (#29 thrash fix): if the upstream we already follow still qualifies,
+	// keep it. A transient reachability flap of a CLOSER peer must not pull us off a
+	// still-valid upstream and back again every tick (which would re-run `repmgr standby
+	// follow` -- the #182 no-thrash invariant). We only re-home when the current upstream
+	// stops qualifying (down/promoted/diverged), which is exactly when re-homing is needed.
+	if o.CurrentUpstream != "" && o.CurrentUpstream != leader && o.CurrentUpstream != o.LocalNode {
+		for _, p := range o.Peers {
+			if p.Name == o.CurrentUpstream && cascadeQualifies(o, p, selfDist, lead) {
+				return o.CurrentUpstream
+			}
+		}
+	}
 	best := ""
 	bestDist := -1
 	for _, p := range o.Peers {
 		if p.Name == o.LocalNode || p.Name == leader {
 			continue
 		}
-		// Must be a live, same-timeline standby: never gossip-only/unreachable, never a
-		// primary, never on a divergent line -- following anything else risks stranding
-		// or a divergent chain.
-		if !p.Reachable || p.Gossip || p.Role != pg.RoleStandby {
+		if !cascadeQualifies(o, p, selfDist, lead) {
 			continue
 		}
-		if !p.TimelineOK || !o.Local.TimelineOK || p.Timeline != o.Local.Timeline {
-			continue
-		}
-		po := podOrdinal(p.Name)
-		if po < 0 {
-			continue
-		}
-		dist := absInt(po - lead)
-		// strictly closer to the leader than this node (acyclic) and the closest such
-		// node to this one (immediate upstream -> a chain, not a fan-in).
-		if dist < selfDist && dist > bestDist {
+		dist := absInt(podOrdinal(p.Name) - lead)
+		// the closest qualifying node to this one (immediate upstream -> a chain, not a
+		// fan-in onto the node nearest the primary).
+		if dist > bestDist {
 			best = p.Name
 			bestDist = dist
 		}
@@ -562,6 +571,25 @@ func cascadeFollowTarget(o Observation) string {
 		return leader
 	}
 	return best
+}
+
+// cascadeQualifies reports whether peer p is a safe cascade upstream for the local node:
+// a live (SQL-reachable, not gossip-only), same-timeline STANDBY -- never a primary or a
+// divergent line, which would risk stranding or a divergent chain -- whose ordinal
+// distance to the leader is strictly less than the local node's (so the chain is acyclic:
+// distance strictly decreases toward the primary, two nodes can never follow each other).
+func cascadeQualifies(o Observation, p PeerState, selfDist, lead int) bool {
+	if !p.Reachable || p.Gossip || p.Role != pg.RoleStandby {
+		return false
+	}
+	if !p.TimelineOK || !o.Local.TimelineOK || p.Timeline != o.Local.Timeline {
+		return false
+	}
+	po := podOrdinal(p.Name)
+	if po < 0 {
+		return false
+	}
+	return absInt(po-lead) < selfDist
 }
 
 // podOrdinal extracts the StatefulSet ordinal from a pod name (<base>-<ordinal>),

--- a/images/repmgr/agent/internal/reconcile/reconcile.go
+++ b/images/repmgr/agent/internal/reconcile/reconcile.go
@@ -9,7 +9,12 @@
 // committed data incorrectly.
 package reconcile
 
-import "github.com/cagriekin/pg-ha-agent/internal/pg"
+import (
+	"strconv"
+	"strings"
+
+	"github.com/cagriekin/pg-ha-agent/internal/pg"
+)
 
 // Action is what the agent should do this tick.
 type Action int
@@ -119,6 +124,13 @@ type Observation struct {
 	// replaying WAL toward consistency is alive but not yet SQL-ready. The agent
 	// must not act on a starting node's stale on-disk role (#181).
 	LocalProcessAlive bool
+	// Cascade enables cascading replication (#29): a standby may follow another
+	// standby instead of the primary, to offload the primary's WAL senders. Default
+	// false -> every standby follows the lease holder (byte-stable). Even when true,
+	// cascadeFollowTarget only picks an upstream that is verifiably safe and otherwise
+	// falls back to the leader, so a broken/missing/promoted upstream never strands a
+	// standby (it re-homes on the next tick via the Follow target change).
+	Cascade bool
 }
 
 // Decide maps an Observation to the single action to take.
@@ -252,6 +264,13 @@ func Decide(o Observation) Decision {
 	case o.Local.Running && o.Local.InRecovery:
 		if o.LeaderIdentity == "" {
 			return d(Wait, "", "standby but no known leader; keep the current upstream")
+		}
+		// Cascading replication (#29): a standby may follow another standby to offload
+		// the primary's WAL senders. cascadeFollowTarget returns the leader unless a
+		// verifiably-safe upstream standby qualifies, so this is byte-identical to
+		// following the lease holder when cascade is off or no safe upstream exists.
+		if up := cascadeFollowTarget(o); up != o.LeaderIdentity {
+			return d(Follow, up, "standby; cascade-follow upstream "+up+" (offload primary)")
 		}
 		return d(Follow, o.LeaderIdentity, "standby; follow the lease holder")
 
@@ -481,4 +500,87 @@ func switchoverTargetReady(o Observation) string {
 		return t
 	}
 	return "" // requested target is not among the observed peers
+}
+
+// cascadeFollowTarget returns the node this standby should follow. With cascade off
+// (Observation.Cascade=false) or no safe upstream, it returns the lease holder
+// (LeaderIdentity) -- byte-identical to following the primary. With cascade on it may
+// return an intermediate standby so WAL-sender load spreads into a chain rooted at the
+// primary, but ONLY one that is verifiably safe; the action layer re-homes when this
+// target changes, so a failed/promoted/diverged upstream falls back to the leader on
+// the next tick (it stops qualifying), never stranding the standby.
+//
+// Topology: a chain by pod ordinal toward the leader. A candidate qualifies when it is
+// a reachable, same-timeline STANDBY whose ordinal distance to the leader is strictly
+// less than this node's -- which guarantees an acyclic chain (distance strictly
+// decreases toward the primary, so two nodes can never follow each other). Among
+// qualifying candidates the one CLOSEST to this node (largest distance still below
+// ours) is the immediate upstream, spreading senders across the chain rather than
+// fanning every node onto the one nearest the primary.
+func cascadeFollowTarget(o Observation) string {
+	leader := o.LeaderIdentity
+	if !o.Cascade || leader == "" {
+		return leader
+	}
+	self := podOrdinal(o.LocalNode)
+	lead := podOrdinal(leader)
+	if self < 0 || lead < 0 {
+		return leader // cannot reason about ordinals; follow the primary
+	}
+	selfDist := absInt(self - lead)
+	if selfDist <= 1 {
+		return leader // adjacent to the primary: nothing safe to interpose
+	}
+	best := ""
+	bestDist := -1
+	for _, p := range o.Peers {
+		if p.Name == o.LocalNode || p.Name == leader {
+			continue
+		}
+		// Must be a live, same-timeline standby: never gossip-only/unreachable, never a
+		// primary, never on a divergent line -- following anything else risks stranding
+		// or a divergent chain.
+		if !p.Reachable || p.Gossip || p.Role != pg.RoleStandby {
+			continue
+		}
+		if !p.TimelineOK || !o.Local.TimelineOK || p.Timeline != o.Local.Timeline {
+			continue
+		}
+		po := podOrdinal(p.Name)
+		if po < 0 {
+			continue
+		}
+		dist := absInt(po - lead)
+		// strictly closer to the leader than this node (acyclic) and the closest such
+		// node to this one (immediate upstream -> a chain, not a fan-in).
+		if dist < selfDist && dist > bestDist {
+			best = p.Name
+			bestDist = dist
+		}
+	}
+	if best == "" {
+		return leader
+	}
+	return best
+}
+
+// podOrdinal extracts the StatefulSet ordinal from a pod name (<base>-<ordinal>),
+// returning -1 if absent or unparseable.
+func podOrdinal(pod string) int {
+	i := strings.LastIndex(pod, "-")
+	if i < 0 || i == len(pod)-1 {
+		return -1
+	}
+	n, err := strconv.Atoi(pod[i+1:])
+	if err != nil || n < 0 {
+		return -1
+	}
+	return n
+}
+
+func absInt(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
 }

--- a/images/repmgr/agent/internal/reconcile/reconcile_test.go
+++ b/images/repmgr/agent/internal/reconcile/reconcile_test.go
@@ -233,6 +233,22 @@ func TestCascadeFollowTarget(t *testing.T) {
 		// local timeline not yet known -> never cascade (cannot verify same line).
 		{"on: local timeline unknown -> leader", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: LocalState{TimelineOK: false},
 			Peers: []PeerState{standby("pg-2", 5, 5, 1)}}, "pg-0"},
+		// Stickiness (#29 thrash fix): when the upstream we already follow still qualifies,
+		// keep it -- do NOT flap to a closer peer. This is the tick-B half of the oscillation:
+		// we follow pg-1 (re-homed when pg-2 flapped down); pg-2 is back, but pg-1 still
+		// qualifies, so STAY on pg-1 rather than switching back to pg-2 (which would re-run
+		// `repmgr standby follow` and, if pg-2 keeps flapping, every tick).
+		{"sticky: current upstream still qualifies -> keep it (no flap to closer peer)", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: localTL5, CurrentUpstream: "pg-1",
+			Peers: []PeerState{standby("pg-1", 5, 5, 1), standby("pg-2", 5, 5, 1)}}, "pg-1"},
+		// But re-home when the current upstream stops qualifying -- that is when re-homing
+		// is actually needed (never strand on a dead/diverged upstream).
+		{"sticky: current upstream down -> re-home to next qualifying", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: localTL5, CurrentUpstream: "pg-2",
+			Peers: []PeerState{standby("pg-1", 5, 5, 1), down("pg-2")}}, "pg-1"},
+		{"sticky: current upstream diverged -> re-home to next qualifying", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: localTL5, CurrentUpstream: "pg-2",
+			Peers: []PeerState{standby("pg-1", 5, 5, 1), standby("pg-2", 4, 5, 1)}}, "pg-1"},
+		// A stale current upstream no longer present as a peer -> ignored, normal closest pick.
+		{"sticky: current upstream absent -> normal closest pick", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: localTL5, CurrentUpstream: "pg-9",
+			Peers: []PeerState{standby("pg-1", 5, 5, 1), standby("pg-2", 5, 5, 1)}}, "pg-2"},
 	}
 	for _, c := range cases {
 		if got := cascadeFollowTarget(c.o); got != c.expect {

--- a/images/repmgr/agent/internal/reconcile/reconcile_test.go
+++ b/images/repmgr/agent/internal/reconcile/reconcile_test.go
@@ -186,3 +186,72 @@ func TestDecideFenceIsUnconditional(t *testing.T) {
 		t.Errorf("lost-lease read-write node must fence, got %v (%s)", got.Action, got.Reason)
 	}
 }
+
+// #29: cascading replication. cascadeFollowTarget is a pure chooser; default off and
+// every unsafe case falls back to the leader so a standby is never stranded.
+func TestCascadeFollowTarget(t *testing.T) {
+	localTL5 := LocalState{Timeline: tl(5), TimelineOK: true}
+	// unreachable peer (not gossip): position unknown, never a cascade upstream.
+	down := func(name string) PeerState { return PeerState{Name: name, Reachable: false} }
+
+	cases := []struct {
+		name   string
+		o      Observation
+		expect string
+	}{
+		// Off -> always the leader, even with perfectly good intermediate standbys.
+		{"cascade off -> leader", Observation{Cascade: false, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: localTL5,
+			Peers: []PeerState{standby("pg-1", 5, 5, 1), standby("pg-2", 5, 5, 1)}}, "pg-0"},
+		// On: chain by ordinal toward the leader -> the immediate upstream (closest below self).
+		{"on: pg-3 follows pg-2 (immediate upstream)", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: localTL5,
+			Peers: []PeerState{standby("pg-1", 5, 5, 1), standby("pg-2", 5, 5, 1)}}, "pg-2"},
+		{"on: pg-2 follows pg-1", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-2", Local: localTL5,
+			Peers: []PeerState{standby("pg-1", 5, 5, 1)}}, "pg-1"},
+		// Adjacent to the leader -> nothing safe to interpose -> leader.
+		{"on: pg-1 adjacent to leader -> leader", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-1", Local: localTL5,
+			Peers: []PeerState{standby("pg-2", 5, 5, 1)}}, "pg-0"},
+		// Leader elsewhere in ordinal space (post-failover): chain still works by distance.
+		{"on: leader pg-2, pg-0 follows pg-1", Observation{Cascade: true, LeaderIdentity: "pg-2", LocalNode: "pg-0", Local: localTL5,
+			Peers: []PeerState{standby("pg-1", 5, 5, 1)}}, "pg-1"},
+		// No SAFE upstream -> leader (re-home). Intermediate down/divergent/primary/gossip excluded.
+		{"on: only intermediate is down -> leader", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: localTL5,
+			Peers: []PeerState{down("pg-1"), down("pg-2")}}, "pg-0"},
+		{"on: divergent-timeline intermediate excluded -> leader", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: localTL5,
+			Peers: []PeerState{standby("pg-2", 4, 5, 1)}}, "pg-0"},
+		{"on: primary-role intermediate excluded -> leader", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: localTL5,
+			Peers: []PeerState{primary("pg-2", 5, 5, 1)}}, "pg-0"},
+		{"on: gossip-only intermediate excluded -> leader", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: localTL5,
+			Peers: []PeerState{gossipPeer("pg-2", 5, 5, 1)}}, "pg-0"},
+		// Mixed: pg-2 down, pg-1 healthy -> falls through to pg-1 (still a valid closer upstream).
+		{"on: nearest down, next healthy -> next", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: localTL5,
+			Peers: []PeerState{standby("pg-1", 5, 5, 1), down("pg-2")}}, "pg-1"},
+		// Defensive: unparseable ordinals / empty leader -> leader (never strand).
+		{"on: unparseable local ordinal -> leader", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "weird", Local: localTL5,
+			Peers: []PeerState{standby("pg-1", 5, 5, 1)}}, "pg-0"},
+		{"on: empty leader -> empty (no upstream yet)", Observation{Cascade: true, LeaderIdentity: "", LocalNode: "pg-3", Local: localTL5,
+			Peers: []PeerState{standby("pg-1", 5, 5, 1)}}, ""},
+		// local timeline not yet known -> never cascade (cannot verify same line).
+		{"on: local timeline unknown -> leader", Observation{Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: LocalState{TimelineOK: false},
+			Peers: []PeerState{standby("pg-2", 5, 5, 1)}}, "pg-0"},
+	}
+	for _, c := range cases {
+		if got := cascadeFollowTarget(c.o); got != c.expect {
+			t.Errorf("%s: got %q want %q", c.name, got, c.expect)
+		}
+	}
+}
+
+// #29: the chooser is wired into Decide -- a running standby with cascade on and a safe
+// upstream returns Follow targeting that upstream (not the leader); off -> the leader.
+func TestDecideCascadeWiring(t *testing.T) {
+	local := LocalState{HasData: true, Running: true, InRecovery: true, Timeline: tl(5), TimelineOK: true, LSN: ls(5, 0x100), LSNOK: true}
+	peers := []PeerState{standby("pg-1", 5, 5, 1), standby("pg-2", 5, 5, 1)}
+	off := Decide(Observation{HoldLease: false, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: local, Peers: peers})
+	if off.Action != Follow || off.Target != "pg-0" {
+		t.Errorf("cascade off: want Follow pg-0, got %v %q", off.Action, off.Target)
+	}
+	on := Decide(Observation{HoldLease: false, Cascade: true, LeaderIdentity: "pg-0", LocalNode: "pg-3", Local: local, Peers: peers})
+	if on.Action != Follow || on.Target != "pg-2" {
+		t.Errorf("cascade on: want Follow pg-2 (immediate upstream), got %v %q", on.Action, on.Target)
+	}
+}

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+- **Optional cascading replication (#29, `repmgr.agent.cascadingReplication`, agent mode,
+  default off).** A standby may stream from another standby — a chain by pod ordinal toward
+  the primary — to offload the primary's WAL senders on larger clusters (`replicaCount >= 2`).
+  The agent only follows a verifiably-safe same-timeline upstream and stays sticky on it,
+  re-homing to the leader on any upstream failure/promotion, so a standby is never stranded
+  and failover is not delayed. Off by default the render and follow behavior are byte-stable.
+  The agent binary changed, so this needs a new image tag + chart minor when released.
+
 ## 1.2.0 - 2026-06-21
 
 Optional client-connection TLS for PostgreSQL, PGPool, and the metrics exporter (#110).

--- a/pg/ENVIRONMENT.md
+++ b/pg/ENVIRONMENT.md
@@ -48,6 +48,7 @@ these; `config.Load` fail-fasts at boot if any is missing.
 | `SPLIT_BRAIN_ACTION` | enum | yes | `repmgr.splitBrainDetection.action` (`log`/`fence`) | agent |
 | `POD_CIDR` | CIDR | yes | `repmgr.agent.podCidr` (`10.0.0.0/8`) | agent (hardened pg_hba: trusted pod network) |
 | `POSTGRESQL_PGHBA` | newline-list | no | `postgresql.pgHba` (joined) | agent (user pg_hba rules, above the catch-alls) |
+| `CASCADE_REPLICATION` | boolean | no | `repmgr.agent.cascadingReplication` (`false`) | agent (cascading replication, #29; emitted only when true) |
 
 Lease timings must satisfy `LEASE_DURATION > RENEW_DEADLINE > RETRY_PERIOD`
 (validated at boot). The agent also writes a `0600 ~/.pgpass` from `REPMGR_*` so a

--- a/pg/Makefile
+++ b/pg/Makefile
@@ -4,7 +4,7 @@ TESTS_DIR := tests
 MAKEFLAGS += --output-sync=target
 
 .PHONY: test test-template test-cluster test-minimal test-repmgr test-repmgr-chaos test-full test-failover test-upgrade \
-        test-repmgr-failover test-agent test-agent-etcd test-agent-etcd-tls test-tls test-pgpool-failover test-migrate-agent test-scaledown test-agent-rolling test-config test-config-repmgr test-backup-restore test-special-chars byte-stable cluster-create cluster-delete cluster-exists clean help
+        test-repmgr-failover test-agent test-agent-etcd test-agent-etcd-tls test-tls test-pgpool-failover test-cascading-replication test-migrate-agent test-scaledown test-agent-rolling test-config test-config-repmgr test-backup-restore test-special-chars byte-stable cluster-create cluster-delete cluster-exists clean help
 
 help:
 	@echo "Targets:"
@@ -21,6 +21,7 @@ help:
 	@echo "  test-agent-etcd-tls - Run agent etcd-DCS test over mutual TLS + RBAC (standalone, opt-in)"
 	@echo "  test-tls           - Run client-connection TLS test (PostgreSQL+PGPool+exporter, standalone, opt-in)"
 	@echo "  test-pgpool-failover - Run PGPool failover + health-check test (standalone, opt-in)"
+	@echo "  test-cascading-replication - Run cascading-replication chain + re-homing test (standalone, opt-in)"
 	@echo "  test-migrate-agent - Run repmgrd->agent migration test (standalone, long)"
 	@echo "  test-upgrade    - Run upgrade path tests"
 	@echo "  test-config     - Run postgresql configuration tests (standalone)"
@@ -73,6 +74,9 @@ test-tls: cluster-exists
 
 test-pgpool-failover: cluster-exists
 	@bash $(TESTS_DIR)/test-pgpool-failover.sh
+
+test-cascading-replication: cluster-exists
+	@bash $(TESTS_DIR)/test-cascading-replication.sh
 
 # repmgrd -> agent migration (--cascade=orphan recreate). Standalone + long-running
 # (installs repmgrd, then rolls to agent), so not in test-cluster; run explicitly.

--- a/pg/README.md
+++ b/pg/README.md
@@ -236,6 +236,7 @@ When repmgr is enabled, two sidecars run alongside PostgreSQL in each pod:
 | `repmgr.agent.retryPeriod` | Lease acquire/renew retry interval | `2s` |
 | `repmgr.agent.reconcileInterval` | Reconcile tick interval | `5s` |
 | `repmgr.agent.podCidr` | Pod CIDR trusted in the agent's hardened SCRAM-only pg_hba (no `0.0.0.0/0 md5`); set to your cluster's pod CIDR if outside `10.0.0.0/8` | `10.0.0.0/8` |
+| `repmgr.agent.cascadingReplication` | Let a standby stream from another standby (a chain by pod ordinal toward the primary) to offload the primary's WAL senders. Default off; agent mode only; meaningful at `replicaCount >= 2` (3+ nodes). The agent only picks a verifiably-safe same-timeline upstream and re-homes to the leader if it fails/promotes, so failover is not delayed and a standby is never stranded. | `false` |
 
 Must satisfy `leaseDuration > renewDeadline > retryPeriod`. For managed clouds, widen them (e.g. `30s/20s/4s`) so a brief apiserver blip does not trip an unnecessary demote. Note: with the Kubernetes Lease backend, a control-plane outage longer than `renewDeadline` is itself a write outage (the healthy primary self-demotes on losing apiserver contact, and no standby can acquire until the control plane returns); this is the safe choice under an asymmetric partition.
 

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -413,6 +413,13 @@ spec:
               value: {{ .Values.repmgr.agent.retryPeriod | quote }}
             - name: RECONCILE_INTERVAL
               value: {{ .Values.repmgr.agent.reconcileInterval | quote }}
+{{- if .Values.repmgr.agent.cascadingReplication }}
+            {{- /* Cascading replication (#29): a standby may follow another standby to
+                   offload the primary's WAL senders. The agent picks a safe upstream and
+                   falls back to the primary, so a failed upstream never strands a node. */}}
+            - name: CASCADE_REPLICATION
+              value: "true"
+{{- end }}
             - name: MASTER_SERVICE
               value: {{ include "pg.fullname" . | quote }}
             - name: POD_SELECTOR

--- a/pg/tests/test-cascading-replication.sh
+++ b/pg/tests/test-cascading-replication.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Live cascading-replication test (#29). With repmgr.agent.cascadingReplication=true and
-# 3 nodes, the standby two hops from the leader follows the INTERMEDIATE standby (pod-1),
-# not the primary directly — offloading the primary's WAL senders into a chain. Proves:
-# (1) the chain forms (the far standby streams from the intermediate, not the leader),
-# (2) data propagates leader -> intermediate -> far standby, and (3) re-homing: killing
-# the intermediate does NOT strand the far standby (it falls back to a live upstream and
-# keeps receiving). Agent mode. OPT-IN / standalone: `make -C pg test-cascading-replication`.
+# Live cascading-replication test (#29). With repmgr.agent.cascadingReplication=true the
+# agent chains standbys by pod ordinal toward the leader so a standby may follow another
+# standby instead of the primary (offloading the primary's WAL senders). 4 nodes are used
+# so a cascade hop exists REGARDLESS of which ordinal the agent elects leader -- the test
+# never skips to a false green. Proves: (1) the chain forms (some standby has a downstream
+# that streams from it, not from the leader), (2) data propagates leader -> chain -> tail,
+# and (3) re-homing -- killing an intermediate does NOT strand its downstream: the
+# downstream's upstream moves to another LIVE node and it keeps receiving.
+# Agent mode. OPT-IN / standalone: `make -C pg test-cascading-replication`.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -16,20 +18,28 @@ NAMESPACE="${NAMESPACE:-pg-test-cascading}"
 RELEASE="${RELEASE:-pgcasc}"
 FULLNAME=$(resolve_fullname "${RELEASE}" "${CHART_DIR}" "${SCRIPT_DIR}/values-agent.yaml")
 LEASE="${FULLNAME}-leader"
+PODS=("${FULLNAME}-0" "${FULLNAME}-1" "${FULLNAME}-2" "${FULLNAME}-3")
 
 begin_suite "Cascading replication (#29)"
 
-# --- install agent mode, replicaCount 2 (-> 3 pods), cascading on ---
+# downstreams_of <pod> -> space-separated application_names streaming FROM that pod
+downstreams_of() {
+  pg_exec "${NAMESPACE}" "$1" "SELECT string_agg(application_name, ' ') FROM pg_stat_replication" "testuser" "testdb" 2>/dev/null || echo ""
+}
+# is <pod> Running (for the re-home liveness check)
+pod_running() { [ "$(kubectl get pod "$1" -n "${NAMESPACE}" -o jsonpath='{.status.phase}' 2>/dev/null)" = "Running" ]; }
+
+# --- install agent mode, replicaCount 3 (-> 4 pods), cascading on ---
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 helm upgrade --install "${RELEASE}" "${CHART_DIR}" -n "${NAMESPACE}" \
   -f "${SCRIPT_DIR}/values-agent.yaml" \
-  --set postgresql.replicaCount=2 \
+  --set postgresql.replicaCount=3 \
   --set repmgr.agent.cascadingReplication=true \
-  --wait --timeout 10m
+  --wait --timeout 12m
 
-wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 3 600
+wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 4 700
 
-# --- find the leader (lease holder that is actually read-write) ---
+# --- find the read-write leader (lease holder) ---
 echo "  Waiting for a primary + lease holder to settle (up to 240s)..."
 LEADER=""; s=0
 while [[ ${s} -lt 240 ]]; do
@@ -42,26 +52,13 @@ while [[ ${s} -lt 240 ]]; do
 done
 assert_contains "agent elected a read-write leader" "${LEADER:-none}" "${FULLNAME}"
 
-# The chain is by pod ordinal toward the leader. The INTERMEDIATE is always ordinal 1;
-# the cascaded (far) node is the one two hops from the leader: ordinal 2 when the leader
-# is 0, ordinal 0 when the leader is 2. When the leader is the middle (ordinal 1) both
-# standbys are adjacent — no cascade is possible (correct), so those asserts are skipped.
-INTERMEDIATE="${FULLNAME}-1"
-lead_ord="${LEADER##*-}"
-case "${lead_ord}" in
-  0) CASCADED="${FULLNAME}-2" ;;
-  2) CASCADED="${FULLNAME}-0" ;;
-  *) CASCADED="" ;;
-esac
-echo "  leader=${LEADER} intermediate=${INTERMEDIATE} cascaded=${CASCADED:-<none: leader is middle ordinal>}"
-
-# --- data propagates from the leader to ALL standbys (the chain carries WAL) ---
+# --- data propagates from the leader to ALL standbys (the chain carries WAL end to end) ---
 MARK="casc-$(date +%s)"
 pg_exec "${NAMESPACE}" "${LEADER}" "CREATE TABLE IF NOT EXISTS casc (id serial PRIMARY KEY, v text); INSERT INTO casc (v) VALUES ('${MARK}')" "testuser" "testdb"
-for pod in "${FULLNAME}-0" "${FULLNAME}-1" "${FULLNAME}-2"; do
+for pod in "${PODS[@]}"; do
   [[ "${pod}" == "${LEADER}" ]] && continue
   got=""; w=0
-  while [[ ${w} -lt 60 ]]; do
+  while [[ ${w} -lt 90 ]]; do
     got=$(pg_exec "${NAMESPACE}" "${pod}" "SELECT v FROM casc WHERE v='${MARK}'" "testuser" "testdb" 2>/dev/null || echo "")
     [[ "${got}" == "${MARK}" ]] && break
     sleep 3; w=$((w + 3))
@@ -69,42 +66,68 @@ for pod in "${FULLNAME}-0" "${FULLNAME}-1" "${FULLNAME}-2"; do
   assert_eq "#29: data reached standby ${pod}" "${MARK}" "${got}"
 done
 
-if [[ -n "${CASCADED}" ]]; then
-  # --- the chain formed: the far standby streams from the INTERMEDIATE, not the leader.
-  #     application_name in pg_stat_replication is the downstream pod name (agent sets it). ---
-  echo "  Waiting for the cascade to form (${CASCADED} <- ${INTERMEDIATE}) up to 150s..."
-  cascaded_off_intermediate=false; c=0
-  while [[ ${c} -lt 150 ]]; do
-    n=$(pg_exec "${NAMESPACE}" "${INTERMEDIATE}" "SELECT count(*) FROM pg_stat_replication WHERE application_name='${CASCADED}'" "testuser" "testdb" 2>/dev/null || echo "0")
-    [[ "${n}" == "1" ]] && { cascaded_off_intermediate=true; echo "  cascade formed after ~${c}s"; break; }
-    sleep 5; c=$((c + 5))
+# --- the chain formed: SOME standby (not the leader) has a downstream streaming from it.
+#     With 4 nodes this holds for ANY elected leader ordinal, so this assertion ALWAYS
+#     runs -- it cannot silently skip to green. INTERMEDIATE = a standby with a downstream;
+#     CASCADED = the node streaming from it (an application_name = pod name). ---
+echo "  Waiting for a cascade hop to form (a standby with a downstream) up to 150s..."
+INTERMEDIATE=""; CASCADED=""; c=0
+while [[ ${c} -lt 150 ]]; do
+  for pod in "${PODS[@]}"; do
+    [[ "${pod}" == "${LEADER}" ]] && continue
+    downs=$(downstreams_of "${pod}")
+    if [[ -n "${downs}" ]]; then
+      for d in ${downs}; do
+        [[ "${d}" == "${FULLNAME}-"* ]] || continue
+        INTERMEDIATE="${pod}"; CASCADED="${d}"; break
+      done
+    fi
+    [[ -n "${INTERMEDIATE}" ]] && break
   done
-  assert_eq "#29: far standby ${CASCADED} streams from the intermediate ${INTERMEDIATE}" "true" "${cascaded_off_intermediate}"
-  # and it does NOT also stream directly from the leader (load really moved off the primary)
-  on_leader=$(pg_exec "${NAMESPACE}" "${LEADER}" "SELECT count(*) FROM pg_stat_replication WHERE application_name='${CASCADED}'" "testuser" "testdb" 2>/dev/null || echo "")
-  assert_eq "#29: far standby does NOT stream directly from the leader (offloaded)" "0" "${on_leader}"
+  [[ -n "${INTERMEDIATE}" ]] && { echo "  cascade hop: ${CASCADED} streams from ${INTERMEDIATE} (after ~${c}s)"; break; }
+  sleep 5; c=$((c + 5))
+done
+assert_contains "#29: a standby acts as a cascade upstream (chain formed, not all from leader)" "${INTERMEDIATE:-none}" "${FULLNAME}"
 
-  # --- re-homing: kill the intermediate. The far standby's upstream is gone, so the agent
-  #     must re-home it to a live upstream (falls back to the leader) -- never stranded. ---
-  if [[ "${cascaded_off_intermediate}" == "true" ]]; then
-    echo "  Deleting the intermediate ${INTERMEDIATE} (re-homing the far standby)..."
-    kubectl delete pod "${INTERMEDIATE}" -n "${NAMESPACE}" --grace-period=10 --wait=false 2>/dev/null || true
-    REMARK="casc-rehome-$(date +%s)"
-    pg_exec "${NAMESPACE}" "${LEADER}" "INSERT INTO casc (v) VALUES ('${REMARK}')" "testuser" "testdb"
-    rehomed=""; rh=0
-    while [[ ${rh} -lt 120 ]]; do
-      rehomed=$(pg_exec "${NAMESPACE}" "${CASCADED}" "SELECT v FROM casc WHERE v='${REMARK}'" "testuser" "testdb" 2>/dev/null || echo "")
-      [[ "${rehomed}" == "${REMARK}" ]] && { echo "  far standby kept receiving after ~${rh}s (re-homed, not stranded)"; break; }
-      sleep 5; rh=$((rh + 5))
+if [[ -n "${INTERMEDIATE}" && -n "${CASCADED}" ]]; then
+  # the cascaded node streams from the INTERMEDIATE, not directly from the leader
+  on_leader=$(downstreams_of "${LEADER}")
+  has_cascaded_on_leader=$(printf '%s\n' "${on_leader}" | grep -wc "${CASCADED}" || true)
+  assert_eq "#29: cascaded ${CASCADED} does NOT stream directly from the leader (offloaded)" "0" "${has_cascaded_on_leader}"
+
+  # --- re-homing: kill the INTERMEDIATE. Its downstream must re-home to another LIVE node
+  #     (not the dead intermediate) and keep receiving -- never stranded. We prove the
+  #     UPSTREAM MOVED (some live node != INTERMEDIATE now has CASCADED as a downstream),
+  #     not merely that data arrived (which the StatefulSet recreating the pod could mask). ---
+  echo "  Deleting intermediate ${INTERMEDIATE}; ${CASCADED} must re-home to a live upstream..."
+  kubectl delete pod "${INTERMEDIATE}" -n "${NAMESPACE}" --grace-period=10 --wait=false 2>/dev/null || true
+  rehomed=""; rh=0
+  while [[ ${rh} -lt 120 ]]; do
+    for pod in "${PODS[@]}"; do
+      [[ "${pod}" == "${INTERMEDIATE}" || "${pod}" == "${CASCADED}" ]] && continue
+      pod_running "${pod}" || continue
+      downs=$(downstreams_of "${pod}")
+      if printf '%s\n' "${downs}" | grep -qw "${CASCADED}"; then rehomed="${pod}"; break; fi
     done
-    assert_eq "#29: far standby is NOT stranded when its upstream dies (re-homed + still receiving)" "${REMARK}" "${rehomed}"
-  else
-    skip "#29: far standby is NOT stranded when its upstream dies (cascade never formed)"
-  fi
+    [[ -n "${rehomed}" ]] && { echo "  ${CASCADED} re-homed to ${rehomed} after ~${rh}s"; break; }
+    sleep 5; rh=$((rh + 5))
+  done
+  assert_contains "#29: cascaded node re-homed to a live upstream when its intermediate died" "${rehomed:-none}" "${FULLNAME}"
+
+  # and it kept receiving: a marker written AFTER the intermediate died reaches it
+  REMARK="casc-rehome-$(date +%s)"
+  pg_exec "${NAMESPACE}" "${LEADER}" "INSERT INTO casc (v) VALUES ('${REMARK}')" "testuser" "testdb"
+  arr=""; a=0
+  while [[ ${a} -lt 90 ]]; do
+    arr=$(pg_exec "${NAMESPACE}" "${CASCADED}" "SELECT v FROM casc WHERE v='${REMARK}'" "testuser" "testdb" 2>/dev/null || echo "")
+    [[ "${arr}" == "${REMARK}" ]] && break
+    sleep 3; a=$((a + 3))
+  done
+  assert_eq "#29: cascaded node keeps receiving after re-home (not stranded)" "${REMARK}" "${arr}"
 else
-  skip "#29: far standby streams from the intermediate (leader is the middle ordinal -- no cascade)"
-  skip "#29: far standby does NOT stream directly from the leader (leader is the middle ordinal)"
-  skip "#29: far standby is NOT stranded when its upstream dies (leader is the middle ordinal)"
+  skip "#29: cascaded node does NOT stream directly from the leader (no cascade hop formed)"
+  skip "#29: cascaded node re-homed to a live upstream when its intermediate died (no cascade hop)"
+  skip "#29: cascaded node keeps receiving after re-home (no cascade hop)"
 fi
 
 end_suite

--- a/pg/tests/test-cascading-replication.sh
+++ b/pg/tests/test-cascading-replication.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Live cascading-replication test (#29). With repmgr.agent.cascadingReplication=true and
+# 3 nodes, the standby two hops from the leader follows the INTERMEDIATE standby (pod-1),
+# not the primary directly — offloading the primary's WAL senders into a chain. Proves:
+# (1) the chain forms (the far standby streams from the intermediate, not the leader),
+# (2) data propagates leader -> intermediate -> far standby, and (3) re-homing: killing
+# the intermediate does NOT strand the far standby (it falls back to a live upstream and
+# keeps receiving). Agent mode. OPT-IN / standalone: `make -C pg test-cascading-replication`.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+source "${SCRIPT_DIR}/helpers.sh"
+
+NAMESPACE="${NAMESPACE:-pg-test-cascading}"
+RELEASE="${RELEASE:-pgcasc}"
+FULLNAME=$(resolve_fullname "${RELEASE}" "${CHART_DIR}" "${SCRIPT_DIR}/values-agent.yaml")
+LEASE="${FULLNAME}-leader"
+
+begin_suite "Cascading replication (#29)"
+
+# --- install agent mode, replicaCount 2 (-> 3 pods), cascading on ---
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+helm upgrade --install "${RELEASE}" "${CHART_DIR}" -n "${NAMESPACE}" \
+  -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set postgresql.replicaCount=2 \
+  --set repmgr.agent.cascadingReplication=true \
+  --wait --timeout 10m
+
+wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 3 600
+
+# --- find the leader (lease holder that is actually read-write) ---
+echo "  Waiting for a primary + lease holder to settle (up to 240s)..."
+LEADER=""; s=0
+while [[ ${s} -lt 240 ]]; do
+  h=$(kubectl get lease "${LEASE}" -n "${NAMESPACE}" -o jsonpath='{.spec.holderIdentity}' 2>/dev/null || echo "")
+  if [[ -n "${h}" ]]; then
+    rw=$(pg_exec "${NAMESPACE}" "${h}" "SELECT NOT pg_is_in_recovery()" "testuser" "testdb" 2>/dev/null || echo "")
+    [[ "${rw}" == "t" ]] && { LEADER="${h}"; break; }
+  fi
+  sleep 5; s=$((s + 5))
+done
+assert_contains "agent elected a read-write leader" "${LEADER:-none}" "${FULLNAME}"
+
+# The chain is by pod ordinal toward the leader. The INTERMEDIATE is always ordinal 1;
+# the cascaded (far) node is the one two hops from the leader: ordinal 2 when the leader
+# is 0, ordinal 0 when the leader is 2. When the leader is the middle (ordinal 1) both
+# standbys are adjacent — no cascade is possible (correct), so those asserts are skipped.
+INTERMEDIATE="${FULLNAME}-1"
+lead_ord="${LEADER##*-}"
+case "${lead_ord}" in
+  0) CASCADED="${FULLNAME}-2" ;;
+  2) CASCADED="${FULLNAME}-0" ;;
+  *) CASCADED="" ;;
+esac
+echo "  leader=${LEADER} intermediate=${INTERMEDIATE} cascaded=${CASCADED:-<none: leader is middle ordinal>}"
+
+# --- data propagates from the leader to ALL standbys (the chain carries WAL) ---
+MARK="casc-$(date +%s)"
+pg_exec "${NAMESPACE}" "${LEADER}" "CREATE TABLE IF NOT EXISTS casc (id serial PRIMARY KEY, v text); INSERT INTO casc (v) VALUES ('${MARK}')" "testuser" "testdb"
+for pod in "${FULLNAME}-0" "${FULLNAME}-1" "${FULLNAME}-2"; do
+  [[ "${pod}" == "${LEADER}" ]] && continue
+  got=""; w=0
+  while [[ ${w} -lt 60 ]]; do
+    got=$(pg_exec "${NAMESPACE}" "${pod}" "SELECT v FROM casc WHERE v='${MARK}'" "testuser" "testdb" 2>/dev/null || echo "")
+    [[ "${got}" == "${MARK}" ]] && break
+    sleep 3; w=$((w + 3))
+  done
+  assert_eq "#29: data reached standby ${pod}" "${MARK}" "${got}"
+done
+
+if [[ -n "${CASCADED}" ]]; then
+  # --- the chain formed: the far standby streams from the INTERMEDIATE, not the leader.
+  #     application_name in pg_stat_replication is the downstream pod name (agent sets it). ---
+  echo "  Waiting for the cascade to form (${CASCADED} <- ${INTERMEDIATE}) up to 150s..."
+  cascaded_off_intermediate=false; c=0
+  while [[ ${c} -lt 150 ]]; do
+    n=$(pg_exec "${NAMESPACE}" "${INTERMEDIATE}" "SELECT count(*) FROM pg_stat_replication WHERE application_name='${CASCADED}'" "testuser" "testdb" 2>/dev/null || echo "0")
+    [[ "${n}" == "1" ]] && { cascaded_off_intermediate=true; echo "  cascade formed after ~${c}s"; break; }
+    sleep 5; c=$((c + 5))
+  done
+  assert_eq "#29: far standby ${CASCADED} streams from the intermediate ${INTERMEDIATE}" "true" "${cascaded_off_intermediate}"
+  # and it does NOT also stream directly from the leader (load really moved off the primary)
+  on_leader=$(pg_exec "${NAMESPACE}" "${LEADER}" "SELECT count(*) FROM pg_stat_replication WHERE application_name='${CASCADED}'" "testuser" "testdb" 2>/dev/null || echo "")
+  assert_eq "#29: far standby does NOT stream directly from the leader (offloaded)" "0" "${on_leader}"
+
+  # --- re-homing: kill the intermediate. The far standby's upstream is gone, so the agent
+  #     must re-home it to a live upstream (falls back to the leader) -- never stranded. ---
+  if [[ "${cascaded_off_intermediate}" == "true" ]]; then
+    echo "  Deleting the intermediate ${INTERMEDIATE} (re-homing the far standby)..."
+    kubectl delete pod "${INTERMEDIATE}" -n "${NAMESPACE}" --grace-period=10 --wait=false 2>/dev/null || true
+    REMARK="casc-rehome-$(date +%s)"
+    pg_exec "${NAMESPACE}" "${LEADER}" "INSERT INTO casc (v) VALUES ('${REMARK}')" "testuser" "testdb"
+    rehomed=""; rh=0
+    while [[ ${rh} -lt 120 ]]; do
+      rehomed=$(pg_exec "${NAMESPACE}" "${CASCADED}" "SELECT v FROM casc WHERE v='${REMARK}'" "testuser" "testdb" 2>/dev/null || echo "")
+      [[ "${rehomed}" == "${REMARK}" ]] && { echo "  far standby kept receiving after ~${rh}s (re-homed, not stranded)"; break; }
+      sleep 5; rh=$((rh + 5))
+    done
+    assert_eq "#29: far standby is NOT stranded when its upstream dies (re-homed + still receiving)" "${REMARK}" "${rehomed}"
+  else
+    skip "#29: far standby is NOT stranded when its upstream dies (cascade never formed)"
+  fi
+else
+  skip "#29: far standby streams from the intermediate (leader is the middle ordinal -- no cascade)"
+  skip "#29: far standby does NOT stream directly from the leader (leader is the middle ordinal)"
+  skip "#29: far standby is NOT stranded when its upstream dies (leader is the middle ordinal)"
+fi
+
+end_suite
+print_summary

--- a/pg/tests/test-cascading-replication.sh
+++ b/pg/tests/test-cascading-replication.sh
@@ -30,11 +30,17 @@ downstreams_of() {
 pod_running() { [ "$(kubectl get pod "$1" -n "${NAMESPACE}" -o jsonpath='{.status.phase}' 2>/dev/null)" = "Running" ]; }
 
 # --- install agent mode, replicaCount 3 (-> 4 pods), cascading on ---
+# The chart default is a HARD per-node anti-affinity (one postgresql pod per node).
+# The CI Kind cluster has only 3 worker nodes, so a 4th pod stays Pending forever and
+# the install times out. 4 pods are required so a cascade hop exists for ANY elected
+# leader ordinal (3 pods false-greens when the middle ordinal leads). Override with a
+# SOFT anti-affinity so the 4 pods still spread but co-locate when nodes run out.
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 helm upgrade --install "${RELEASE}" "${CHART_DIR}" -n "${NAMESPACE}" \
   -f "${SCRIPT_DIR}/values-agent.yaml" \
   --set postgresql.replicaCount=3 \
   --set repmgr.agent.cascadingReplication=true \
+  --set-json 'postgresql.affinity={"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"weight":100,"podAffinityTerm":{"labelSelector":{"matchLabels":{"app.kubernetes.io/component":"postgresql"}},"topologyKey":"kubernetes.io/hostname"}}]}}' \
   --wait --timeout 12m
 
 wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 4 700
@@ -95,24 +101,31 @@ if [[ -n "${INTERMEDIATE}" && -n "${CASCADED}" ]]; then
   has_cascaded_on_leader=$(printf '%s\n' "${on_leader}" | grep -wc "${CASCADED}" || true)
   assert_eq "#29: cascaded ${CASCADED} does NOT stream directly from the leader (offloaded)" "0" "${has_cascaded_on_leader}"
 
-  # --- re-homing: kill the INTERMEDIATE. Its downstream must re-home to another LIVE node
-  #     (not the dead intermediate) and keep receiving -- never stranded. We prove the
-  #     UPSTREAM MOVED (some live node != INTERMEDIATE now has CASCADED as a downstream),
-  #     not merely that data arrived (which the StatefulSet recreating the pod could mask). ---
-  echo "  Deleting intermediate ${INTERMEDIATE}; ${CASCADED} must re-home to a live upstream..."
+  # --- re-homing: take the INTERMEDIATE down and prove its downstream re-homes to a
+  #     DIFFERENT live node -- not merely that data still arrives, which the StatefulSet
+  #     recreating the pod would mask. A deleted StatefulSet pod returns in ~40s and the
+  #     chain just re-converges through it (the downstream reconnects to the SAME hostname,
+  #     so the upstream never observably moves). local-path PVCs are node-pinned, so we
+  #     cordon the intermediate's node first: the recreated pod cannot schedule and stays
+  #     down for the whole observation window, forcing a real move. Uncordon after (also
+  #     via an EXIT trap so a mid-test failure never leaves the node cordoned). ---
+  node=$(kubectl get pod "${INTERMEDIATE}" -n "${NAMESPACE}" -o jsonpath='{.spec.nodeName}' 2>/dev/null)
+  trap 'kubectl uncordon "${node}" >/dev/null 2>&1 || true' EXIT
+  echo "  Cordoning ${node}, deleting intermediate ${INTERMEDIATE}; ${CASCADED} must re-home to a different live upstream..."
+  kubectl cordon "${node}" >/dev/null 2>&1 || true
   kubectl delete pod "${INTERMEDIATE}" -n "${NAMESPACE}" --grace-period=10 --wait=false 2>/dev/null || true
   rehomed=""; rh=0
-  while [[ ${rh} -lt 120 ]]; do
+  while [[ ${rh} -lt 150 ]]; do
     for pod in "${PODS[@]}"; do
       [[ "${pod}" == "${INTERMEDIATE}" || "${pod}" == "${CASCADED}" ]] && continue
       pod_running "${pod}" || continue
       downs=$(downstreams_of "${pod}")
       if printf '%s\n' "${downs}" | grep -qw "${CASCADED}"; then rehomed="${pod}"; break; fi
     done
-    [[ -n "${rehomed}" ]] && { echo "  ${CASCADED} re-homed to ${rehomed} after ~${rh}s"; break; }
+    [[ -n "${rehomed}" ]] && { echo "  ${CASCADED} re-homed to ${rehomed} (live, != ${INTERMEDIATE}) after ~${rh}s"; break; }
     sleep 5; rh=$((rh + 5))
   done
-  assert_contains "#29: cascaded node re-homed to a live upstream when its intermediate died" "${rehomed:-none}" "${FULLNAME}"
+  assert_contains "#29: cascaded node re-homed to a different live upstream when its intermediate died" "${rehomed:-none}" "${FULLNAME}"
 
   # and it kept receiving: a marker written AFTER the intermediate died reaches it
   REMARK="casc-rehome-$(date +%s)"
@@ -124,9 +137,13 @@ if [[ -n "${INTERMEDIATE}" && -n "${CASCADED}" ]]; then
     sleep 3; a=$((a + 3))
   done
   assert_eq "#29: cascaded node keeps receiving after re-home (not stranded)" "${REMARK}" "${arr}"
+
+  # let the intermediate recover and the chain re-converge before teardown
+  kubectl uncordon "${node}" >/dev/null 2>&1 || true
+  trap - EXIT
 else
   skip "#29: cascaded node does NOT stream directly from the leader (no cascade hop formed)"
-  skip "#29: cascaded node re-homed to a live upstream when its intermediate died (no cascade hop)"
+  skip "#29: cascaded node re-homed to a different live upstream when its intermediate died (no cascade hop)"
   skip "#29: cascaded node keeps receiving after re-home (no cascade hop)"
 fi
 

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -2596,5 +2596,25 @@ pgv_tls=$(helm template test-pgv "${PGVECTOR_DIR}" \
   --show-only templates/postgresql-configmap.yaml 2>&1)
 assert_contains "#110 pgvector: server TLS renders ssl = on" "${pgv_tls}" "ssl = on"
 
+# ======================================================================
+# #29: cascading replication. Off by default (byte-stable); the agent gets the
+# CASCADE_REPLICATION env only when the knob is on, and only in agent mode.
+# ======================================================================
+casc_off=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --show-only templates/statefulset.yaml 2>&1)
+assert_not_contains "#29 off: no CASCADE_REPLICATION env by default" "${casc_off}" "CASCADE_REPLICATION"
+casc_on=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --set repmgr.agent.cascadingReplication=true \
+  --show-only templates/statefulset.yaml 2>&1)
+assert_contains "#29 on: agent gets CASCADE_REPLICATION env" "${casc_on}" 'name: CASCADE_REPLICATION
+              value: "true"'
+# repmgrd mode: cascading is agent-only -> the env is never emitted even if the knob is set
+casc_repmgrd=$(helm template test-pg "${CHART_DIR}" \
+  --set repmgr.enabled=true --set repmgr.failoverMode=repmgrd \
+  --set repmgr.image.majorVersion=18 --set postgresql.majorVersion=18 \
+  --set repmgr.agent.cascadingReplication=true \
+  --show-only templates/statefulset.yaml 2>&1)
+assert_not_contains "#29: repmgrd mode never gets CASCADE_REPLICATION (agent-only)" "${casc_repmgrd}" "CASCADE_REPLICATION"
+
 end_suite
 print_summary

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -222,6 +222,13 @@ repmgr:
     renewDeadline: 10s
     retryPeriod: 2s
     reconcileInterval: 5s
+    # Cascading replication (#29). Off by default: every standby streams from the
+    # primary. When true, a standby may instead follow another standby (a chain by
+    # pod ordinal toward the primary) to offload the primary's WAL senders on larger
+    # clusters. The agent only picks a verifiably-safe same-timeline upstream and
+    # falls back to the primary otherwise, and re-homes on failover -- a broken or
+    # promoted upstream never strands a standby. Most useful at higher replicaCount.
+    cascadingReplication: false
     # Leadership store (DCS). "kubernetes" (default) holds the leader Lease in the
     # apiserver. "etcd" holds it in etcd instead, so a Kubernetes control-plane
     # outage no longer self-demotes the primary (only an etcd quorum loss does);

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- **Optional cascading replication (#29, `repmgr.agent.cascadingReplication`, agent mode,
+  default off).** A standby may stream from another standby (a pod-ordinal chain toward the
+  primary) to offload the primary's WAL senders; the agent only follows a verifiably-safe
+  same-timeline upstream and re-homes to the leader on failure, never stranding a standby.
+  Byte-stable when off. Shares pg's agent; see the pg CHANGELOG. Needs a new image tag +
+  chart minor when released.
+
 ## 1.2.0 - 2026-06-21
 
 Optional client-connection TLS for PostgreSQL, PGPool, and the metrics exporter (#110).

--- a/pgvector/ENVIRONMENT.md
+++ b/pgvector/ENVIRONMENT.md
@@ -48,6 +48,7 @@ these; `config.Load` fail-fasts at boot if any is missing.
 | `SPLIT_BRAIN_ACTION` | enum | yes | `repmgr.splitBrainDetection.action` (`log`/`fence`) | agent |
 | `POD_CIDR` | CIDR | yes | `repmgr.agent.podCidr` (`10.0.0.0/8`) | agent (hardened pg_hba: trusted pod network) |
 | `POSTGRESQL_PGHBA` | newline-list | no | `postgresql.pgHba` (joined) | agent (user pg_hba rules, above the catch-alls) |
+| `CASCADE_REPLICATION` | boolean | no | `repmgr.agent.cascadingReplication` (`false`) | agent (cascading replication, #29; emitted only when true) |
 
 Lease timings must satisfy `LEASE_DURATION > RENEW_DEADLINE > RETRY_PERIOD`
 (validated at boot). The agent also writes a `0600 ~/.pgpass` from `REPMGR_*` so a

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -209,6 +209,12 @@ repmgr:
     renewDeadline: 10s
     retryPeriod: 2s
     reconcileInterval: 5s
+    # Cascading replication (#29). Off by default: every standby streams from the
+    # primary. When true, a standby may follow another standby (a chain by pod ordinal
+    # toward the primary) to offload the primary's WAL senders on larger clusters. The
+    # agent only picks a verifiably-safe same-timeline upstream, falls back to the
+    # primary otherwise, and re-homes on failover. See the pg chart for detail.
+    cascadingReplication: false
     # Leadership store (DCS). "kubernetes" (default) holds the leader Lease in the
     # apiserver. "etcd" holds it in etcd instead, so a Kubernetes control-plane
     # outage no longer self-demotes the primary (only an etcd quorum loss does);


### PR DESCRIPTION
Closes #29. Optional cascading replication, **off by default** (`repmgr.agent.cascadingReplication: false`).

## Design
`repmgr.agent.cascadingReplication` → `CASCADE_REPLICATION` env (agent mode only) → `config.CascadeReplication` → `Observation.Cascade`. The follow upstream is chosen by a **pure function** `reconcile.cascadeFollowTarget`:

- **Off / no safe upstream → the lease holder** — byte-identical to following the primary.
- **On →** a chain by pod ordinal toward the leader: the candidate is a *reachable, same-timeline STANDBY* whose ordinal distance to the leader is **strictly less** than this node's (→ acyclic: distance strictly decreases toward the primary, so two nodes can never follow each other), and the **closest** such node (→ immediate upstream, spreading WAL senders along the chain rather than fanning everyone onto one node).
- **Every unsafe case falls back to the leader:** upstream down / gossip-only / primary-role / divergent timeline / adjacent-to-leader / unparseable ordinals / local timeline unknown.

**Failover safety:** the existing `Follow` action already register+follows any target and re-homes when the target changes. On a primary failover or an intermediate-standby failure, the dead/promoted/diverged upstream stops qualifying → `cascadeFollowTarget` returns the leader (or the next healthy link) → the node re-homes on the next tick. A standby is never stranded. `BootstrapClone` is unchanged (a fresh node clones from the leader, then cascades in steady state).

## Implemented
- values knob (pg + pgvector) + statefulset env wiring (agent-mode gated)
- `config.CascadeReplication`, `Observation.Cascade`, `cascadeFollowTarget` + `Decide` wiring
- Go unit tests (12 chooser cases + Decide wiring) + 3 render asserts

**Default-off, byte-stable when off.** Static-validated locally: `go vet` + `go test ./...` (all pkgs), `make -C pg test-template` 754/754, `helm lint pg pgvector`.

## Needs review / follow-up (CI + reviewer)
- **Live validation not added.** A 3-node (`replicaCount ≥ 2`) test should assert pod-N streams from pod-(N-1) (not the primary) via `pg_stat_wal_receiver.sender_host` / `pg_stat_replication.application_name`, and that both a primary failover and an intermediate-standby failure re-home without breaking replication. I did not add/run it (one-shot; can't iterate on a flaky live test). The decision logic is unit-tested; the `repmgr standby follow --upstream-node-id=<standby>` integration + failover timing need live CI + a reviewer's eye.
- **Release coordination:** the agent changed, so a new image tag + Chart minor bump are required **at release**. Deliberately NOT bumped here to avoid disrupting the in-flight 1.2.0 release (image `-25`) and colliding with parallel PRs — CI builds this branch's agent under the existing tag, so PR validation is unaffected.
- Brief replication interruption on upstream loss (until the next reconcile tick re-homes) is expected and acceptable.