### PR TITLE
feat(redis): v1.0-high operability hardening (1.1.0)

### DIFF
--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.1.0
+
+Operability and production-hardening (non-breaking; defaults unchanged).
+
+### Added
+- Fail-fast validation that `redis.config.maxmemory` does not exceed
+  `redis.resources.limits.memory` (#82).
+- `imagePullSecrets` applied to every pod — redis, sentinel, exporter, and the
+  bootstrap init container (#84).
+- Configurable production `redis.conf` settings: `loglevel`, `databases`,
+  `slowlog-log-slower-than`, `slowlog-max-len`, `client-output-buffer-limit`, an
+  explicit `dir /data`, and configurable `timeout` / `tcp-keepalive` (#81, #78).
+- Complete `Chart.yaml` metadata: `home`, `icon`, `sources`, `maintainers` (#85).
+
 ## 1.0.0
 
 High-availability replication via Redis Sentinel. **Breaking**: the default

--- a/redis/Chart.yaml
+++ b/redis/Chart.yaml
@@ -4,6 +4,12 @@ description: Redis with AOF persistence and Sentinel-based HA replication
 type: application
 version: 1.0.0
 appVersion: "8"
+home: https://github.com/cagriekin/charts/tree/master/redis
+icon: https://www.vectorlogo.zone/logos/redis/redis-icon.svg
+sources:
+  - https://github.com/cagriekin/charts
+  - https://redis.io
+  - https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/
 keywords:
   - redis
   - cache
@@ -11,6 +17,10 @@ keywords:
   - replication
   - sentinel
   - high-availability
+maintainers:
+  - name: cagriekin
+    email: cagri.ekin@gmail.com
+    url: https://github.com/cagriekin
 dependencies:
   - name: common
     version: 0.1.0

--- a/redis/Chart.yaml
+++ b/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: Redis with AOF persistence and Sentinel-based HA replication
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "8"
 home: https://github.com/cagriekin/charts/tree/master/redis
 icon: https://www.vectorlogo.zone/logos/redis/redis-icon.svg

--- a/redis/templates/_helpers.tpl
+++ b/redis/templates/_helpers.tpl
@@ -83,22 +83,44 @@
 {{- end }}
 {{- end }}
 
-{{- /* Parse a memory quantity to bytes. Accepts redis units (b/k/kb/m/mb/g/gb, where
-       the *b suffix is binary and the bare suffix is decimal) and k8s units
-       (Ki/Mi/Gi binary, K/M/G decimal) -- both collapse to the same lowercased map. */ -}}
+{{- /* Render a numeric value as a plain integer, never scientific notation. Helm parses
+       an unquoted YAML number as float64, and toString of one >= 1e7 yields e.g. "3e+08",
+       which redis-server rejects and the byte parser mangles. Strings pass through. */ -}}
+{{- define "redis.intval" -}}
+{{- if or (kindIs "float64" .) (kindIs "int" .) (kindIs "int64" .) }}{{- int64 . -}}{{- else }}{{- . -}}{{- end -}}
+{{- end }}
+
+{{- /* Parse a memory quantity to bytes. Accepts a bare number (bytes), redis units
+       (k/kb/m/mb/g/gb, *b = binary, bare = decimal) and k8s units (Ki/Mi/Gi/Ti/Pi binary,
+       K/M/G/T/P decimal) -- collapsed to one lowercased map. A numeric (unquoted) input is
+       used directly to avoid float64 scientific-notation corruption. Fails fast on an
+       unparseable number or an unsupported unit (no silent fall-through to bytes). */ -}}
 {{- define "redis.bytes" -}}
-{{- $s := . | toString -}}
-{{- $num := regexReplaceAll "[^0-9.]" $s "" | float64 -}}
-{{- $unit := regexReplaceAll "[0-9.]" $s "" | lower -}}
-{{- $mult := 1.0 -}}
-{{- if or (eq $unit "gi") (eq $unit "gb") }}{{- $mult = 1073741824.0 -}}
-{{- else if eq $unit "g" }}{{- $mult = 1000000000.0 -}}
-{{- else if or (eq $unit "mi") (eq $unit "mb") }}{{- $mult = 1048576.0 -}}
-{{- else if eq $unit "m" }}{{- $mult = 1000000.0 -}}
-{{- else if or (eq $unit "ki") (eq $unit "kb") }}{{- $mult = 1024.0 -}}
-{{- else if eq $unit "k" }}{{- $mult = 1000.0 -}}
+{{- if or (kindIs "float64" .) (kindIs "int" .) (kindIs "int64" .) -}}
+{{- int64 . -}}
+{{- else -}}
+{{- $s := trim (toString .) -}}
+{{- $num := regexReplaceAll "[^0-9.]" $s "" -}}
+{{- $unit := lower (trim (regexReplaceAll "[0-9.]" $s "")) -}}
+{{- if not (regexMatch "^[0-9]+(\\.[0-9]+)?$" $num) -}}
+{{- fail (printf "redis: cannot parse memory quantity %q" $s) -}}
 {{- end -}}
-{{- mulf $num $mult | floor | int64 -}}
+{{- $mult := 0.0 -}}
+{{- if eq $unit "" }}{{- $mult = 1.0 -}}
+{{- else if eq $unit "k" }}{{- $mult = 1000.0 -}}
+{{- else if or (eq $unit "ki") (eq $unit "kb") }}{{- $mult = 1024.0 -}}
+{{- else if eq $unit "m" }}{{- $mult = 1000000.0 -}}
+{{- else if or (eq $unit "mi") (eq $unit "mb") }}{{- $mult = 1048576.0 -}}
+{{- else if eq $unit "g" }}{{- $mult = 1000000000.0 -}}
+{{- else if or (eq $unit "gi") (eq $unit "gb") }}{{- $mult = 1073741824.0 -}}
+{{- else if eq $unit "t" }}{{- $mult = 1000000000000.0 -}}
+{{- else if or (eq $unit "ti") (eq $unit "tb") }}{{- $mult = 1099511627776.0 -}}
+{{- else if eq $unit "p" }}{{- $mult = 1000000000000000.0 -}}
+{{- else if or (eq $unit "pi") (eq $unit "pb") }}{{- $mult = 1125899906842624.0 -}}
+{{- else }}{{- fail (printf "redis: unsupported memory unit %q in %q (use bytes or k/kb/ki, m/mb/mi, g/gb/gi, t/tb/ti, p/pb/pi)" $unit $s) -}}
+{{- end -}}
+{{- mulf (float64 $num) $mult | floor | int64 -}}
+{{- end -}}
 {{- end }}
 
 {{- /* Fail-fast validation. Called at the top of statefulset.yaml. */ -}}
@@ -136,7 +158,7 @@
 {{- $maxBytes := int64 (include "redis.bytes" $maxmemory) }}
 {{- $limitBytes := int64 (include "redis.bytes" $memLimit) }}
 {{- if gt $maxBytes $limitBytes }}
-{{- fail (printf "redis.config.maxmemory (%s) exceeds redis.resources.limits.memory (%s); set maxmemory to ~80%% of the limit to leave headroom for AOF rewrite buffers and fragmentation" $maxmemory $memLimit) }}
+{{- fail (printf "redis.config.maxmemory (%s) exceeds redis.resources.limits.memory (%s); set maxmemory to ~80%% of the limit to leave headroom for AOF rewrite buffers and fragmentation" (include "redis.intval" $maxmemory) $memLimit) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/redis/templates/_helpers.tpl
+++ b/redis/templates/_helpers.tpl
@@ -83,6 +83,24 @@
 {{- end }}
 {{- end }}
 
+{{- /* Parse a memory quantity to bytes. Accepts redis units (b/k/kb/m/mb/g/gb, where
+       the *b suffix is binary and the bare suffix is decimal) and k8s units
+       (Ki/Mi/Gi binary, K/M/G decimal) -- both collapse to the same lowercased map. */ -}}
+{{- define "redis.bytes" -}}
+{{- $s := . | toString -}}
+{{- $num := regexReplaceAll "[^0-9.]" $s "" | float64 -}}
+{{- $unit := regexReplaceAll "[0-9.]" $s "" | lower -}}
+{{- $mult := 1.0 -}}
+{{- if or (eq $unit "gi") (eq $unit "gb") }}{{- $mult = 1073741824.0 -}}
+{{- else if eq $unit "g" }}{{- $mult = 1000000000.0 -}}
+{{- else if or (eq $unit "mi") (eq $unit "mb") }}{{- $mult = 1048576.0 -}}
+{{- else if eq $unit "m" }}{{- $mult = 1000000.0 -}}
+{{- else if or (eq $unit "ki") (eq $unit "kb") }}{{- $mult = 1024.0 -}}
+{{- else if eq $unit "k" }}{{- $mult = 1000.0 -}}
+{{- end -}}
+{{- mulf $num $mult | floor | int64 -}}
+{{- end }}
+
 {{- /* Fail-fast validation. Called at the top of statefulset.yaml. */ -}}
 {{- define "redis.validate" -}}
 {{- if not (has .Values.architecture (list "standalone" "replication")) }}
@@ -111,6 +129,15 @@
 {{- end }}
 {{- if and .Values.tls.clientCertAuth (not .Values.tls.enabled) }}
 {{- fail "tls.clientCertAuth requires tls.enabled" }}
+{{- end }}
+{{- $memLimit := dig "resources" "limits" "memory" "" .Values.redis }}
+{{- $maxmemory := index .Values.redis.config "maxmemory" }}
+{{- if and $memLimit $maxmemory }}
+{{- $maxBytes := int64 (include "redis.bytes" $maxmemory) }}
+{{- $limitBytes := int64 (include "redis.bytes" $memLimit) }}
+{{- if gt $maxBytes $limitBytes }}
+{{- fail (printf "redis.config.maxmemory (%s) exceeds redis.resources.limits.memory (%s); set maxmemory to ~80%% of the limit to leave headroom for AOF rewrite buffers and fragmentation" $maxmemory $memLimit) }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/redis/templates/_helpers.tpl
+++ b/redis/templates/_helpers.tpl
@@ -244,6 +244,10 @@ cp /config-ro/sentinel.conf /config-rw/sentinel.conf
 {{- define "redis.exporterPodSpec" -}}
 securityContext:
   {{- toYaml .Values.exporter.podSecurityContext | nindent 2 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 containers:
   - name: redis-exporter
     image: "{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"

--- a/redis/templates/configmap.yaml
+++ b/redis/templates/configmap.yaml
@@ -17,6 +17,14 @@ data:
     auto-aof-rewrite-min-size {{ index .Values.redis.config "auto-aof-rewrite-min-size" }}
     maxmemory {{ .Values.redis.config.maxmemory }}
     maxmemory-policy {{ index .Values.redis.config "maxmemory-policy" }}
+    dir /data
+    loglevel {{ .Values.redis.config.loglevel }}
+    databases {{ .Values.redis.config.databases }}
+    slowlog-log-slower-than {{ index .Values.redis.config "slowlog-log-slower-than" }}
+    slowlog-max-len {{ index .Values.redis.config "slowlog-max-len" }}
+{{- range (index .Values.redis.config "client-output-buffer-limit") }}
+    client-output-buffer-limit {{ . }}
+{{- end }}
     tcp-keepalive 60
     timeout 0
 {{- if .Values.redis.config.rdbSnapshots }}

--- a/redis/templates/configmap.yaml
+++ b/redis/templates/configmap.yaml
@@ -13,20 +13,20 @@ data:
     appendonly yes
     appendfsync {{ .Values.redis.config.appendfsync }}
     no-appendfsync-on-rewrite {{ index .Values.redis.config "no-appendfsync-on-rewrite" }}
-    auto-aof-rewrite-percentage {{ index .Values.redis.config "auto-aof-rewrite-percentage" }}
+    auto-aof-rewrite-percentage {{ include "redis.intval" (index .Values.redis.config "auto-aof-rewrite-percentage") }}
     auto-aof-rewrite-min-size {{ index .Values.redis.config "auto-aof-rewrite-min-size" }}
-    maxmemory {{ .Values.redis.config.maxmemory }}
+    maxmemory {{ include "redis.intval" .Values.redis.config.maxmemory }}
     maxmemory-policy {{ index .Values.redis.config "maxmemory-policy" }}
     dir /data
     loglevel {{ .Values.redis.config.loglevel }}
-    databases {{ .Values.redis.config.databases }}
-    slowlog-log-slower-than {{ index .Values.redis.config "slowlog-log-slower-than" }}
-    slowlog-max-len {{ index .Values.redis.config "slowlog-max-len" }}
+    databases {{ include "redis.intval" .Values.redis.config.databases }}
+    slowlog-log-slower-than {{ include "redis.intval" (index .Values.redis.config "slowlog-log-slower-than") }}
+    slowlog-max-len {{ include "redis.intval" (index .Values.redis.config "slowlog-max-len") }}
 {{- range (index .Values.redis.config "client-output-buffer-limit") }}
     client-output-buffer-limit {{ . }}
 {{- end }}
-    tcp-keepalive {{ index .Values.redis.config "tcp-keepalive" }}
-    timeout {{ .Values.redis.config.timeout }}
+    tcp-keepalive {{ include "redis.intval" (index .Values.redis.config "tcp-keepalive") }}
+    timeout {{ include "redis.intval" .Values.redis.config.timeout }}
 {{- if .Values.redis.config.rdbSnapshots }}
 {{- range .Values.redis.config.rdbSnapshots }}
     save {{ .seconds }} {{ .changes }}
@@ -36,8 +36,8 @@ data:
 {{- end }}
 {{- if eq .Values.architecture "replication" }}
     replica-read-only {{ index .Values.redis.config "replica-read-only" }}
-    min-replicas-to-write {{ index .Values.redis.config "min-replicas-to-write" }}
-    min-replicas-max-lag {{ index .Values.redis.config "min-replicas-max-lag" }}
+    min-replicas-to-write {{ include "redis.intval" (index .Values.redis.config "min-replicas-to-write") }}
+    min-replicas-max-lag {{ include "redis.intval" (index .Values.redis.config "min-replicas-max-lag") }}
 {{- end }}
 {{- if .Values.tls.enabled }}
     port 0

--- a/redis/templates/configmap.yaml
+++ b/redis/templates/configmap.yaml
@@ -25,8 +25,8 @@ data:
 {{- range (index .Values.redis.config "client-output-buffer-limit") }}
     client-output-buffer-limit {{ . }}
 {{- end }}
-    tcp-keepalive 60
-    timeout 0
+    tcp-keepalive {{ index .Values.redis.config "tcp-keepalive" }}
+    timeout {{ .Values.redis.config.timeout }}
 {{- if .Values.redis.config.rdbSnapshots }}
 {{- range .Values.redis.config.rdbSnapshots }}
     save {{ .seconds }} {{ .changes }}

--- a/redis/templates/statefulset.yaml
+++ b/redis/templates/statefulset.yaml
@@ -39,6 +39,10 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.redis.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml .Values.redis.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.redis.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
@@ -378,6 +382,10 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.redis.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml .Values.redis.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"

--- a/redis/tests/unit/configmap_test.yaml
+++ b/redis/tests/unit/configmap_test.yaml
@@ -64,6 +64,20 @@ tests:
           path: data["redis.conf"]
           pattern: 'slowlog-log-slower-than 10000'
 
+  - it: client timeout and tcp-keepalive are configurable
+    values:
+      - ../values-minimal.yaml
+    set:
+      redis.config.timeout: 300
+      redis.config.tcp-keepalive: 120
+    asserts:
+      - matchRegex:
+          path: data["redis.conf"]
+          pattern: 'timeout 300'
+      - matchRegex:
+          path: data["redis.conf"]
+          pattern: 'tcp-keepalive 120'
+
   - it: client-output-buffer-limit rendered when set
     values:
       - ../values-minimal.yaml

--- a/redis/tests/unit/configmap_test.yaml
+++ b/redis/tests/unit/configmap_test.yaml
@@ -64,6 +64,23 @@ tests:
           path: data["redis.conf"]
           pattern: 'slowlog-log-slower-than 10000'
 
+  - it: unquoted numeric config values render as plain integers (no scientific notation)
+    values:
+      - ../values-minimal.yaml
+    set:
+      redis.config.maxmemory: 100000000
+      redis.config.slowlog-log-slower-than: 10000000
+    asserts:
+      - matchRegex:
+          path: data["redis.conf"]
+          pattern: 'maxmemory 100000000'
+      - matchRegex:
+          path: data["redis.conf"]
+          pattern: 'slowlog-log-slower-than 10000000'
+      - notMatchRegex:
+          path: data["redis.conf"]
+          pattern: 'e\+0'
+
   - it: client timeout and tcp-keepalive are configurable
     values:
       - ../values-minimal.yaml

--- a/redis/tests/unit/configmap_test.yaml
+++ b/redis/tests/unit/configmap_test.yaml
@@ -47,6 +47,34 @@ tests:
           path: data["redis.conf"]
           pattern: 'save ""'
 
+  - it: production redis.conf settings rendered
+    values:
+      - ../values-minimal.yaml
+    asserts:
+      - matchRegex:
+          path: data["redis.conf"]
+          pattern: 'dir /data'
+      - matchRegex:
+          path: data["redis.conf"]
+          pattern: 'loglevel notice'
+      - matchRegex:
+          path: data["redis.conf"]
+          pattern: 'databases 16'
+      - matchRegex:
+          path: data["redis.conf"]
+          pattern: 'slowlog-log-slower-than 10000'
+
+  - it: client-output-buffer-limit rendered when set
+    values:
+      - ../values-minimal.yaml
+    set:
+      redis.config.client-output-buffer-limit:
+        - "replica 512mb 128mb 60"
+    asserts:
+      - matchRegex:
+          path: data["redis.conf"]
+          pattern: 'client-output-buffer-limit replica 512mb 128mb 60'
+
   - it: standalone - no sentinel.conf or min-replicas directives
     values:
       - ../values-minimal.yaml

--- a/redis/tests/unit/guards_test.yaml
+++ b/redis/tests/unit/guards_test.yaml
@@ -73,6 +73,28 @@ tests:
       - failedTemplate:
           errorMessage: tls.clientCertAuth requires tls.enabled
 
+  - it: maxmemory exceeding the container memory limit is rejected
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.config.maxmemory: 512mb
+      redis.resources.limits.memory: 256Mi
+    asserts:
+      - failedTemplate:
+          errorMessage: "redis.config.maxmemory (512mb) exceeds redis.resources.limits.memory (256Mi); set maxmemory to ~80% of the limit to leave headroom for AOF rewrite buffers and fragmentation"
+
+  - it: maxmemory within the limit renders
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.config.maxmemory: 200mb
+      redis.resources.limits.memory: 256Mi
+    asserts:
+      - isKind:
+          of: StatefulSet
+
   - it: standalone renders a single-pod StatefulSet
     template: templates/statefulset.yaml
     values:

--- a/redis/tests/unit/guards_test.yaml
+++ b/redis/tests/unit/guards_test.yaml
@@ -95,6 +95,48 @@ tests:
       - isKind:
           of: StatefulSet
 
+  - it: large k8s units (Gi/Ti) parse correctly (no false-positive rejection)
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.config.maxmemory: 1gb
+      redis.resources.limits.memory: 2Ti
+    asserts:
+      - isKind:
+          of: StatefulSet
+
+  - it: unquoted numeric maxmemory over the limit is rejected (no float64 bypass)
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.config.maxmemory: 300000000
+      redis.resources.limits.memory: 256Mi
+    asserts:
+      - failedTemplate:
+          errorMessage: "redis.config.maxmemory (300000000) exceeds redis.resources.limits.memory (256Mi); set maxmemory to ~80% of the limit to leave headroom for AOF rewrite buffers and fragmentation"
+
+  - it: an unsupported memory unit fails fast (no silent byte fallthrough)
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.config.maxmemory: 200mib
+    asserts:
+      - failedTemplate:
+          errorMessage: "redis: unsupported memory unit \"mib\" in \"200mib\" (use bytes or k/kb/ki, m/mb/mi, g/gb/gi, t/tb/ti, p/pb/pi)"
+
+  - it: a malformed memory quantity fails fast
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.config.maxmemory: 1.2.3gb
+    asserts:
+      - failedTemplate:
+          errorMessage: 'redis: cannot parse memory quantity "1.2.3gb"'
+
   - it: standalone renders a single-pod StatefulSet
     template: templates/statefulset.yaml
     values:

--- a/redis/tests/unit/statefulset_test.yaml
+++ b/redis/tests/unit/statefulset_test.yaml
@@ -139,6 +139,32 @@ tests:
       - notExists:
           path: metadata.annotations
 
+  - it: imagePullSecrets render on the pod (standalone)
+    template: templates/statefulset.yaml
+    values:
+      - ../values-minimal.yaml
+    set:
+      imagePullSecrets:
+        - name: my-creds
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: my-creds
+
+  - it: imagePullSecrets render on the pod (replication)
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      imagePullSecrets:
+        - name: my-creds
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: my-creds
+
   # --- Replication (Sentinel HA) ---
   - it: replication - 3 pods, headless serviceName, OrderedReady
     template: templates/statefulset.yaml

--- a/redis/values.yaml
+++ b/redis/values.yaml
@@ -87,6 +87,10 @@ redis:
     auto-aof-rewrite-percentage: "100"
     auto-aof-rewrite-min-size: "64mb"
     # General production settings (defaults match Redis defaults).
+    # Close idle client connections after N seconds (0 = never).
+    timeout: 0
+    # TCP keepalive (seconds); 0 disables.
+    tcp-keepalive: 60
     loglevel: "notice"
     databases: 16
     slowlog-log-slower-than: 10000

--- a/redis/values.yaml
+++ b/redis/values.yaml
@@ -10,6 +10,10 @@ architecture: replication
 # Cluster DNS domain, used to build the stable per-pod FQDNs Sentinel announces.
 clusterDomain: cluster.local
 
+# Image pull secrets, applied to every pod (redis, sentinel, exporter, init).
+imagePullSecrets: []
+# - name: my-registry-creds
+
 redis:
   image:
     repository: redis

--- a/redis/values.yaml
+++ b/redis/values.yaml
@@ -86,6 +86,17 @@ redis:
     no-appendfsync-on-rewrite: "yes"
     auto-aof-rewrite-percentage: "100"
     auto-aof-rewrite-min-size: "64mb"
+    # General production settings (defaults match Redis defaults).
+    loglevel: "notice"
+    databases: 16
+    slowlog-log-slower-than: 10000
+    slowlog-max-len: 128
+    # Per-class client output buffer limits (list of full directive args). Empty = Redis
+    # defaults. Example for a busy replication/pubsub workload:
+    # client-output-buffer-limit:
+    #   - "replica 512mb 128mb 60"
+    #   - "pubsub 32mb 8mb 60"
+    client-output-buffer-limit: []
     # Write-safety (replication mode only): the master refuses writes unless at least
     # min-replicas-to-write replicas are connected within min-replicas-max-lag seconds.
     # Shrinks the data-loss window on failover. Must be < replicaCount + 1.


### PR DESCRIPTION
Handles the five remaining `v1.0-high` redis issues, one commit each. Non-breaking;
defaults are unchanged. Chart bumped to **1.1.0**.

| Commit | Issue | Change |
|--------|-------|--------|
| `e519f4b` | #82 | Fail-fast guard when `redis.config.maxmemory` exceeds `redis.resources.limits.memory` (new `redis.bytes` helper parses redis + k8s units). |
| `0ae7485` | #84 | `imagePullSecrets` applied to every pod (redis, sentinel, exporter, bootstrap init). |
| `d35413c` | #85 | Complete `Chart.yaml` metadata: `home`, `icon`, `sources`, `maintainers`. |
| `dc5159d` | #81 | Configurable `loglevel`, `databases`, `slowlog-*`, `client-output-buffer-limit`, explicit `dir /data`. |
| `5caefbc` | #78 | Configurable `timeout` + `tcp-keepalive` (were hardcoded); 1.1.0 bump + CHANGELOG. |

All new settings default to Redis's own defaults, so an existing install renders the
same config (plus the now-explicit `dir /data`).

Closes #82
Closes #84
Closes #85
Closes #81
Closes #78

## Validation
74 helm-unittest assertions + 71 `test-template.sh` assertions, `helm lint` clean
(default / standalone / replication / TLS).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Redis production defaults (log level, database count, slowlog settings, connection timeout, TCP keepalive, and client output buffer limits).
  * Added `imagePullSecrets` support applied across all Redis-related pods (including sentinel/exporter and the bootstrap init step).
  * Added fail-fast validation to ensure `maxmemory` never exceeds the pod memory limit.
* **Bug Fixes**
  * Improved `redis.conf` rendering for numeric values and configurable `client-output-buffer-limit` directives.
* **Documentation**
  * Updated chart metadata (home/icon/sources/maintainers) and added a new 1.1.0 changelog entry for production hardening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->