### PR TITLE
feat(redis): ACL support with chart-managed operator user (1.2.0) (#87)

### DIFF
--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -13,9 +13,11 @@ are unchanged).
   used for replication (`masteruser`/`masterauth`), Sentinel (`auth-user`/`auth-pass`), the
   exporter (`REDIS_USER`), and probes; lets you lock down the `default` user.
 - Fail-fast validation of ACL config (auth prerequisite, username charset, no
-  `on`/`off`/`nopass`/`reset*`/`>`/`#` in `rules`, operator/`default` interlocks, ACL knobs
-  set while `acl.enabled` is false, and BYO `existingSecret` requiring an explicit
-  `passwordSecret.name` for every ACL user and the operator).
+  `on`/`off`/`nopass`/`reset*`/`>`/`#` and no shell metacharacters (`" $ ` + backslash) in
+  `rules` — they are appended to `redis.conf` via a shell `echo` at startup —
+  operator/`default` interlocks, ACL knobs set while `acl.enabled` is false, and BYO
+  `existingSecret` requiring an explicit `passwordSecret.name` for every ACL user and the
+  operator).
 
 ## 1.1.0
 

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.2.0
+
+ACL support (non-breaking; `redis.auth.acl.enabled` defaults `false`, so existing installs
+are unchanged).
+
+### Added
+- Redis ACL users via `redis.auth.acl` (#87): layer named, per-command/per-key users on top
+  of password auth, in both `standalone` and `replication`. Passwords stay out of the
+  ConfigMap (rendered into `redis.conf` at runtime from Secret-backed env).
+- A chart-managed **operator user** (`redis.auth.acl.operatorUser`) — the privileged identity
+  used for replication (`masteruser`/`masterauth`), Sentinel (`auth-user`/`auth-pass`), the
+  exporter (`REDIS_USER`), and probes; lets you lock down the `default` user.
+- Fail-fast validation of ACL config (auth prerequisite, username charset, no
+  `on`/`off`/`nopass`/`reset*`/`>`/`#` in `rules`, operator/`default` interlocks).
+
 ## 1.1.0
 
 Operability and production-hardening (non-breaking; defaults unchanged).

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -13,7 +13,9 @@ are unchanged).
   used for replication (`masteruser`/`masterauth`), Sentinel (`auth-user`/`auth-pass`), the
   exporter (`REDIS_USER`), and probes; lets you lock down the `default` user.
 - Fail-fast validation of ACL config (auth prerequisite, username charset, no
-  `on`/`off`/`nopass`/`reset*`/`>`/`#` in `rules`, operator/`default` interlocks).
+  `on`/`off`/`nopass`/`reset*`/`>`/`#` in `rules`, operator/`default` interlocks, ACL knobs
+  set while `acl.enabled` is false, and BYO `existingSecret` requiring an explicit
+  `passwordSecret.name` for every ACL user and the operator).
 
 ## 1.1.0
 

--- a/redis/Chart.yaml
+++ b/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: Redis with AOF persistence and Sentinel-based HA replication
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "8"
 home: https://github.com/cagriekin/charts/tree/master/redis
 icon: https://www.vectorlogo.zone/logos/redis/redis-icon.svg

--- a/redis/Makefile
+++ b/redis/Makefile
@@ -3,7 +3,7 @@ KIND_CONFIG := kind-config.yaml
 TESTS_DIR := tests
 MAKEFLAGS += --output-sync=target
 
-.PHONY: test test-template test-cluster test-minimal test-full test-persistence test-replication test-failover test-ha test-tls cluster-create cluster-delete cluster-exists clean help
+.PHONY: test test-template test-cluster test-minimal test-full test-persistence test-replication test-failover test-ha test-tls test-acl cluster-create cluster-delete cluster-exists clean help
 
 help:
 	@echo "Targets:"
@@ -17,6 +17,7 @@ help:
 	@echo "  test-replication - Run replication topology tests"
 	@echo "  test-failover   - Run Sentinel failover tests (needs an existing replication release)"
 	@echo "  test-tls        - Run replication-over-TLS smoke (opt-in; generates a self-signed cert)"
+	@echo "  test-acl        - Run ACL tests (standalone restricted user + replication locked default)"
 	@echo "  cluster-create  - Create Kind cluster"
 	@echo "  cluster-delete  - Delete Kind cluster"
 	@echo "  clean           - Delete cluster and test namespaces"
@@ -26,7 +27,7 @@ test: cluster-create test-template test-cluster cluster-delete
 test-template:
 	@bash $(TESTS_DIR)/test-template.sh
 
-test-cluster: test-minimal test-full test-persistence test-ha
+test-cluster: test-minimal test-full test-persistence test-ha test-acl
 	@echo "All test suites passed"
 
 cluster-exists:
@@ -71,6 +72,9 @@ test-failover: cluster-exists
 
 test-tls: cluster-exists
 	@bash $(TESTS_DIR)/test-tls.sh
+
+test-acl: cluster-exists
+	@bash $(TESTS_DIR)/test-acl.sh
 
 clean: cluster-delete
 	@echo "Cleaned up"

--- a/redis/README.md
+++ b/redis/README.md
@@ -140,6 +140,64 @@ also Sentinel's admin port — keep `redis.auth.enabled: true` (the default) so 
 password; disabling auth while `allowExternal: true` leaves cluster reconfiguration open to
 any in-namespace pod.
 
+### ACL
+
+Redis ACLs layer named, per-command/per-key users on top of the password auth above
+(`redis.auth.acl`, requires `redis.auth.enabled`). Works in both `standalone` and
+`replication`.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `redis.auth.acl.enabled` | Enable ACL users | `false` |
+| `redis.auth.acl.operatorUser` | Privileged identity the chart authenticates as | `default` |
+| `redis.auth.acl.operatorPasswordSecret.name` / `.key` | Operator password source (empty = reuse the redis auth Secret) | `""` |
+| `redis.auth.acl.users[].name` | ACL username (`^[A-Za-z0-9_.-]+$`) | — |
+| `redis.auth.acl.users[].rules` | Permission tokens only (no `on`/password) | `""` |
+| `redis.auth.acl.users[].passwordSecret.name` / `.key` | Per-user password source | `""` |
+
+```yaml
+redis:
+  auth:
+    acl:
+      enabled: true
+      users:
+        - name: app
+          rules: "~app:* &app:* +@read +@write -@dangerous"
+          passwordSecret:
+            key: app-acl-password   # empty name => chart generates this key
+```
+
+**`rules` carries permission tokens only** — key patterns (`~app:*`), channel patterns
+(`&app:*`), and command rules (`+@read`, `-@dangerous`). The chart emits `on` and the
+password itself, so do **not** put `on`/`off`/`nopass`/`reset*`/`>password`/`#hash` in
+`rules` (rejected at render time). Pub/sub needs an explicit `&<pattern>` because Redis
+defaults to `resetchannels`.
+
+**Operator user.** The chart authenticates as `operatorUser` for replication
+(`masteruser`/`masterauth`), Sentinel (`auth-user`/`auth-pass`), the exporter, and the
+liveness/readiness/preStop probes. Its permissions are **chart-managed and always full**
+(`~* &* +@all`) — you pick only its name and password source, never its rules, because a
+restricted operator silently breaks replication, failover, and metrics. The default
+`operatorUser: default` keeps today's behavior exactly (the `default` user via
+`requirepass`). **To lock down the `default` user, define it under `users[]` and set
+`operatorUser` to a separate name** — the chart then drops `requirepass` and renders an
+explicit `user default` line. (Locking down `default` while it is still the operator is
+rejected.)
+
+**Passwords.** Each user's password comes from a Secret. With an empty `passwordSecret.name`
+the chart generates a random value (key `acl-<name>-password` unless you set `.key`) and
+persists it across upgrades via `lookup`. Under render-only pipelines (e.g. ArgoCD) `lookup`
+is empty, so **set `passwordSecret.name` (and `operatorPasswordSecret.name`) for every ACL
+user**, or each sync regenerates the passwords and locks out clients — the same caveat as
+`redis.auth.existingSecret.name`.
+
+**Runtime changes are not persisted.** There is no `aclfile`; the rendered config is the
+source of truth, so `ACL SETUSER`/`ACL SAVE` at runtime are lost on restart — change users
+through values + `helm upgrade`. **Rotating a password** is a deliberate operation: during
+the rolling restart a re-elected master may briefly hold the new password while a
+not-yet-restarted replica still presents the old `masterauth`, so rotate during a quiet
+window.
+
 ### Scheduling, PDB, NetworkPolicy
 
 | Parameter | Description | Default |

--- a/redis/templates/_helpers.tpl
+++ b/redis/templates/_helpers.tpl
@@ -176,14 +176,25 @@ cp /etc/redis/redis.conf /config-rw/redis.conf
 {{- if ne (include "redis.aclDefinesDefault" .) "true" }}
   echo "requirepass ${REDIS_PASSWORD}"
 {{- end }}
+{{- include "redis.aclUserLines" . }}
+} >> /config-rw/redis.conf
+exec redis-server /config-rw/redis.conf
+{{- end }}
+
+{{- /* The operator + per-user ACL `user` lines appended to redis.conf at startup, shared by
+       the standalone start script and the replication bootstrap so the two topologies can
+       never render divergent ACLs. Emits nothing when ACL is off. Passwords come from env
+       (OPERATOR_PWD / ACL_PASS_<i>); names are charset-validated and rules are rejected if
+       they contain shell metacharacters, both in redis.validate, before reaching this echo. */ -}}
+{{- define "redis.aclUserLines" -}}
+{{- if .Values.redis.auth.acl.enabled }}
 {{- if ne (include "redis.operatorUser" .) "default" }}
   echo "user {{ .Values.redis.auth.acl.operatorUser }} on >${OPERATOR_PWD} ~* &* +@all"
 {{- end }}
 {{- range $i, $u := .Values.redis.auth.acl.users }}
   echo "user {{ $u.name }} on >${ACL_PASS_{{ $i }}} {{ $u.rules }}"
 {{- end }}
