### PR TITLE
fix(pg,pgvector): exporter reads TLS CA under sslmode=verify-* (#204)

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,23 @@
 # pg chart changelog
 
+## 1.2.3 - 2026-06-23
+
+Chart-only fix for a postgres-exporter TLS regression (#204). No image change
+(`trixie-5.5.0-26`); only affects deployments with `prometheusExporter.enabled` and
+`prometheusExporter.sslmode` set to `verify-ca`/`verify-full`.
+
+### Fixed
+
+- **Exporter could not read the TLS CA under `sslmode=verify-ca`/`verify-full`, so every
+  scrape failed with `permission denied` and `pg_up` stayed `0` (#204).** The CA secret
+  was mounted whole at `defaultMode: 0400` (owner-read only); the exporter runs as a
+  non-root UID with no `fsGroup`, so the root-owned `ca.crt` was unreadable. The scrape
+  target stayed `up` (the `/metrics` endpoint returns 200 with `pg_up 0`), making it a
+  silent monitoring blackout. The exporter's TLS volume now projects **only** the public
+  `ca.crt` at a world-readable `0444` -- no `fsGroup` needed. The server cert `tls.crt`
+  and private key `tls.key` are no longer mounted into the exporter (it never read them;
+  the monitoring user is exempt from client-cert auth). Regression from the #110 mTLS work.
+
 ## 1.2.2 - 2026-06-22
 
 Fixes a `pg_hba.conf` dual-authorship bug that broke md5-password authentication on

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: PostgreSQL with repmgr replication and optional PGPool-II
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/templates/_helpers.tpl
+++ b/pg/templates/_helpers.tpl
@@ -378,7 +378,16 @@ volumes:
   - name: postgresql-tls
     secret:
       secretName: {{ .Values.postgresql.tls.existingSecret | quote }}
-      defaultMode: 0400
+      # Project only the (public) CA at a world-readable mode (#204). Secret-volume
+      # files are owned root:root; the exporter runs as a non-root UID with no fsGroup,
+      # so the previous 0400 left ca.crt unreadable (sslmode=verify-* scrapes failed with
+      # "permission denied", pg_up=0). The exporter verifies the server cert with ca.crt
+      # only -- it needs neither tls.crt nor the server private key tls.key, so they are
+      # no longer mounted.
+      items:
+        - key: ca.crt
+          path: ca.crt
+      defaultMode: 0444
 {{- end }}
 {{- end }}
 

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -1498,6 +1498,16 @@ assert_eq "pgbackrest #120: enabled without a passphrase secret fails fast" "1" 
 ro_exp=$(helm template test-pg "${CHART_DIR}" --set prometheusExporter.enabled=true --show-only templates/prometheus-exporter-deployment.yaml 2>&1)
 assert_contains "#117: exporter readOnlyRootFilesystem" "${ro_exp}" "readOnlyRootFilesystem: true"
 assert_contains "#117: exporter has a writable /tmp" "${ro_exp}" "mountPath: /tmp"
+
+# #204: under sslmode=verify-*, the exporter's CA volume must project only the (public)
+# ca.crt at a world-readable mode (0444), not the whole secret at 0400 -- the exporter
+# runs as a non-root UID with no fsGroup, so root-owned 0400 files were unreadable
+# (pg_up=0). The server private key tls.key must not be mounted into the exporter.
+tls_exp=$(helm template test-pg "${CHART_DIR}" --set prometheusExporter.enabled=true --set postgresql.tls.enabled=true --set postgresql.tls.existingSecret=pg-tls --set prometheusExporter.sslmode=verify-ca --show-only templates/prometheus-exporter-deployment.yaml 2>&1)
+assert_contains "#204: exporter CA volume world-readable (0444)" "${tls_exp}" "defaultMode: 0444"
+assert_contains "#204: exporter CA volume projects ca.crt" "${tls_exp}" "key: ca.crt"
+assert_not_contains "#204: exporter CA volume does not mount server private key" "${tls_exp}" "key: tls.key"
+
 # scope each per-container so the assert proves THAT container is read-only with a
 # writable /tmp (a whole-render grep would let one container's /tmp satisfy the other).
 ro_bk_cj=$(helm template test-pg "${CHART_DIR}" --set backup.enabled=true --set backup.s3.endpoint=https://e --set backup.s3.bucket=b --set backup.existingSecret.name=s --show-only templates/backup-cronjob.yaml 2>&1)

--- a/pg/tests/unit/exporter_test.yaml
+++ b/pg/tests/unit/exporter_test.yaml
@@ -1,0 +1,74 @@
+suite: pg prometheus exporter TLS CA volume
+# The configmap is listed so the deployment's checksum/config include resolves; each
+# test scopes its assertions to the deployment with an explicit `template:`.
+templates:
+  - templates/prometheus-exporter-deployment.yaml
+  - templates/prometheus-exporter-configmap.yaml
+release:
+  name: test-pg
+tests:
+  # #204: under sslmode=verify-*, the exporter must mount the CA and be able to read it.
+  - it: verify-ca projects only ca.crt at a world-readable mode
+    template: templates/prometheus-exporter-deployment.yaml
+    values:
+      - ../values-agent.yaml
+    set:
+      prometheusExporter.enabled: true
+      postgresql.tls.enabled: true
+      postgresql.tls.existingSecret: pg-tls
+      prometheusExporter.sslmode: verify-ca
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[?(@.name=="postgresql-tls")].secret.secretName
+          value: pg-tls
+      # 0444 octal == 292 decimal (go-yaml parses the rendered 0444 literal as octal).
+      - equal:
+          path: spec.template.spec.volumes[?(@.name=="postgresql-tls")].secret.defaultMode
+          value: 292
+      # only ca.crt is projected -- tls.key (server private key) and tls.crt are not mounted
+      - lengthEqual:
+          path: spec.template.spec.volumes[?(@.name=="postgresql-tls")].secret.items
+          count: 1
+      - contains:
+          path: spec.template.spec.volumes[?(@.name=="postgresql-tls")].secret.items
+          content:
+            key: ca.crt
+            path: ca.crt
+      - notContains:
+          path: spec.template.spec.volumes[?(@.name=="postgresql-tls")].secret.items
+          content:
+            key: tls.key
+            path: tls.key
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="postgres-exporter")].volumeMounts
+          content:
+            name: postgresql-tls
+            mountPath: /etc/postgres_exporter/tls
+            readOnly: true
+          any: true
+
+  - it: verify-full also projects the CA volume
+    template: templates/prometheus-exporter-deployment.yaml
+    values:
+      - ../values-agent.yaml
+    set:
+      prometheusExporter.enabled: true
+      postgresql.tls.enabled: true
+      postgresql.tls.existingSecret: pg-tls
+      prometheusExporter.sslmode: verify-full
+    asserts:
+      - exists:
+          path: spec.template.spec.volumes[?(@.name=="postgresql-tls")]
+
+  - it: sslmode require mounts no CA volume (no cert verification)
+    template: templates/prometheus-exporter-deployment.yaml
+    values:
+      - ../values-agent.yaml
+    set:
+      prometheusExporter.enabled: true
+      postgresql.tls.enabled: true
+      postgresql.tls.existingSecret: pg-tls
+      prometheusExporter.sslmode: require
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name=="postgresql-tls")]

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,18 @@
 # pgvector chart changelog
 
