### PR TITLE
docs(changelog): fold cascading replication (#29) into 1.2.0

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,6 +1,10 @@
 # pg chart changelog
 
-## Unreleased
+## 1.2.0 - 2026-06-21
+
+Optional client-connection TLS for PostgreSQL, PGPool, and the metrics exporter (#110),
+plus optional cascading replication (#29). Both off by default — no rendered change at
+defaults. Image moves to `trixie-5.5.0-25`.
 
 ### Added
 
@@ -10,15 +14,6 @@
   The agent only follows a verifiably-safe same-timeline upstream and stays sticky on it,
   re-homing to the leader on any upstream failure/promotion, so a standby is never stranded
   and failover is not delayed. Off by default the render and follow behavior are byte-stable.
-  The agent binary changed, so this needs a new image tag + chart minor when released.
-
-## 1.2.0 - 2026-06-21
-
-Optional client-connection TLS for PostgreSQL, PGPool, and the metrics exporter (#110).
-Off by default — no rendered change at defaults. Image moves to `trixie-5.5.0-25`.
-
-### Added
-
 - **PostgreSQL server TLS (`postgresql.tls.enabled`).** Serves `ssl = on` from a BYO
   Secret (`postgresql.tls.existingSecret`, keys `tls.crt`/`tls.key`/`ca.crt`, mounted
   read-only at `/etc/postgresql/tls`, `defaultMode: 0400`) via a chart-managed

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,6 +1,11 @@
 # pgvector chart changelog
 
-## Unreleased
+## 1.2.0 - 2026-06-21
+
+Optional client-connection TLS for PostgreSQL, PGPool, and the metrics exporter (#110),
+plus optional cascading replication (#29). Both off by default — no rendered change at
+defaults. Image moves to `trixie-5.5.0-25`.
+pgvector shares pg's templates and agent; see the pg CHANGELOG for the full detail.
 
 ### Added
 
@@ -8,17 +13,7 @@
   default off).** A standby may stream from another standby (a pod-ordinal chain toward the
   primary) to offload the primary's WAL senders; the agent only follows a verifiably-safe
   same-timeline upstream and re-homes to the leader on failure, never stranding a standby.
-  Byte-stable when off. Shares pg's agent; see the pg CHANGELOG. Needs a new image tag +
-  chart minor when released.
-
-## 1.2.0 - 2026-06-21
-
-Optional client-connection TLS for PostgreSQL, PGPool, and the metrics exporter (#110).
-Off by default — no rendered change at defaults. Image moves to `trixie-5.5.0-25`.
-pgvector shares pg's templates and agent; see the pg CHANGELOG for the full detail.
-
-### Added
-
+  Byte-stable when off. Shares pg's agent; see the pg CHANGELOG.
 - **PostgreSQL server TLS** (`postgresql.tls.enabled`, BYO `existingSecret`), **enforced
   TLS** (`postgresql.tls.require`) and **mutual TLS** (`postgresql.tls.clientCertAuth`,
   agent mode only, with internal service users exempted from the client-cert requirement).


### PR DESCRIPTION
Prep for the combined 1.2.0 release. #29 (cascading replication) merged while the chart was already staged at 1.2.0, so its chart files and agent changes ship together with TLS (#110) in 1.2.0 on image `trixie-5.5.0-25` (both features default-off, byte-stable). This moves the cascade entry from Unreleased into the 1.2.0 section in both pg and pgvector and drops the stale separate-minor note.

No chart/template/code change — CHANGELOG only.

After merge: push tags `trixie-5.5.0-25`, `pg-1.2.0`, `pgvector-1.2.0` to cut the release.