-} >> /config-rw/redis.conf
-exec redis-server /config-rw/redis.conf
+{{- end }}
 {{- end }}
 
 {{- /* Total redis pods = replicas + 1 master. */ -}}
@@ -300,6 +311,17 @@ exec redis-server /config-rw/redis.conf
 {{- if regexMatch "(^|[[:space:]])[>#]" $rules }}
 {{- fail (printf "redis.auth.acl: user %q rules must not embed a password (>...) or hash (#...); set passwordSecret instead" .name) }}
 {{- end }}
+{{- /* rules is appended to redis.conf through a double-quoted shell `echo` at startup, so any
+       character the shell still interprets inside double quotes ($, `, ", \) would allow
+       command injection. None of these appear in legitimate Redis ACL rule syntax (key/channel
+       globs, +/-commands, @categories, selectors), so reject them outright. Checks the raw
+       value, not the lowercased copy. */}}
+{{- if regexMatch "[\"$`\\\\]" (.rules | default "") }}
+{{- fail (printf "redis.auth.acl: user %q rules must not contain the shell metacharacters \" $ ` or \\ (rules are appended to redis.conf via a shell echo at startup)" .name) }}
+{{- end }}
+{{- if regexMatch "[[:cntrl:]]" (.rules | default "") }}
+{{- fail (printf "redis.auth.acl: user %q rules must not contain control characters or newlines" .name) }}
+{{- end }}
 {{- end }}
 {{- if and (ne $op "default") (has $op $names) }}
 {{- fail (printf "redis.auth.acl: operatorUser %q must not also appear in users[]; the chart manages the operator user with full permissions (~* &* +@all)" $op) }}
@@ -410,14 +432,7 @@ cp /config-ro/redis.conf /config-rw/redis.conf
   echo "masteruser ${OPERATOR_USER}"
   echo "masterauth ${OPERATOR_PWD}"
 {{- end }}
-{{- if .Values.redis.auth.acl.enabled }}
-{{- if ne (include "redis.operatorUser" .) "default" }}
-  echo "user {{ .Values.redis.auth.acl.operatorUser }} on >${OPERATOR_PWD} ~* &* +@all"
-{{- end }}
-{{- range $i, $u := .Values.redis.auth.acl.users }}
-  echo "user {{ $u.name }} on >${ACL_PASS_{{ $i }}} {{ $u.rules }}"
-{{- end }}
-{{- end }}
+{{- include "redis.aclUserLines" . }}
 } >> /config-rw/redis.conf
 
 if [ -n "$MASTER" ] && [ "$MASTER" != "$POD_FQDN" ]; then
@@ -456,6 +471,30 @@ cp /config-ro/sentinel.conf /config-rw/sentinel.conf
 } >> /config-rw/sentinel.conf
 {{- end }}
 
+{{- /* Exporter auth env (REDIS_USER/REDIS_PASSWORD), selecting operator vs default-user
+       credentials. Shared by the replication exporter sidecar (statefulset.yaml) and the
+       standalone exporter Deployment (redis.exporterPodSpec) so the two never desync. Emits
+       list items at zero indent; the caller guards on redis.auth.enabled and applies nindent. */ -}}
+{{- define "redis.exporterAuthEnv" -}}
+{{- if .Values.redis.auth.enabled }}
+{{- if ne (include "redis.operatorUser" .) "default" }}
+- name: REDIS_USER
+  value: {{ .Values.redis.auth.acl.operatorUser | quote }}
+- name: REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "redis.operatorSecretName" . }}
+      key: {{ include "redis.operatorSecretKey" . }}
+{{- else }}
+- name: REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "redis.secretName" . }}
+      key: {{ .Values.redis.auth.existingSecret.key }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "redis.exporterPodSpec" -}}
 securityContext:
   {{- toYaml .Values.exporter.podSecurityContext | nindent 2 }}
@@ -472,23 +511,9 @@ containers:
     env:
       - name: REDIS_ADDR
         value: "{{ if .Values.tls.enabled }}rediss{{ else }}redis{{ end }}://{{ include "redis.fullname" . }}:{{ .Values.service.port }}"
-{{- if .Values.redis.auth.enabled }}
-{{- if ne (include "redis.operatorUser" .) "default" }}
-      - name: REDIS_USER
-        value: {{ .Values.redis.auth.acl.operatorUser | quote }}
-      - name: REDIS_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: {{ include "redis.operatorSecretName" . }}
-            key: {{ include "redis.operatorSecretKey" . }}
-{{- else }}
-      - name: REDIS_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: {{ include "redis.secretName" . }}
-            key: {{ .Values.redis.auth.existingSecret.key }}
-{{- end }}
-{{- end }}
+      {{- with (include "redis.exporterAuthEnv" . | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
 {{- if .Values.tls.enabled }}
       - name: REDIS_EXPORTER_TLS_CLIENT_KEY_FILE
         value: /etc/redis/tls/tls.key

--- a/redis/templates/_helpers.tpl
+++ b/redis/templates/_helpers.tpl
@@ -68,6 +68,114 @@
 {{- end }}
 {{- end }}
 
+{{- /* ACL operator user: the single privileged identity the chart itself authenticates as
+       (replication masteruser, Sentinel auth-user, exporter, probes). "default" => the chart
+       keeps using the primary password (requirepass) and emits no operator-specific wiring. */ -}}
+{{- define "redis.operatorUser" -}}
+{{- .Values.redis.auth.acl.operatorUser | default "default" }}
+{{- end }}
+
+{{- /* True (string) only when ACL is on AND a users[] entry redefines the `default` user, in
+       which case requirepass is dropped in favor of an explicit `user default` line. */ -}}
+{{- define "redis.aclDefinesDefault" -}}
+{{- $found := false }}
+{{- if .Values.redis.auth.acl.enabled }}
+{{- range .Values.redis.auth.acl.users }}
+{{- if eq .name "default" }}{{- $found = true }}{{- end }}
+{{- end }}
+{{- end }}
+{{- $found }}
+{{- end }}
+
+{{- /* Secret name/key for the operator user's password: a provided operatorPasswordSecret,
+       else reuse the redis auth Secret/key (one privileged password reusing the primary). */ -}}
+{{- define "redis.operatorSecretName" -}}
+{{- if .Values.redis.auth.acl.operatorPasswordSecret.name }}
+{{- .Values.redis.auth.acl.operatorPasswordSecret.name }}
+{{- else }}
+{{- include "redis.secretName" . }}
+{{- end }}
+{{- end }}
+
+{{- define "redis.operatorSecretKey" -}}
+{{- if .Values.redis.auth.acl.operatorPasswordSecret.key }}
+{{- .Values.redis.auth.acl.operatorPasswordSecret.key }}
+{{- else }}
+{{- .Values.redis.auth.existingSecret.key }}
+{{- end }}
+{{- end }}
+
+{{- /* Per-user password Secret name/key. Takes (dict "ctx" $ "user" $u). Empty
+       passwordSecret.name reuses the redis auth Secret; empty key defaults to
+       acl-<name>-password (the key the chart generates in secret.yaml). */ -}}
+{{- define "redis.aclUserSecretName" -}}
+{{- if and .user.passwordSecret .user.passwordSecret.name }}
+{{- .user.passwordSecret.name }}
+{{- else }}
+{{- include "redis.secretName" .ctx }}
+{{- end }}
+{{- end }}
+
+{{- define "redis.aclUserSecretKey" -}}
+{{- if and .user.passwordSecret .user.passwordSecret.key }}
+{{- .user.passwordSecret.key }}
+{{- else }}
+{{- printf "acl-%s-password" .user.name }}
+{{- end }}
+{{- end }}
+
+{{- /* Container env exposing the operator password (when operatorUser != default) and one
+       ACL_PASS_<i> per ACL user, sourced from Secrets. Rendered into the bootstrap init
+       container and the standalone redis container, which append the `user` lines. */ -}}
+{{- define "redis.aclEnv" -}}
+{{- if .Values.redis.auth.acl.enabled }}
+{{- if ne (include "redis.operatorUser" .) "default" }}
+- name: OPERATOR_USER
+  value: {{ .Values.redis.auth.acl.operatorUser | quote }}
+- name: OPERATOR_PWD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "redis.operatorSecretName" . }}
+      key: {{ include "redis.operatorSecretKey" . }}
+{{- end }}
+{{- range $i, $u := .Values.redis.auth.acl.users }}
+- name: ACL_PASS_{{ $i }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "redis.aclUserSecretName" (dict "ctx" $ "user" $u) }}
+      key: {{ include "redis.aclUserSecretKey" (dict "ctx" $ "user" $u) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- /* `--user <operatorUser> ` (with a trailing space) for in-pod redis-cli when the chart
+       authenticates as a non-default operator; empty otherwise. There is no REDISCLI_USER
+       env, so the username must be passed on the command line. */ -}}
+{{- define "redis.cliUserOpt" -}}
+{{- if and .Values.redis.auth.acl.enabled (ne (include "redis.operatorUser" .) "default") }}
+{{- printf "--user %s " .Values.redis.auth.acl.operatorUser }}
+{{- end }}
+{{- end }}
+
+{{- /* Standalone startup wrapper (ACL only): standalone has no bootstrap init container, so
+       it renders redis.conf into a writable copy, appends requirepass (unless `default` is
+       redefined) + the operator and ACL `user` lines (passwords via env), then execs. */ -}}
+{{- define "redis.standaloneStartScript" -}}
+cp /etc/redis/redis.conf /config-rw/redis.conf
+{
+{{- if ne (include "redis.aclDefinesDefault" .) "true" }}
+  echo "requirepass ${REDIS_PASSWORD}"
+{{- end }}
+{{- if ne (include "redis.operatorUser" .) "default" }}
+  echo "user {{ .Values.redis.auth.acl.operatorUser }} on >${OPERATOR_PWD} ~* &* +@all"
+{{- end }}
+{{- range $i, $u := .Values.redis.auth.acl.users }}
+  echo "user {{ $u.name }} on >${ACL_PASS_{{ $i }}} {{ $u.rules }}"
+{{- end }}
+} >> /config-rw/redis.conf
+exec redis-server /config-rw/redis.conf
+{{- end }}
+
 {{- /* Total redis pods = replicas + 1 master. */ -}}
 {{- define "redis.podCount" -}}
 {{- add (int .Values.redis.replicaCount) 1 }}
