### PR TITLE
fix(pg,pgvector,pgpool): omit RO backend in agent mode when replicaCount=0 (1.2.4) (#207)

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,23 @@
 # pg chart changelog
 
+## 1.2.4 - 2026-06-24
+
+Chart-only fix for agent-mode pgpool instability at `postgresql.replicaCount: 0` (#207).
+No image change (`trixie-5.5.0-26`); only affects `pgpool.enabled` + `repmgr.enabled` +
+`repmgr.failoverMode: agent` deployments running primary-only.
+
+### Fixed
+
+- **Agent-mode pgpool churned `restarting myself` and dropped live primary connections
+  when `postgresql.replicaCount: 0` (#207).** The pgpool ConfigMap unconditionally
+  configured a second backend (`backend_hostname1`) pointing at the `-readonly` Service.
+  With zero standbys that Service has no endpoints, so pgpool health-checked a backend that
+  could never come up, repeatedly fired failover/failback events, and restarted itself --
+  tearing down every client connection to the healthy primary on each cycle. Clients saw
+  `EOF`/`unable to read data from DB node 0` even though node 0 was fine. The RO backend is
+  now emitted only when `replicaCount > 0`; primary-only agent mode renders as a single
+  RW backend (weighted 1) -- a valid, stable single-backend router.
+
 ## 1.2.3 - 2026-06-23
 
 Chart-only fix for a postgres-exporter TLS regression (#204). No image change

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: PostgreSQL with repmgr replication and optional PGPool-II
 type: application
-version: 1.2.3
+version: 1.2.4
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/README.md
+++ b/pg/README.md
@@ -240,7 +240,7 @@ When repmgr is enabled, two sidecars run alongside PostgreSQL in each pod:
 
 Must satisfy `leaseDuration > renewDeadline > retryPeriod`. For managed clouds, widen them (e.g. `30s/20s/4s`) so a brief apiserver blip does not trip an unnecessary demote. Note: with the Kubernetes Lease backend, a control-plane outage longer than `renewDeadline` is itself a write outage (the healthy primary self-demotes on losing apiserver contact, and no standby can acquire until the control plane returns); this is the safe choice under an asymmetric partition.
 
-In agent mode the agent also fronts the read/write split: `pgpool` (if enabled) points at the RW (`<fullname>`) and RO (`<fullname>-readonly`) Services with failover off, and the agent maintains the Service selector and `pg-role` labels itself (no repmgrd/service-updater sidecars).
+In agent mode the agent also fronts the read/write split: `pgpool` (if enabled) points at the RW (`<fullname>`) and RO (`<fullname>-readonly`) Services with failover off, and the agent maintains the Service selector and `pg-role` labels itself (no repmgrd/service-updater sidecars). With `postgresql.replicaCount: 0` (primary-only) there are no standbys, so pgpool configures only the RW backend and runs as a single-backend router — the RO backend is omitted to avoid health-checking an endpointless Service (#207).
 
 ### Migrating an existing release to agent mode
 

--- a/pg/templates/pgpool-configmap.yaml
+++ b/pg/templates/pgpool-configmap.yaml
@@ -27,15 +27,26 @@ data:
     # it recycles connections when the RW Service endpoint moves after a failover.
     backend_hostname0 = '{{ include "pg.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local'
     backend_port0 = 5432
+{{- if gt (int .Values.postgresql.replicaCount) 0 }}
     backend_weight0 = 0
+{{- else }}
+    backend_weight0 = 1
+{{- end }}
     backend_flag0 = 'ALWAYS_PRIMARY|DISALLOW_TO_FAILOVER'
     backend_application_name0 = 'primary'
+{{- if gt (int .Values.postgresql.replicaCount) 0 }}
 
+    # RO backend only when standbys exist. With replicaCount=0 the -readonly
+    # Service has zero endpoints, so a backend1 here would fail every health
+    # check and churn pgpool into repeated "restarting myself" cycles, tearing
+    # down live connections to the healthy primary. Omit it -> single-backend
+    # router to the primary, which is valid and stable for primary-only agent mode.
     backend_hostname1 = '{{ include "pg.fullname" . }}-readonly.{{ .Release.Namespace }}.svc.cluster.local'
     backend_port1 = 5432
     backend_weight1 = 1
     backend_flag1 = 'DISALLOW_TO_FAILOVER'
     backend_application_name1 = 'readonly'
+{{- end }}
 {{- else if .Values.repmgr.enabled }}
     {{- range $i := until (int (add .Values.postgresql.replicaCount 1)) }}
     backend_hostname{{ $i }} = '{{ include "pg.fullname" $ }}-{{ $i }}.{{ include "pg.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.cluster.local'

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -151,6 +151,17 @@ assert_contains "#157: pgpool reset_query_list doubles embedded single quotes" "
 stanza_quote=$(helm template test-pg "${CHART_DIR}" --set pgbackrest.enabled=true --set pgbackrest.s3.endpoint=https://s --set pgbackrest.s3.bucket=b --set pgbackrest.existingSecret.name=sec --set-string "pgbackrest.stanza=x'y" --show-only templates/postgresql-configmap.yaml 2>&1)
 assert_contains "#157: archive_command doubles single quotes in the stanza" "${stanza_quote}" "stanza=x''y archive-push"
 
+# #207: agent-mode pgpool must only configure the RO (-readonly) backend when standbys
+# exist. With replicaCount=0 the -readonly Service has zero endpoints, so a backend1
+# there fails every health check and churns pgpool into "restarting myself" cycles,
+# killing live connections to the healthy primary.
+pgpool_agent_ro=$(helm template test-pg "${CHART_DIR}" --set pgpool.enabled=true --set repmgr.enabled=true --set repmgr.failoverMode=agent --set postgresql.replicaCount=2 --show-only templates/pgpool-configmap.yaml 2>&1)
+assert_contains "#207: agent mode with standbys configures RO backend1" "${pgpool_agent_ro}" "backend_hostname1 = 'test-pg-readonly"
+assert_contains "#207: agent mode with standbys weights primary 0" "${pgpool_agent_ro}" "backend_weight0 = 0"
+pgpool_agent_primary=$(helm template test-pg "${CHART_DIR}" --set pgpool.enabled=true --set repmgr.enabled=true --set repmgr.failoverMode=agent --set postgresql.replicaCount=0 --show-only templates/pgpool-configmap.yaml 2>&1)
+assert_not_contains "#207: agent mode primary-only omits RO backend1" "${pgpool_agent_primary}" "backend_hostname1"
+assert_contains "#207: agent mode primary-only weights the sole primary 1" "${pgpool_agent_primary}" "backend_weight0 = 1"
+
 # #156: env values must be quoted (k8s EnvVar.value is a string; a numeric/bool-looking
 # value renders as a YAML scalar the API server rejects with an unmarshal error).
 numericenv=$(helm template test-pg "${CHART_DIR}" --set repmgr.database=12345 --show-only templates/statefulset.yaml 2>&1)

--- a/pg/tests/unit/pgpool_configmap_test.yaml
+++ b/pg/tests/unit/pgpool_configmap_test.yaml
@@ -1,0 +1,45 @@
+suite: pgpool ConfigMap backend topology
+release:
+  name: test-pg
+templates:
+  - templates/pgpool-configmap.yaml
+tests:
+  # --- agent mode WITH standbys: RW (weight 0) + RO (weight 1) ---
+  - it: agent mode with standbys emits both RW and RO backends
+    values:
+      - ../values-agent-pgpool.yaml
+    set:
+      postgresql.replicaCount: 2
+    asserts:
+      - matchRegex:
+          path: data["pgpool.conf"]
+          pattern: backend_hostname0 = 'test-pg\.
+      - matchRegex:
+          path: data["pgpool.conf"]
+          pattern: backend_weight0 = 0
+      - matchRegex:
+          path: data["pgpool.conf"]
+          pattern: backend_hostname1 = 'test-pg-readonly\.
+      - matchRegex:
+          path: data["pgpool.conf"]
+          pattern: backend_weight1 = 1
+
+  # --- agent mode primary-only (replicaCount=0): RW only, no RO backend (#207) ---
+  - it: agent mode primary-only omits the RO backend and weights the primary 1
+    values:
+      - ../values-agent-pgpool.yaml
+    set:
+      postgresql.replicaCount: 0
+    asserts:
+      - matchRegex:
+          path: data["pgpool.conf"]
+          pattern: backend_hostname0 = 'test-pg\.
+      - matchRegex:
+          path: data["pgpool.conf"]
+          pattern: backend_weight0 = 1
+      - notMatchRegex:
+          path: data["pgpool.conf"]
+          pattern: backend_hostname1
+      - notMatchRegex:
+          path: data["pgpool.conf"]
+          pattern: backend_hostname[0-9]+ = '[^']*-readonly

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,20 @@
 # pgvector chart changelog
 
+## 1.2.4 - 2026-06-24
+
+Chart-only fix for agent-mode pgpool instability at `postgresql.replicaCount: 0` (#207).
+No image change (`trixie-5.5.0-26`). Shares pg's pgpool template (symlinked); see the pg
+CHANGELOG for detail.
+
+### Fixed
+
+- **Agent-mode pgpool churned `restarting myself` and dropped live primary connections
+  when `postgresql.replicaCount: 0` (#207).** The pgpool ConfigMap unconditionally
+  configured a second backend at the `-readonly` Service, which has zero endpoints with no
+  standbys, so pgpool health-checked an unreachable backend and repeatedly restarted. The
+  RO backend is now emitted only when `replicaCount > 0`; primary-only agent mode renders a
+  single, stable RW backend.
+
 ## 1.2.3 - 2026-06-23
 
 Chart-only fix for a postgres-exporter TLS regression (#204). No image change

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with pgvector extension and optional PGPool-II
 type: application
-version: 1.2.3
+version: 1.2.4
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg


### PR DESCRIPTION
## Summary

Fixes #207. In **agent failover mode** (`repmgr.enabled` + `repmgr.failoverMode: agent`), the pgpool ConfigMap unconditionally configured a second backend (`backend_hostname1`) pointing at the `<fullname>-readonly` Service — even when `postgresql.replicaCount: 0`. With no standbys, that Service has zero endpoints, so pgpool health-checked a backend that could never come up, repeatedly fired failover/failback events, and `restarting myself`'d — tearing down every live client connection to the healthy primary on each cycle. Clients saw `EOF` / `unable to read data from DB node 0` although node 0 was fine.

## Fix

The RO backend is now emitted **only when `replicaCount > 0`**. Primary-only agent mode renders a single RW backend (weighted `1`, since there is no second backend to balance to) — a valid, stable single-backend router.

- `replicaCount >= 1` (agent): unchanged — RW `backend0` (weight 0) + RO `backend1` (weight 1).
- `replicaCount = 0` (agent): RW `backend0` only, weight 1; no `backend1`, no `-readonly`.
- repmgrd mode and non-repmgr paths: untouched.

## Test plan

- New `pg/tests/unit/pgpool_configmap_test.yaml` (helm-unittest): with-standbys vs primary-only backend topology.
- `#207` assertions added to `pg/tests/test-template.sh`.
- Full unit suite **30/30** (7 suites), template suite **788/788**, `helm lint` clean for the primary-only agent value set.
- Render matrix verified: agent+standbys, agent primary-only, agent default (replicaCount=1), repmgrd primary-only.

Chart-only fix, no image change. Bumps `pg` `1.2.3 → 1.2.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pgpool agent-mode instability when `postgresql.replicaCount: 0` by omitting the read-only backend when no standbys exist.
  * Prevents health-check failover/failback loops that could interrupt primary connections.
* **Documentation**
  * Clarified agent-mode behavior for primary-only deployments in the README.
* **New Features**
  * Conditionally renders routing: single RW backend for primary-only, RW+RO when replicas are present.
* **Tests**
  * Added template/unit coverage for both `replicaCount=2` and `replicaCount=0` rendered configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->