+## 1.2.3 - 2026-06-23
+
+Chart-only fix for a postgres-exporter TLS regression (#204). No image change
+(`trixie-5.5.0-26`). Shares pg's exporter template; see the pg CHANGELOG for detail.
+
+### Fixed
+
+- **Exporter could not read the TLS CA under `sslmode=verify-ca`/`verify-full`
+  (`permission denied`, `pg_up=0`) (#204).** The CA secret was mounted whole at
+  `defaultMode: 0400`, unreadable by the exporter's non-root UID (no `fsGroup`). The TLS
+  volume now projects only the public `ca.crt` at `0444`; `tls.crt`/`tls.key` are no
+  longer mounted. Regression from the #110 mTLS work.
+
 ## 1.2.2 - 2026-06-22
 
 Fixes the agent-mode `pg_hba.conf` dual-authorship bug (#199); image moves to

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with pgvector extension and optional PGPool-II
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg


### PR DESCRIPTION
## Summary

Fixes #204. Under `prometheusExporter.sslmode=verify-ca`/`verify-full`, the postgres-exporter could not read the mounted TLS CA: every scrape failed with `permission denied` and `pg_up` stayed `0`, while the scrape target stayed `up` (a silent monitoring blackout). Regression from the #110 mTLS work.

**Root cause:** the exporter mounted the whole `postgresql-tls` secret at `defaultMode: 0400` (owner-read only). Secret-volume files are owned `root:root`; the exporter runs as a non-root UID (`65534`) with no `fsGroup`, so `ca.crt` was unreadable (`EACCES`).

**Fix:** the exporter's TLS volume now projects **only** the public `ca.crt` at a world-readable `0444` -- no `fsGroup` needed. The server cert `tls.crt` and private key `tls.key` are no longer mounted into the exporter (it never read them; the monitoring user is exempt from client-cert auth). Shared with pgvector via the `_helpers.tpl` symlink.

## Changes

- `pg/templates/_helpers.tpl` -- exporter `postgresql-tls` volume: `items: [ca.crt]` at `defaultMode: 0444` (was whole secret at `0400`).
- `pg/tests/unit/exporter_test.yaml` (new) -- 3 helm-unittest cases: verify-ca projects only `ca.crt` at `0444`, `tls.key` absent, CA mounted RO; verify-full mounts the CA; `require` mounts nothing.
- `pg/tests/test-template.sh` -- #204 render assertions.
- `pg`/`pgvector` `Chart.yaml` `1.2.2 -> 1.2.3` (chart-only, no image change) + both CHANGELOGs.

## Validation

- `helm lint pg pgvector`: 0 failed
- helm-unittest (all 5 charts): pg 28, pgvector 10, etcd 25, kafka 35, redis 79 pass
- `make -C pg test-template`: 784/784
- vendored-subchart freshness, kubeconform, kube-linter: all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PostgreSQL exporter TLS regression affecting deployments using prometheus exporter with SSL certificate verification modes. The exporter can now properly read TLS certificates with correct file permissions.

* **Tests**
  * Added test coverage for TLS certificate mounting behavior.

* **Chores**
  * Bumped chart versions to 1.2.3 for both `pg` and `pgvector` charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->