@@ -161,6 +269,35 @@
 {{- fail (printf "redis.config.maxmemory (%s) exceeds redis.resources.limits.memory (%s); set maxmemory to ~80%% of the limit to leave headroom for AOF rewrite buffers and fragmentation" (include "redis.intval" $maxmemory) $memLimit) }}
 {{- end }}
 {{- end }}
+{{- if .Values.redis.auth.acl.enabled }}
+{{- if not .Values.redis.auth.enabled }}
+{{- fail "redis.auth.acl.enabled requires redis.auth.enabled" }}
+{{- end }}
+{{- $op := include "redis.operatorUser" . }}
+{{- $names := list }}
+{{- range .Values.redis.auth.acl.users }}
+{{- if not (regexMatch "^[A-Za-z0-9_.-]+$" .name) }}
+{{- fail (printf "redis.auth.acl: user name %q must match ^[A-Za-z0-9_.-]+$ (no spaces or shell-significant characters)" .name) }}
+{{- end }}
+{{- if has .name $names }}
+{{- fail (printf "redis.auth.acl: duplicate user name %q" .name) }}
+{{- end }}
+{{- $names = append $names .name }}
+{{- $rules := lower (.rules | default "") }}
+{{- if regexMatch "(^|[[:space:]])(on|off|nopass|reset|resetpass|resetkeys|resetchannels|clearselectors)([[:space:]]|$)" $rules }}
+{{- fail (printf "redis.auth.acl: user %q rules must contain permission tokens only; the chart manages enablement (drop on/off/nopass/reset*)" .name) }}
+{{- end }}
+{{- if regexMatch "(^|[[:space:]])[>#]" $rules }}
+{{- fail (printf "redis.auth.acl: user %q rules must not embed a password (>...) or hash (#...); set passwordSecret instead" .name) }}
+{{- end }}
+{{- end }}
+{{- if and (ne $op "default") (has $op $names) }}
+{{- fail (printf "redis.auth.acl: operatorUser %q must not also appear in users[]; the chart manages the operator user with full permissions (~* &* +@all)" $op) }}
+{{- end }}
+{{- if and (has "default" $names) (eq $op "default") }}
+{{- fail "redis.auth.acl: redefining the `default` user requires a separate operatorUser; the chart authenticates as operatorUser for replication, failover, the exporter, and probes, so locking down `default` while it is the operator would break them" }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{- /* Failover-safe bootstrap. Runs in the redis-bootstrap init container: discovers
@@ -226,10 +363,27 @@ cp /config-ro/redis.conf /config-rw/redis.conf
 {
   echo "replica-announce-ip ${POD_FQDN}"
   echo "replica-announce-port ${REDIS_PORT}"
+{{- if ne (include "redis.aclDefinesDefault" .) "true" }}
   if [ -n "${REDIS_PASSWORD:-}" ]; then
     echo "requirepass ${REDIS_PASSWORD}"
+  fi
+{{- end }}
+{{- if eq (include "redis.operatorUser" .) "default" }}
+  if [ -n "${REDIS_PASSWORD:-}" ]; then
     echo "masterauth ${REDIS_PASSWORD}"
   fi
+{{- else }}
+  echo "masteruser ${OPERATOR_USER}"
+  echo "masterauth ${OPERATOR_PWD}"
+{{- end }}
+{{- if .Values.redis.auth.acl.enabled }}
+{{- if ne (include "redis.operatorUser" .) "default" }}
+  echo "user {{ .Values.redis.auth.acl.operatorUser }} on >${OPERATOR_PWD} ~* &* +@all"
+{{- end }}
+{{- range $i, $u := .Values.redis.auth.acl.users }}
+  echo "user {{ $u.name }} on >${ACL_PASS_{{ $i }}} {{ $u.rules }}"
+{{- end }}
+{{- end }}
 } >> /config-rw/redis.conf
 
 if [ -n "$MASTER" ] && [ "$MASTER" != "$POD_FQDN" ]; then
@@ -254,9 +408,14 @@ cp /config-ro/sentinel.conf /config-rw/sentinel.conf
     echo "requirepass ${SENTINEL_PASSWORD}"
   fi
   echo "sentinel monitor ${MASTER_NAME} ${MASTER_FQDN} ${REDIS_PORT} ${QUORUM}"
+{{- if eq (include "redis.operatorUser" .) "default" }}
   if [ -n "${REDIS_PASSWORD:-}" ]; then
     echo "sentinel auth-pass ${MASTER_NAME} ${REDIS_PASSWORD}"
   fi
+{{- else }}
+  echo "sentinel auth-user ${MASTER_NAME} ${OPERATOR_USER}"
+  echo "sentinel auth-pass ${MASTER_NAME} ${OPERATOR_PWD}"
+{{- end }}
   echo "sentinel down-after-milliseconds ${MASTER_NAME} ${DOWN_AFTER_MS}"
   echo "sentinel failover-timeout ${MASTER_NAME} ${FAILOVER_TIMEOUT}"
   echo "sentinel parallel-syncs ${MASTER_NAME} ${PARALLEL_SYNCS}"
@@ -280,11 +439,21 @@ containers:
       - name: REDIS_ADDR
         value: "{{ if .Values.tls.enabled }}rediss{{ else }}redis{{ end }}://{{ include "redis.fullname" . }}:{{ .Values.service.port }}"
 {{- if .Values.redis.auth.enabled }}
+{{- if ne (include "redis.operatorUser" .) "default" }}
+      - name: REDIS_USER
+        value: {{ .Values.redis.auth.acl.operatorUser | quote }}
+      - name: REDIS_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ include "redis.operatorSecretName" . }}
+            key: {{ include "redis.operatorSecretKey" . }}
+{{- else }}
       - name: REDIS_PASSWORD
         valueFrom:
           secretKeyRef:
             name: {{ include "redis.secretName" . }}
             key: {{ .Values.redis.auth.existingSecret.key }}
+{{- end }}
 {{- end }}
 {{- if .Values.tls.enabled }}
       - name: REDIS_EXPORTER_TLS_CLIENT_KEY_FILE

--- a/redis/templates/_helpers.tpl
+++ b/redis/templates/_helpers.tpl
@@ -71,8 +71,18 @@
 {{- /* ACL operator user: the single privileged identity the chart itself authenticates as
        (replication masteruser, Sentinel auth-user, exporter, probes). "default" => the chart
        keeps using the primary password (requirepass) and emits no operator-specific wiring. */ -}}
+{{- /* The privileged identity the chart authenticates as (replication masteruser/masterauth,
+       Sentinel auth-user, exporter REDIS_USER, probes). Meaningful only when ACL is enabled;
+       returns "default" otherwise so every `eq/ne operatorUser "default"` call site collapses
+       to the no-ACL path and never wires OPERATOR_ or REDIS_USER env against undefined or a
+       user that does not exist. A non-default operatorUser while ACL is off is rejected by
+       redis.validate. */ -}}
 {{- define "redis.operatorUser" -}}
+{{- if .Values.redis.auth.acl.enabled }}
 {{- .Values.redis.auth.acl.operatorUser | default "default" }}
+{{- else }}
+{{- "default" }}
+{{- end }}
 {{- end }}
 
 {{- /* True (string) only when ACL is on AND a users[] entry redefines the `default` user, in
@@ -296,6 +306,30 @@ exec redis-server /config-rw/redis.conf
 {{- end }}
 {{- if and (has "default" $names) (eq $op "default") }}
 {{- fail "redis.auth.acl: redefining the `default` user requires a separate operatorUser; the chart authenticates as operatorUser for replication, failover, the exporter, and probes, so locking down `default` while it is the operator would break them" }}
+{{- end }}
+{{- /* BYO Secret: secret.yaml generates no ACL passwords when existingSecret.name is set,
+       so every ACL identity must point at a key the user pre-populated, or the pods fail at
+       startup on a missing secretKeyRef. Require explicit names rather than silently
+       defaulting to acl-<name>-password keys that will not exist in the supplied Secret. */}}
+{{- if .Values.redis.auth.existingSecret.name }}
+{{- if and (ne $op "default") (not .Values.redis.auth.acl.operatorPasswordSecret.name) }}
+{{- fail "redis.auth.acl: with redis.auth.existingSecret.name set, operatorPasswordSecret.name must also be set (the chart writes no operator password into a user-supplied Secret)" }}
+{{- end }}
+{{- range .Values.redis.auth.acl.users }}
+{{- if not (and .passwordSecret .passwordSecret.name) }}
+{{- fail (printf "redis.auth.acl: with redis.auth.existingSecret.name set, user %q must set passwordSecret.name (the chart writes no per-user password into a user-supplied Secret)" .name) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- else }}
+{{- /* ACL knobs set while disabled would feed undefined OPERATOR_ and ACL_PASS_ env into the
+       bootstrap and exporter wiring. Fail fast. Checks the raw value, since redis.operatorUser
+       reports "default" whenever ACL is off. */}}
+{{- if ne (.Values.redis.auth.acl.operatorUser | default "default") "default" }}
+{{- fail "redis.auth.acl.operatorUser is non-default but redis.auth.acl.enabled is false; enable ACL or leave operatorUser as 'default'" }}
+{{- end }}
+{{- if .Values.redis.auth.acl.users }}
+{{- fail "redis.auth.acl.users is set but redis.auth.acl.enabled is false; set redis.auth.acl.enabled=true or remove the users" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/redis/templates/secret.yaml
+++ b/redis/templates/secret.yaml
@@ -1,17 +1,44 @@
 {{- if and .Values.redis.auth.enabled (not .Values.redis.auth.existingSecret.name) }}
-{{- /* Generate a random password Secret when the user did not supply one. Reuse the
-       password from the live Secret so helm upgrade never rotates a credential the
-       running cluster still authenticates with. lookup returns nothing under helm
-       template/--dry-run, so render-only pipelines (e.g. ArgoCD) should set
-       redis.auth.existingSecret.name instead. */}}
+{{- /* Generate a random password Secret when the user did not supply one. Reuse passwords
+       from the live Secret so helm upgrade never rotates a credential the running cluster
+       still authenticates with. lookup returns nothing under helm template/--dry-run, so
+       render-only pipelines (e.g. ArgoCD) should set redis.auth.existingSecret.name (and,
+       for ACL, every users[].passwordSecret.name) instead. */}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace (include "redis.fullname" .) }}
-{{- $key := .Values.redis.auth.existingSecret.key }}
-{{- $password := randAlphaNum 32 | b64enc }}
+{{- $primaryKey := .Values.redis.auth.existingSecret.key }}
+{{- $data := dict }}
+{{- /* Primary (default-user) password: reuse if present; fail if the live Secret exists but
+       lacks the key, since regenerating would rotate it and lock out the running cluster. */}}
+{{- $primaryVal := randAlphaNum 32 | b64enc }}
 {{- if $existing }}
-{{- if hasKey $existing.data $key }}
-{{- $password = index $existing.data $key }}
+{{- if hasKey $existing.data $primaryKey }}
+{{- $primaryVal = index $existing.data $primaryKey }}
 {{- else }}
-{{- fail (printf "Secret %q exists but has no key %q; regenerating would rotate the password and lock out the running cluster. Fix the Secret or set redis.auth.existingSecret.key to the existing key." (include "redis.fullname" .) $key) }}
+{{- fail (printf "Secret %q exists but has no key %q; regenerating would rotate the password and lock out the running cluster. Fix the Secret or set redis.auth.existingSecret.key to the existing key." (include "redis.fullname" .) $primaryKey) }}
+{{- end }}
+{{- end }}
+{{- $_ := set $data $primaryKey $primaryVal }}
+{{- /* ACL passwords (operator + per-user) stored in this chart-managed Secret. Newly added
+       keys generate fresh; keys already present in the live Secret are reused. These do NOT
+       fail-on-missing (unlike the primary): a missing key just means a user was added. */}}
+{{- if .Values.redis.auth.acl.enabled }}
+{{- $keys := list }}
+{{- if and (ne (include "redis.operatorUser" .) "default") (not .Values.redis.auth.acl.operatorPasswordSecret.name) }}
+{{- $keys = append $keys (include "redis.operatorSecretKey" .) }}
+{{- end }}
+{{- range $u := .Values.redis.auth.acl.users }}
+{{- if not (and $u.passwordSecret $u.passwordSecret.name) }}
+{{- $keys = append $keys (include "redis.aclUserSecretKey" (dict "ctx" $ "user" $u)) }}
+{{- end }}
+{{- end }}
+{{- range $k := $keys }}
+{{- if not (hasKey $data $k) }}
+{{- $val := randAlphaNum 32 | b64enc }}
+{{- if and $existing (hasKey $existing.data $k) }}
+{{- $val = index $existing.data $k }}
+{{- end }}
+{{- $_ := set $data $k $val }}
+{{- end }}
 {{- end }}
 {{- end }}
 apiVersion: v1
@@ -27,5 +54,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{ $key }}: {{ $password | quote }}
+{{- range $k, $v := $data }}
+  {{ $k }}: {{ $v | quote }}
+{{- end }}
 {{- end }}

--- a/redis/templates/statefulset.yaml
+++ b/redis/templates/statefulset.yaml
@@ -285,22 +285,8 @@ spec:
                   fieldPath: metadata.name
             - name: REDIS_ADDR
               value: "{{ if .Values.tls.enabled }}rediss{{ else }}redis{{ end }}://$(POD_NAME).{{ include "redis.headlessDomain" . }}:{{ $port }}"
-            {{- if .Values.redis.auth.enabled }}
-            {{- if ne (include "redis.operatorUser" .) "default" }}
-            - name: REDIS_USER
-              value: {{ .Values.redis.auth.acl.operatorUser | quote }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "redis.operatorSecretName" . }}
-                  key: {{ include "redis.operatorSecretKey" . }}
-            {{- else }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "redis.secretName" . }}
-                  key: {{ .Values.redis.auth.existingSecret.key }}
-            {{- end }}
+            {{- with (include "redis.exporterAuthEnv" . | trim) }}
+            {{- . | nindent 12 }}
             {{- end }}
             {{- if .Values.tls.enabled }}
             - name: REDIS_EXPORTER_TLS_CLIENT_KEY_FILE
@@ -425,11 +411,16 @@ spec:
             - |-
               {{- include "redis.standaloneStartScript" . | nindent 14 }}
           env:
+            {{- /* Only the requirepass path consumes REDIS_PASSWORD; when a users[] entry
+                   redefines `default`, its password comes from the ACL line (ACL_PASS_i), so
+                   the standalone start script emits no requirepass and this env is unused. */}}
+            {{- if ne (include "redis.aclDefinesDefault" .) "true" }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "redis.secretName" . }}
                   key: {{ .Values.redis.auth.existingSecret.key }}
+            {{- end }}
             {{- include "redis.aclEnv" . | nindent 12 }}
 {{- else if .Values.redis.auth.enabled }}
           command:

--- a/redis/templates/statefulset.yaml
+++ b/redis/templates/statefulset.yaml
@@ -6,6 +6,7 @@
 {{- if .Values.tls.enabled -}}
 {{- $tlsCli = "--tls --cert /etc/redis/tls/tls.crt --key /etc/redis/tls/tls.key --cacert /etc/redis/tls/ca.crt " -}}
 {{- end -}}
+{{- $cliUser := include "redis.cliUserOpt" . -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -129,6 +130,7 @@ spec:
                   name: {{ include "redis.sentinelSecretName" . }}
                   key: {{ include "redis.sentinelSecretKey" . }}
             {{- end }}
+            {{- include "redis.aclEnv" . | nindent 12 }}
           resources:
             {{- toYaml .Values.redis.bootstrap.resources | nindent 12 }}
           volumeMounts:
@@ -158,8 +160,13 @@ spec:
             - name: REDISCLI_AUTH
               valueFrom:
                 secretKeyRef:
+                {{- if and .Values.redis.auth.acl.enabled (ne (include "redis.operatorUser" .) "default") }}
+                  name: {{ include "redis.operatorSecretName" . }}
+                  key: {{ include "redis.operatorSecretKey" . }}
+                {{- else }}
                   name: {{ include "redis.secretName" . }}
                   key: {{ .Values.redis.auth.existingSecret.key }}
+                {{- end }}
             {{- end }}
           ports:
             - name: redis
@@ -170,7 +177,7 @@ spec:
               command:
                 - sh
                 - -c
-                - redis-cli {{ $tlsCli }}-p {{ $port }} ping
+                - redis-cli {{ $tlsCli }}{{ $cliUser }}-p {{ $port }} ping
             initialDelaySeconds: {{ .Values.redis.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.redis.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.redis.livenessProbe.timeoutSeconds }}
@@ -180,7 +187,7 @@ spec:
               command:
                 - sh
                 - -c
-                - redis-cli {{ $tlsCli }}-p {{ $port }} ping
+                - redis-cli {{ $tlsCli }}{{ $cliUser }}-p {{ $port }} ping
             initialDelaySeconds: {{ .Values.redis.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.redis.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.redis.readinessProbe.timeoutSeconds }}
@@ -191,7 +198,7 @@ spec:
               command:
                 - sh
                 - -c
-                - redis-cli {{ $tlsCli }}-p {{ $port }} ping
+                - redis-cli {{ $tlsCli }}{{ $cliUser }}-p {{ $port }} ping
             periodSeconds: {{ .Values.redis.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.redis.startupProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.redis.startupProbe.failureThreshold }}
@@ -202,7 +209,7 @@ spec:
                 command:
                   - sh
                   - -c
-                  - redis-cli {{ $tlsCli }}-p {{ $port }} SHUTDOWN SAVE
+                  - redis-cli {{ $tlsCli }}{{ $cliUser }}-p {{ $port }} SHUTDOWN SAVE
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}
           volumeMounts:
@@ -279,11 +286,21 @@ spec:
             - name: REDIS_ADDR
               value: "{{ if .Values.tls.enabled }}rediss{{ else }}redis{{ end }}://$(POD_NAME).{{ include "redis.headlessDomain" . }}:{{ $port }}"
             {{- if .Values.redis.auth.enabled }}
+            {{- if ne (include "redis.operatorUser" .) "default" }}
+            - name: REDIS_USER
+              value: {{ .Values.redis.auth.acl.operatorUser | quote }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "redis.operatorSecretName" . }}
+                  key: {{ include "redis.operatorSecretKey" . }}
+            {{- else }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "redis.secretName" . }}
                   key: {{ .Values.redis.auth.existingSecret.key }}
+            {{- end }}
             {{- end }}
             {{- if .Values.tls.enabled }}
             - name: REDIS_EXPORTER_TLS_CLIENT_KEY_FILE
@@ -353,6 +370,15 @@ spec:
             storage: {{ .Values.redis.persistence.size }}
   {{- end }}
 {{- else -}}
+{{- $cliUser := include "redis.cliUserOpt" . -}}
+{{- $saAuth := "" -}}
+{{- if .Values.redis.auth.enabled -}}
+{{- if and .Values.redis.auth.acl.enabled (ne (include "redis.operatorUser" .) "default") -}}
+{{- $saAuth = "-a \"$OPERATOR_PWD\" " -}}
+{{- else -}}
+{{- $saAuth = "-a \"$REDIS_PASSWORD\" " -}}
+{{- end -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -392,7 +418,20 @@ spec:
           imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.redis.containerSecurityContext | nindent 12 }}
-{{- if .Values.redis.auth.enabled }}
+{{- if .Values.redis.auth.acl.enabled }}
+          command:
+            - sh
+            - -c
+            - |-
+              {{- include "redis.standaloneStartScript" . | nindent 14 }}
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "redis.secretName" . }}
+                  key: {{ .Values.redis.auth.existingSecret.key }}
+            {{- include "redis.aclEnv" . | nindent 12 }}
+{{- else if .Values.redis.auth.enabled }}
           command:
             - sh
             - -c
@@ -417,7 +456,7 @@ spec:
               command:
                 - sh
                 - -c
-                - redis-cli {{ if .Values.redis.auth.enabled }}-a "$REDIS_PASSWORD" {{ end }}ping
+                - redis-cli {{ $cliUser }}{{ $saAuth }}ping
             initialDelaySeconds: {{ .Values.redis.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.redis.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.redis.livenessProbe.timeoutSeconds }}
@@ -427,7 +466,7 @@ spec:
               command:
                 - sh
                 - -c
-                - redis-cli {{ if .Values.redis.auth.enabled }}-a "$REDIS_PASSWORD" {{ end }}ping
+                - redis-cli {{ $cliUser }}{{ $saAuth }}ping
             initialDelaySeconds: {{ .Values.redis.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.redis.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.redis.readinessProbe.timeoutSeconds }}
@@ -438,18 +477,27 @@ spec:
                 command:
                   - sh
                   - -c
-                  - redis-cli {{ if .Values.redis.auth.enabled }}-a "$REDIS_PASSWORD" {{ end }}SHUTDOWN SAVE
+                  - redis-cli {{ $cliUser }}{{ $saAuth }}SHUTDOWN SAVE
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /etc/redis
+            {{- if .Values.redis.auth.acl.enabled }}
+            - name: config-rw
+              mountPath: /config-rw
+            {{- end }}
             - name: data
               mountPath: /data
       volumes:
         - name: config
           configMap:
             name: {{ include "redis.fullname" . }}
+        {{- if .Values.redis.auth.acl.enabled }}
+        - name: config-rw
+          emptyDir:
+            medium: Memory
+        {{- end }}
         {{- if not .Values.redis.persistence.enabled }}
         - name: data
           emptyDir: {}

--- a/redis/templates/statefulset.yaml
+++ b/redis/templates/statefulset.yaml
@@ -119,11 +119,17 @@ spec:
             - name: TLS_ENABLED
               value: {{ .Values.tls.enabled | quote }}
             {{- if .Values.redis.auth.enabled }}
+            {{- /* Only the requirepass/masterauth-as-default path consumes REDIS_PASSWORD. When a
+                   users[] entry redefines `default`, the bootstrap emits no requirepass and (a
+                   separate operatorUser being required) masterauth uses OPERATOR_PWD, so this env
+                   is unused -- mirror the standalone container's gate. */}}
+            {{- if ne (include "redis.aclDefinesDefault" .) "true" }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "redis.secretName" . }}
                   key: {{ .Values.redis.auth.existingSecret.key }}
+            {{- end }}
             - name: SENTINEL_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/redis/tests/test-acl.sh
+++ b/redis/tests/test-acl.sh
@@ -69,10 +69,23 @@ helm upgrade --install "${REL_RE}" "${CHART_DIR}" \
 # (masteruser/masterauth) and Sentinel auth (auth-user/auth-pass) work end to end.
 wait_for_pods_ready "${NS_RE}" "app.kubernetes.io/component=redis" 3 300
 
-MASTER_POD="${FULLNAME_RE}-0"
+# Sentinel can move the master role to any pod, so don't assume -0 is the master --
+# discover the pod currently reporting role:master. The redis container's REDISCLI_AUTH is
+# the operator password, so authenticate as the operator (default is locked down).
+acl_role() {
+  kubectl exec -n "${NS_RE}" "$1" -c redis -- \
+    redis-cli --user ops INFO replication 2>/dev/null | tr -d '\r' | awk -F: '/^role:/{print $2}'
+}
+MASTER_POD=""
+for i in 0 1 2; do
+  if [ "$(acl_role "${FULLNAME_RE}-${i}")" = "master" ]; then MASTER_POD="${FULLNAME_RE}-${i}"; break; fi
+done
+if [ -z "${MASTER_POD}" ]; then
+  fail "a pod reports role:master" "none of ${FULLNAME_RE}-{0,1,2} reported role:master"
+  MASTER_POD="${FULLNAME_RE}-0"
+fi
 
-# Replication is live: the master reports at least one connected replica. The redis
-# container's REDISCLI_AUTH is the operator password, so authenticate as the operator.
+# Replication is live: the master reports at least one connected replica.
 slaves=$(kubectl exec -n "${NS_RE}" "${MASTER_POD}" -c redis -- \
   redis-cli --user ops INFO replication 2>/dev/null | tr -d '\r' | awk -F: '/^connected_slaves:/{print $2}')
 if [[ "${slaves:-0}" -ge 1 ]]; then

--- a/redis/tests/test-acl.sh
+++ b/redis/tests/test-acl.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+source "${SCRIPT_DIR}/helpers.sh"
+
+# Decode a key from the chart-generated Secret (keys may contain dashes).
+get_secret() {
+  kubectl get secret -n "$1" "$2" -o jsonpath="{.data['$3']}" | base64 -d
+}
+
+#######################################################################
+# Part 1: standalone + a restricted `app` user (default operator)
+#######################################################################
+NS_SA="${NAMESPACE_SA:-redis-test-acl-sa}"
+REL_SA="${RELEASE_SA:-redis-acl-sa}"
+FULLNAME_SA=$(resolve_fullname "${REL_SA}" "${CHART_DIR}" "${SCRIPT_DIR}/values-acl.yaml")
+
+begin_suite "ACL - standalone restricted app user"
+
+kubectl create namespace "${NS_SA}" --dry-run=client -o yaml | kubectl apply -f -
+helm upgrade --install "${REL_SA}" "${CHART_DIR}" \
+  -n "${NS_SA}" -f "${SCRIPT_DIR}/values-acl.yaml" --wait --timeout 5m
+wait_for_pods_ready "${NS_SA}" "app.kubernetes.io/component=redis" 1 300
+
+POD_SA="${FULLNAME_SA}-0"
+APP_PW=$(get_secret "${NS_SA}" "${FULLNAME_SA}" "acl-app-password")
+
+# default user (full access) still works via the in-container password.
+def_ping=$(kubectl exec -n "${NS_SA}" "${POD_SA}" -c redis -- \
+  sh -c 'redis-cli -a "$REDIS_PASSWORD" PING' 2>/dev/null | tr -d '\r')
+assert_eq "default user PING returns PONG" "PONG" "${def_ping}"
+
+# app user: allowed on its own keyspace.
+app_set=$(kubectl exec -n "${NS_SA}" "${POD_SA}" -c redis -- \
+  redis-cli --user app -a "${APP_PW}" SET app:1 hello 2>/dev/null | tr -d '\r')
+assert_eq "app user can SET app:1" "OK" "${app_set}"
+
+app_get=$(kubectl exec -n "${NS_SA}" "${POD_SA}" -c redis -- \
+  redis-cli --user app -a "${APP_PW}" GET app:1 2>/dev/null | tr -d '\r')
+assert_eq "app user can GET app:1" "hello" "${app_get}"
+
+# app user: denied outside its keyspace (~app:* only).
+denied_key=$(kubectl exec -n "${NS_SA}" "${POD_SA}" -c redis -- \
+  redis-cli --user app -a "${APP_PW}" SET other:1 x 2>&1 | tr -d '\r' || true)
+assert_contains "app user denied keys outside ~app:*" "${denied_key}" "NOPERM"
+
+# app user: denied admin commands (no @admin in its rules).
+denied_cmd=$(kubectl exec -n "${NS_SA}" "${POD_SA}" -c redis -- \
+  redis-cli --user app -a "${APP_PW}" CONFIG GET maxmemory 2>&1 | tr -d '\r' || true)
+assert_contains "app user denied CONFIG (no @admin)" "${denied_cmd}" "NOPERM"
+
+end_suite
+
+#######################################################################
+# Part 2: replication, locked-down `default` + custom operator `ops`
+#######################################################################
+NS_RE="${NAMESPACE_RE:-redis-test-acl-re}"
+REL_RE="${RELEASE_RE:-redis-acl-re}"
+FULLNAME_RE=$(resolve_fullname "${REL_RE}" "${CHART_DIR}" "${SCRIPT_DIR}/values-acl-replication.yaml")
+
+begin_suite "ACL - replication locked default + operator"
+
+kubectl create namespace "${NS_RE}" --dry-run=client -o yaml | kubectl apply -f -
+helm upgrade --install "${REL_RE}" "${CHART_DIR}" \
+  -n "${NS_RE}" -f "${SCRIPT_DIR}/values-acl-replication.yaml" --wait --timeout 5m
+# All 3 pods becoming Ready already proves the operator-driven replication link
+# (masteruser/masterauth) and Sentinel auth (auth-user/auth-pass) work end to end.
+wait_for_pods_ready "${NS_RE}" "app.kubernetes.io/component=redis" 3 300
+
+MASTER_POD="${FULLNAME_RE}-0"
+
+# Replication is live: the master reports at least one connected replica. The redis
+# container's REDISCLI_AUTH is the operator password, so authenticate as the operator.
+slaves=$(kubectl exec -n "${NS_RE}" "${MASTER_POD}" -c redis -- \
+  redis-cli --user ops INFO replication 2>/dev/null | tr -d '\r' | awk -F: '/^connected_slaves:/{print $2}')
+if [[ "${slaves:-0}" -ge 1 ]]; then
+  pass "operator-driven replication has >=1 connected replica"
+else
+  fail "operator-driven replication has >=1 connected replica" "connected_slaves='${slaves}'"
+fi
+
+# default user is locked down: it cannot write (rules ~app:* +@read only).
+DEF_PW=$(get_secret "${NS_RE}" "${FULLNAME_RE}" "acl-default-password")
+def_denied=$(kubectl exec -n "${NS_RE}" "${MASTER_POD}" -c redis -- \
+  redis-cli --user default -a "${DEF_PW}" SET app:x 1 2>&1 | tr -d '\r' || true)
+assert_contains "locked default user denied writes" "${def_denied}" "NOPERM"
+
+# Exporter scrapes successfully as the operator user (redis_up 1).
+up=$(kubectl exec -n "${NS_RE}" "${MASTER_POD}" -c redis-exporter -- \
+  sh -c 'wget -qO- http://localhost:9121/metrics 2>/dev/null || curl -s http://localhost:9121/metrics' 2>/dev/null \
+  | awk '/^redis_up /{print $2}' | tr -d '\r')
+assert_eq "exporter scrapes redis as operator (redis_up=1)" "1" "${up}"
+
+end_suite
+print_summary

--- a/redis/tests/test-acl.sh
+++ b/redis/tests/test-acl.sh
@@ -70,12 +70,13 @@ helm upgrade --install "${REL_RE}" "${CHART_DIR}" \
 wait_for_pods_ready "${NS_RE}" "app.kubernetes.io/component=redis" 3 300
 
 # Sentinel can move the master role to any pod, so don't assume -0 is the master --
-# discover the pod currently reporting role:master. The redis container's REDISCLI_AUTH is
-# the operator password, so authenticate as the operator (default is locked down).
-acl_role() {
-  kubectl exec -n "${NS_RE}" "$1" -c redis -- \
-    redis-cli --user ops INFO replication 2>/dev/null | tr -d '\r' | awk -F: '/^role:/{print $2}'
-}
+# discover the pod currently reporting role:master. Authenticate as the operator (default is
+# locked down) with an explicit -a, fetched from the Secret, rather than relying on the redis
+# container's REDISCLI_AUTH env -- the test then stays correct regardless of that wiring.
+# operatorUser=ops reuses the primary key (operatorPasswordSecret is unset).
+OPS_PW=$(get_secret "${NS_RE}" "${FULLNAME_RE}" "redis-password")
+acl_ops_cli() { kubectl exec -n "${NS_RE}" "$1" -c redis -- redis-cli --user ops -a "${OPS_PW}" --no-auth-warning "${@:2}"; }
+acl_role() { acl_ops_cli "$1" INFO replication 2>/dev/null | tr -d '\r' | awk -F: '/^role:/{print $2}'; }
 MASTER_POD=""
 for i in 0 1 2; do
   if [ "$(acl_role "${FULLNAME_RE}-${i}")" = "master" ]; then MASTER_POD="${FULLNAME_RE}-${i}"; break; fi
@@ -86,8 +87,7 @@ if [ -z "${MASTER_POD}" ]; then
 fi
 
 # Replication is live: the master reports at least one connected replica.
-slaves=$(kubectl exec -n "${NS_RE}" "${MASTER_POD}" -c redis -- \
-  redis-cli --user ops INFO replication 2>/dev/null | tr -d '\r' | awk -F: '/^connected_slaves:/{print $2}')
+slaves=$(acl_ops_cli "${MASTER_POD}" INFO replication 2>/dev/null | tr -d '\r' | awk -F: '/^connected_slaves:/{print $2}')
 if [[ "${slaves:-0}" -ge 1 ]]; then
   pass "operator-driven replication has >=1 connected replica"
 else

--- a/redis/tests/test-template.sh
+++ b/redis/tests/test-template.sh
@@ -210,6 +210,13 @@ acl_fail=$(helm template r "${CHART_DIR}" --set redis.auth.acl.enabled=true \
 assert_eq "acl: locked default without operator fails" "1" "${acl_rc}"
 assert_contains "acl: locked-default guard names the cause" "${acl_fail}" "requires a separate operatorUser"
 
+# Guard: rules with shell metacharacters are rejected (rules are appended to redis.conf via a
+# shell echo, so $()/backticks/quotes would be command injection at pod startup).
+acl_inj=$(helm template r "${CHART_DIR}" -f "${SCRIPT_DIR}/values-acl.yaml" \
+  --set-string 'redis.auth.acl.users[0].rules=~app:* +@read $(touch /pwned)' 2>&1) && inj_rc=0 || inj_rc=$?
+assert_eq "acl: rules with shell metacharacters fail" "1" "${inj_rc}"
+assert_contains "acl: injection guard names the cause" "${acl_inj}" "must not contain the shell metacharacters"
+
 # Guard: operatorUser set while ACL is disabled is rejected (would feed undefined OPERATOR_ env).
 acl_op_off=$(helm template r "${CHART_DIR}" --set redis.auth.acl.operatorUser=ops 2>&1) && op_rc=0 || op_rc=$?
 assert_eq "acl: non-default operatorUser with acl disabled fails" "1" "${op_rc}"

--- a/redis/tests/test-template.sh
+++ b/redis/tests/test-template.sh
@@ -183,5 +183,30 @@ assert_contains "tls: cert volume mount" "${tls}" "/etc/redis/tls"
 tls_fail=$(helm template r "${CHART_DIR}" --set tls.enabled=true 2>&1) && tls_rc=0 || tls_rc=$?
 assert_eq "tls: enabled without secret fails" "1" "${tls_rc}"
 
+# --- ACL ---
+lint_output=$(helm lint "${CHART_DIR}" -f "${SCRIPT_DIR}/values-acl.yaml" 2>&1) && lint_rc=0 || lint_rc=$?
+assert_eq "helm lint with acl (standalone) values passes" "0" "${lint_rc}"
+lint_output=$(helm lint "${CHART_DIR}" -f "${SCRIPT_DIR}/values-acl-replication.yaml" 2>&1) && lint_rc=0 || lint_rc=$?
+assert_eq "helm lint with acl (replication) values passes" "0" "${lint_rc}"
+
+# Replication, locked-down default + custom operator: the operator identity is wired into the
+# replication link, Sentinel, and the in-pod redis-cli probes, and default becomes a user line.
+acl=$(helm template r "${CHART_DIR}" -f "${SCRIPT_DIR}/values-acl-replication.yaml" 2>&1)
+assert_contains "acl: operator user line rendered" "${acl}" "user ops on"
+assert_contains "acl: default user redefined (requirepass dropped)" "${acl}" "user default on"
+assert_contains "acl: replication uses masteruser" "${acl}" "masteruser"
+assert_contains "acl: sentinel auth-user wired" "${acl}" "sentinel auth-user"
+assert_contains "acl: probes carry --user" "${acl}" "redis-cli --user ops"
+
+# Default operator (additive user) keeps the standalone requirepass path; no operator wiring.
+acl_add=$(helm template r "${CHART_DIR}" -f "${SCRIPT_DIR}/values-acl.yaml" 2>&1)
+assert_contains "acl(additive): app user line rendered" "${acl_add}" "user app on"
+assert_not_contains "acl(additive): no masteruser in standalone" "${acl_add}" "masteruser"
+
+# Guard: locking down default without a separate operator is rejected.
+acl_fail=$(helm template r "${CHART_DIR}" --set redis.auth.acl.enabled=true \
+  --set 'redis.auth.acl.users[0].name=default' --set 'redis.auth.acl.users[0].rules=~* +@read' 2>&1) && acl_rc=0 || acl_rc=$?
+assert_eq "acl: locked default without operator fails" "1" "${acl_rc}"
+
 end_suite
 print_summary

--- a/redis/tests/test-template.sh
+++ b/redis/tests/test-template.sh
@@ -203,10 +203,24 @@ acl_add=$(helm template r "${CHART_DIR}" -f "${SCRIPT_DIR}/values-acl.yaml" 2>&1
 assert_contains "acl(additive): app user line rendered" "${acl_add}" "user app on"
 assert_not_contains "acl(additive): no masteruser in standalone" "${acl_add}" "masteruser"
 
-# Guard: locking down default without a separate operator is rejected.
+# Guard: locking down default without a separate operator is rejected. Assert the specific
+# guard message, not just a non-zero exit, so an unrelated template error can't pass this.
 acl_fail=$(helm template r "${CHART_DIR}" --set redis.auth.acl.enabled=true \
   --set 'redis.auth.acl.users[0].name=default' --set 'redis.auth.acl.users[0].rules=~* +@read' 2>&1) && acl_rc=0 || acl_rc=$?
 assert_eq "acl: locked default without operator fails" "1" "${acl_rc}"
+assert_contains "acl: locked-default guard names the cause" "${acl_fail}" "requires a separate operatorUser"
+
+# Guard: operatorUser set while ACL is disabled is rejected (would feed undefined OPERATOR_ env).
+acl_op_off=$(helm template r "${CHART_DIR}" --set redis.auth.acl.operatorUser=ops 2>&1) && op_rc=0 || op_rc=$?
+assert_eq "acl: non-default operatorUser with acl disabled fails" "1" "${op_rc}"
+assert_contains "acl: operator-without-acl guard names the cause" "${acl_op_off}" "redis.auth.acl.enabled is false"
+
+# Guard: a BYO existingSecret with ACL users lacking an explicit passwordSecret.name is rejected
+# (the chart writes no ACL passwords into a user-supplied Secret, so the keys would be missing).
+acl_byo=$(helm template r "${CHART_DIR}" -f "${SCRIPT_DIR}/values-acl.yaml" \
+  --set redis.auth.existingSecret.name=mysecret 2>&1) && byo_rc=0 || byo_rc=$?
+assert_eq "acl: existingSecret without per-user passwordSecret.name fails" "1" "${byo_rc}"
+assert_contains "acl: BYO-secret guard names the cause" "${acl_byo}" "must set passwordSecret.name"
 
 end_suite
 print_summary

--- a/redis/tests/unit/acl_test.yaml
+++ b/redis/tests/unit/acl_test.yaml
@@ -165,6 +165,11 @@ tests:
         - name: app
           rules: "~app:* +@all"
     asserts:
+      # The operator reuses the primary redis-password key by default (operatorPasswordSecret
+      # unset => operatorSecretKey falls back to existingSecret.key), so no separate
+      # acl-ops-password is generated; the primary key carries the operator password.
+      - exists:
+          path: data["redis-password"]
       - exists:
           path: data["acl-default-password"]
       - exists:
@@ -247,3 +252,46 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: 'redis.auth.acl: operatorUser "ops" must not also appear in users[]; the chart manages the operator user with full permissions (~* &* +@all)'
+
+  - it: guard - non-default operatorUser while acl disabled is rejected
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.auth.acl.enabled: false
+      redis.auth.acl.operatorUser: ops
+    asserts:
+      - failedTemplate:
+          errorMessage: "redis.auth.acl.operatorUser is non-default but redis.auth.acl.enabled is false; enable ACL or leave operatorUser as 'default'"
+
+  - it: guard - acl users while acl disabled is rejected
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.auth.acl.enabled: false
+      redis.auth.acl.users:
+        - name: app
+          rules: "~app:* +@read"
+    asserts:
+      - failedTemplate:
+          errorMessage: "redis.auth.acl.users is set but redis.auth.acl.enabled is false; set redis.auth.acl.enabled=true or remove the users"
+
+  - it: guard - existingSecret with ACL requires explicit per-user passwordSecret.name
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.auth.existingSecret.name: my-redis-secret
+      redis.auth.acl.enabled: true
+      redis.auth.acl.operatorUser: ops
+      redis.auth.acl.operatorPasswordSecret.name: my-redis-secret
+      redis.auth.acl.operatorPasswordSecret.key: ops-pw
+      redis.auth.acl.users:
+        - name: default
+          rules: "~app:* +@read"
+        - name: app
+          rules: "~app:* +@all"
+    asserts:
+      - failedTemplate:
+          errorMessage: 'redis.auth.acl: with redis.auth.existingSecret.name set, user "default" must set passwordSecret.name (the chart writes no per-user password into a user-supplied Secret)'

--- a/redis/tests/unit/acl_test.yaml
+++ b/redis/tests/unit/acl_test.yaml
@@ -1,0 +1,249 @@
+suite: acl
+templates:
+  - templates/statefulset.yaml
+  - templates/configmap.yaml
+  - templates/secret.yaml
+  - templates/exporter-deployment.yaml
+tests:
+  # ---- replication, default operator (additive app user) ----
+  - it: replication default-operator - app user line + requirepass kept, no operator wiring
+    template: templates/configmap.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.auth.acl.enabled: true
+      redis.auth.acl.users:
+        - name: app
+          rules: "~app:* &app:* +@read +@write"
+    asserts:
+      - matchRegex:
+          path: data["bootstrap.sh"]
+          pattern: 'user app on >\$\{ACL_PASS_0\} ~app:\* &app:\* \+@read \+@write'
+      - matchRegex:
+          path: data["bootstrap.sh"]
+          pattern: 'requirepass \$\{REDIS_PASSWORD\}'
+      - matchRegex:
+          path: data["bootstrap.sh"]
+          pattern: 'masterauth \$\{REDIS_PASSWORD\}'
+      - notMatchRegex:
+          path: data["bootstrap.sh"]
+          pattern: masteruser
+      - notMatchRegex:
+          path: data["bootstrap.sh"]
+          pattern: sentinel auth-user
+
+  # ---- replication, locked-down default + custom operator ----
+  - it: replication custom-operator - operator/masteruser/auth-user wired, requirepass dropped
+    template: templates/configmap.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.auth.acl.enabled: true
+      redis.auth.acl.operatorUser: ops
+      redis.auth.acl.users:
+        - name: default
+          rules: "~app:* +@read"
+        - name: app
+          rules: "~app:* +@all"
+    asserts:
+      - matchRegex:
+          path: data["bootstrap.sh"]
+          pattern: 'user ops on >\$\{OPERATOR_PWD\} ~\* &\* \+@all'
+      - matchRegex:
+          path: data["bootstrap.sh"]
+          pattern: 'user default on >\$\{ACL_PASS_0\} ~app:\* \+@read'
+      - matchRegex:
+          path: data["bootstrap.sh"]
+          pattern: 'masteruser \$\{OPERATOR_USER\}'
+      - matchRegex:
+          path: data["bootstrap.sh"]
+          pattern: 'masterauth \$\{OPERATOR_PWD\}'
+      - matchRegex:
+          path: data["bootstrap.sh"]
+          pattern: 'sentinel auth-user \$\{MASTER_NAME\} \$\{OPERATOR_USER\}'
+      - notMatchRegex:
+          path: data["bootstrap.sh"]
+          pattern: 'requirepass \$\{REDIS_PASSWORD\}'
+
+  - it: replication custom-operator - probes carry --user and envs are wired
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.auth.acl.enabled: true
+      redis.auth.acl.operatorUser: ops
+      redis.auth.acl.users:
+        - name: app
+          rules: "~app:* +@all"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
+          pattern: 'redis-cli --user ops -p 6379 ping'
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: OPERATOR_USER
+            value: "ops"
+      - contains:
+          path: spec.template.spec.containers[2].env
+          content:
+            name: REDIS_USER
+            value: "ops"
+
+  # ---- standalone parity ----
+  - it: standalone custom-operator - wrapper renders user lines + config-rw volume
+    template: templates/statefulset.yaml
+    set:
+      architecture: standalone
+      redis.auth.acl.enabled: true
+      redis.auth.acl.operatorUser: ops
+      redis.auth.acl.users:
+        - name: default
+          rules: "~app:* +@read"
+        - name: app
+          rules: "~app:* +@all"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'user ops on >\$\{OPERATOR_PWD\} ~\* &\* \+@all'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'exec redis-server /config-rw/redis.conf'
+      - matchRegex:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
+          pattern: 'redis-cli --user ops -a "\$OPERATOR_PWD" ping'
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config-rw
+            emptyDir:
+              medium: Memory
+
+  - it: standalone exporter deployment - REDIS_USER set for custom operator
+    template: templates/exporter-deployment.yaml
+    set:
+      architecture: standalone
+      exporter.enabled: true
+      redis.auth.acl.enabled: true
+      redis.auth.acl.operatorUser: ops
+      redis.auth.acl.users:
+        - name: app
+          rules: "~app:* +@all"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_USER
+            value: "ops"
+
+  # ---- secret multi-key generation ----
+  - it: secret - per-user password key generated alongside primary
+    template: templates/secret.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.auth.acl.enabled: true
+      redis.auth.acl.users:
+        - name: app
+          rules: "~app:* +@all"
+    asserts:
+      - exists:
+          path: data["redis-password"]
+      - exists:
+          path: data["acl-app-password"]
+
+  - it: secret - custom operator + locked default generate their keys
+    template: templates/secret.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.auth.acl.enabled: true
+      redis.auth.acl.operatorUser: ops
+      redis.auth.acl.users:
+        - name: default
+          rules: "~app:* +@read"
+        - name: app
+          rules: "~app:* +@all"
+    asserts:
+      - exists:
+          path: data["acl-default-password"]
+      - exists:
+          path: data["acl-app-password"]
+
+  # ---- ACL disabled: no leakage ----
+  - it: acl disabled - no ACL user lines or operator wiring
+    template: templates/configmap.yaml
+    values:
+      - ../values-replication.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["bootstrap.sh"]
+          pattern: 'user .* on >'
+      - notMatchRegex:
+          path: data["bootstrap.sh"]
+          pattern: masteruser
+
+  # ---- guards ----
+  - it: guard - acl requires auth.enabled
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.auth.enabled: false
+      redis.auth.acl.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: redis.auth.acl.enabled requires redis.auth.enabled
+
+  - it: guard - rules may not contain enablement/password tokens
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.auth.acl.enabled: true
+      redis.auth.acl.users:
+        - name: app
+          rules: "nopass +@all"
+    asserts:
+      - failedTemplate:
+          errorMessage: 'redis.auth.acl: user "app" rules must contain permission tokens only; the chart manages enablement (drop on/off/nopass/reset*)'
+
+  - it: guard - rules may not embed a password
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.auth.acl.enabled: true
+      redis.auth.acl.users:
+        - name: app
+          rules: ">hunter2 +@all"
+    asserts:
+      - failedTemplate:
+          errorMessage: 'redis.auth.acl: user "app" rules must not embed a password (>...) or hash (#...); set passwordSecret instead'
+
+  - it: guard - locking down default requires a separate operator
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.auth.acl.enabled: true
+      redis.auth.acl.users:
+        - name: default
+          rules: "~app:* +@read"
+    asserts:
+      - failedTemplate:
+          errorMessage: "redis.auth.acl: redefining the `default` user requires a separate operatorUser; the chart authenticates as operatorUser for replication, failover, the exporter, and probes, so locking down `default` while it is the operator would break them"
+
+  - it: guard - operatorUser must not also appear in users[]
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.auth.acl.enabled: true
+      redis.auth.acl.operatorUser: ops
+      redis.auth.acl.users:
+        - name: ops
+          rules: "~* +@all"
+    asserts:
+      - failedTemplate:
+          errorMessage: 'redis.auth.acl: operatorUser "ops" must not also appear in users[]; the chart manages the operator user with full permissions (~* &* +@all)'

--- a/redis/tests/unit/acl_test.yaml
+++ b/redis/tests/unit/acl_test.yaml
@@ -253,6 +253,20 @@ tests:
       - failedTemplate:
           errorMessage: 'redis.auth.acl: operatorUser "ops" must not also appear in users[]; the chart manages the operator user with full permissions (~* &* +@all)'
 
+  - it: guard - rules may not contain shell metacharacters
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      redis.auth.acl.enabled: true
+      redis.auth.acl.operatorUser: ops
+      redis.auth.acl.users:
+        - name: app
+          rules: "~app:* +@read $(touch /pwned)"
+    asserts:
+      - failedTemplate:
+          errorMessage: 'redis.auth.acl: user "app" rules must not contain the shell metacharacters " $ ` or \ (rules are appended to redis.conf via a shell echo at startup)'
+
   - it: guard - non-default operatorUser while acl disabled is rejected
     template: templates/statefulset.yaml
     values:

--- a/redis/tests/values-acl-replication.yaml
+++ b/redis/tests/values-acl-replication.yaml
@@ -1,0 +1,22 @@
+# Replication + ACL with a locked-down `default` user and a separate privileged operator.
+# Exercises masteruser/masterauth, sentinel auth-user/auth-pass, the exporter REDIS_USER,
+# and probe --user -- all of which must use the operator identity, not `default`.
+architecture: replication
+redis:
+  replicaCount: 2
+  persistence:
+    enabled: false
+  auth:
+    enabled: true
+    acl:
+      enabled: true
+      operatorUser: ops
+      users:
+        - name: default
+          rules: "~app:* +@read"
+        - name: app
+          rules: "~app:* +@read +@write"
+exporter:
+  enabled: true
+networkPolicy:
+  enabled: false

--- a/redis/tests/values-acl.yaml
+++ b/redis/tests/values-acl.yaml
@@ -1,0 +1,18 @@
+# Standalone + ACL: an additive, restricted `app` user on top of the default user.
+architecture: standalone
+redis:
+  persistence:
+    enabled: false
+  auth:
+    enabled: true
+    acl:
+      enabled: true
+      users:
+        - name: app
+          rules: "~app:* +@read +@write"
+          passwordSecret:
+            key: acl-app-password
+exporter:
+  enabled: false
+networkPolicy:
+  enabled: false

--- a/redis/values.schema.json
+++ b/redis/values.schema.json
@@ -22,6 +22,49 @@
           "type": "integer",
           "minimum": 0
         },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "acl": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "operatorUser": {
+                  "type": "string",
+                  "pattern": "^[A-Za-z0-9_.-]+$"
+                },
+                "users": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9_.-]+$"
+                      },
+                      "rules": {
+                        "type": "string"
+                      },
+                      "passwordSecret": {
+                        "type": "object",
+                        "properties": {
+                          "name": { "type": "string" },
+                          "key": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "config": {
           "type": "object",
           "properties": {

--- a/redis/values.yaml
+++ b/redis/values.yaml
@@ -69,6 +69,36 @@ redis:
       name: ""
       key: redis-password
 
+    # Redis ACL users (requires auth.enabled). Layer named users on top of the
+    # password auth above for least-privilege, per-command/per-key access. See
+    # README "ACL".
+    acl:
+      enabled: false
+      # The single privileged identity the CHART ITSELF authenticates as: probes,
+      # preStop SHUTDOWN, the exporter, the replication link (masteruser/masterauth),
+      # and Sentinel (auth-user/auth-pass). Its permissions are chart-managed and
+      # always full (~* &* +@all) -- you choose only the name and password source,
+      # never its rules, because a restricted operator silently breaks replication,
+      # failover, and the exporter. Default "default" keeps today's behavior exactly.
+      # To lock down the `default` user you MUST name a separate operator user here.
+      operatorUser: default
+      # Password source for a non-default operator user. Empty name => reuse the
+      # redis auth Secret above; empty key => reuse existingSecret.key.
+      operatorPasswordSecret:
+        name: ""
+        key: ""
+      # Additional ACL users. `rules` carries ONLY permission tokens (key/channel
+      # patterns and +/- command rules); the chart emits `on` and the password
+      # itself, so do NOT put on/off/nopass/reset*/>password/#hash in `rules`.
+      # Each user's password comes from a Secret: empty passwordSecret.name reuses
+      # the redis auth Secret and the chart generates a random value for the key.
+      users: []
+      # - name: app
+      #   rules: "~app:* &app:* +@read +@write -@dangerous"
+      #   passwordSecret:
+      #     name: ""
+      #     key: app-acl-password
+
   # Resources for the one-shot bootstrap init container (role discovery + config render).
   bootstrap:
     resources:


### PR DESCRIPTION
## Summary

Adds Redis ACL support (`redis.auth.acl`) for both `standalone` and `replication`, closing #87. Non-breaking: `acl.enabled` defaults `false`, so existing installs render byte-identically. Ships as chart **1.2.0**.

## Design

- **Operator user** (`acl.operatorUser`, default `default`) — the single privileged identity the chart authenticates as for the replication link (`masteruser`/`masterauth`), Sentinel (`auth-user`/`auth-pass`), the exporter (`REDIS_USER`), and the in-pod probes (`--user`). Its permissions are **chart-managed and always full** (`~* &* +@all`), so a restricted rule can't silently break failover, replication, or metrics scraping. To lock down `default`, define it under `users[]` and set a separate `operatorUser`.
- **`requirepass` ⇄ `user default` switch** — today's `requirepass` path is kept unless a `users[]` entry redefines `default`, in which case `requirepass` is dropped for an explicit `user default` line (the one combination Redis rejects).
- **Passwords never touch the ConfigMap** — usernames/rules render literally; passwords come from Secret-backed env (`ACL_PASS_<i>`/`OPERATOR_PWD`) appended to `redis.conf` at runtime: via the replication bootstrap init container, and via a new standalone `sh -c` wrapper backed by a `config-rw` tmpfs volume.
- **Upgrade-safe `secret.yaml`** — generates and `lookup`-persists per-user password keys; newly added keys generate fresh instead of failing on the enabling upgrade.
- **Fail-fast guards** — auth prerequisite, username charset, forbidden `rules` tokens (`on`/`off`/`nopass`/`reset*`/`>`/`#`), operator-not-in-`users[]`, and the locked-`default` interlock.

## Test plan

- `helm-unittest`: full suite **92/92**, including new `tests/unit/acl_test.yaml` (13 cases).
- `tests/test-template.sh` (no-cluster CI gate): **81/81**, with 12 new ACL render/guard assertions.
- New integration test `tests/test-acl.sh` + `values-acl{,-replication}.yaml`, wired into `make test-cluster`: standalone restricted `app` user (allowed vs `NOPERM`), and replication with locked-down `default` + custom operator asserting replication health, locked-default write denial, and exporter scrape. *(Requires a kind cluster — runs in CI; not executed locally.)*
- Verified across the full render matrix (standalone/replication × default/custom-operator) and confirmed ACL-off output is byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Released Redis Helm chart v1.2.0 with Redis ACL support, including configurable `operatorUser` and additional least-privilege ACL users.
  * Added Secret-backed operator and per-user ACL password handling, with safe credential reuse on upgrades.
  * Updated authentication wiring across standalone, replication, and exporter access.
* **Bug Fixes / Improvements**
  * Enhanced Secret generation to include all required ACL credentials and avoid unintended password rotations.
* **Tests**
  * Added ACL integration, template, and unit test coverage for standalone and replication scenarios.
* **Documentation**
  * Documented the new ACL configuration section with examples and guidance on ACL rule formatting and upgrade behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->