### PR TITLE
feat(redis): exporter configuration options (1.3.0) (#88)

### DIFF
--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.3.0 - 2026-06-24
+
+Exporter configuration options (non-breaking; all new values default to the exporter's
+own defaults, so existing installs are unchanged).
+
+### Added
+- `exporter.connectionTimeout` — Go-duration connection timeout passed as
+  `REDIS_EXPORTER_CONNECTION_TIMEOUT` (#88).
+- `exporter.logFormat` — `txt` (default logfmt) or `json`; passed as
+  `REDIS_EXPORTER_LOG_FORMAT` (#88).
+- Metric group toggles: `includeConfigMetrics`, `inclSystemMetrics`, `exportClientList`,
+  `disableExporterMetrics` — map directly to the matching `REDIS_EXPORTER_*` boolean env
+  vars; all default `false` (#88).
+- `exporter.extraEnvVars` — arbitrary additional env vars for the exporter container
+  (escape hatch for less-common flags, e.g. `REDIS_EXPORTER_SCRIPT`); supports both
+  `value` and `valueFrom` forms (#88).
+- All new options apply to both the replication per-pod sidecar and the standalone
+  exporter Deployment via the shared `redis.exporterConfigEnv` helper (#88).
+
 ## 1.2.0
 
 ACL support (non-breaking; `redis.auth.acl.enabled` defaults `false`, so existing installs

--- a/redis/Chart.yaml
+++ b/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: Redis with AOF persistence and Sentinel-based HA replication
 type: application
-version: 1.2.0
+version: 1.3.0
 appVersion: "8"
 home: https://github.com/cagriekin/charts/tree/master/redis
 icon: https://www.vectorlogo.zone/logos/redis/redis-icon.svg

--- a/redis/README.md
+++ b/redis/README.md
@@ -222,6 +222,14 @@ window.
 | `redis.config.appendfsync` | AOF sync (`always`/`everysec`/`no`) | `everysec` |
 | `exporter.enabled` | Prometheus exporter (sidecar in replication) | `true` |
 | `exporter.serviceMonitor.enabled` / `exporter.prometheusRule.enabled` | ServiceMonitor / alerts | `true` / `false` |
+| `exporter.serviceMonitor.interval` / `scrapeTimeout` | Prometheus scrape interval / timeout | `30s` / `10s` |
+| `exporter.connectionTimeout` | Go-duration connect timeout to Redis (empty = exporter default 15s) | `""` |
+| `exporter.logFormat` | Exporter log format: `txt` (logfmt) or `json` | `txt` |
+| `exporter.includeConfigMetrics` | Include `CONFIG GET` key metrics | `false` |
+| `exporter.inclSystemMetrics` | Include system-level metrics from INFO (process cpu/mem) | `false` |
+| `exporter.exportClientList` | Export per-client metrics via `CLIENT LIST` (expensive) | `false` |
+| `exporter.disableExporterMetrics` | Disable go-runtime metrics from the exporter itself | `false` |
+| `exporter.extraEnvVars` | Additional env vars for the exporter container (supports `value` and `valueFrom`) | `[]` |
 
 ## Monitoring
 
@@ -230,6 +238,22 @@ role and replication metrics are scraped. Enabling `exporter.prometheusRule.enab
 HA alerts: `RedisDown`/`RedisNoMaster`, `RedisMultipleMasters` (split-brain),
 `RedisReplicaDown`, `RedisReplicationLinkDown`, and `RedisWritesBlocked` (the
 `min-replicas-to-write` tripwire). Standalone keeps the original single-instance alerts.
+
+### Exporter tuning
+
+All new options apply to both architectures (replication sidecar and standalone Deployment):
+
+- **`connectionTimeout`** — if your Redis is slow to respond during startup or network
+  hiccups cause false scrape timeouts, raise this (e.g. `"30s"`).
+- **`includeConfigMetrics`** — adds a small set of metrics from `CONFIG GET` (useful for
+  auditing live config without `redis-cli`).
+- **`inclSystemMetrics`** — adds `redis_used_cpu_sys`/`redis_used_cpu_user` from `INFO`.
+- **`exportClientList`** — exports per-client connection metrics via `CLIENT LIST`; avoid on
+  instances with many connected clients (O(n) overhead per scrape).
+- **`disableExporterMetrics`** — suppresses go-runtime and process metrics emitted by the
+  exporter process itself; useful when you want only Redis metrics in the scraped output.
+- **`extraEnvVars`** — pass any other `REDIS_EXPORTER_*` flag (e.g. a Lua script path via
+  `REDIS_EXPORTER_SCRIPT`, or `REDIS_EXPORTER_MAX_DISTINCT_KEY_GROUPS`).
 
 ## Persistence
 

--- a/redis/README.md
+++ b/redis/README.md
@@ -226,7 +226,7 @@ window.
 | `exporter.connectionTimeout` | Go-duration connect timeout to Redis (empty = exporter default 15s) | `""` |
 | `exporter.logFormat` | Exporter log format: `txt` (logfmt) or `json` | `txt` |
 | `exporter.includeConfigMetrics` | Include `CONFIG GET` key metrics | `false` |
-| `exporter.inclSystemMetrics` | Include system-level metrics from INFO (process cpu/mem) | `false` |
+| `exporter.includeSystemMetrics` | Include system-level metrics from INFO (process cpu/mem) | `false` |
 | `exporter.exportClientList` | Export per-client metrics via `CLIENT LIST` (expensive) | `false` |
 | `exporter.disableExporterMetrics` | Disable go-runtime metrics from the exporter itself | `false` |
 | `exporter.extraEnvVars` | Additional env vars for the exporter container (supports `value` and `valueFrom`) | `[]` |
@@ -247,7 +247,7 @@ All new options apply to both architectures (replication sidecar and standalone 
   hiccups cause false scrape timeouts, raise this (e.g. `"30s"`).
 - **`includeConfigMetrics`** — adds a small set of metrics from `CONFIG GET` (useful for
   auditing live config without `redis-cli`).
-- **`inclSystemMetrics`** — adds `redis_used_cpu_sys`/`redis_used_cpu_user` from `INFO`.
+- **`includeSystemMetrics`** — adds `redis_used_cpu_sys`/`redis_used_cpu_user` from `INFO`.
 - **`exportClientList`** — exports per-client connection metrics via `CLIENT LIST`; avoid on
   instances with many connected clients (O(n) overhead per scrape).
 - **`disableExporterMetrics`** — suppresses go-runtime and process metrics emitted by the

--- a/redis/templates/_helpers.tpl
+++ b/redis/templates/_helpers.tpl
@@ -496,10 +496,10 @@ cp /config-ro/sentinel.conf /config-rw/sentinel.conf
 {{- end }}
 
 {{- /* Non-auth exporter configuration env vars: connection timeout, log format, metric
-       group toggles, and the user-supplied extraEnvVars escape hatch. Emits list items at
-       zero indent; the caller trims and nindents. Shared by the standalone exporter
-       Deployment (redis.exporterPodSpec) and the replication exporter sidecar
-       (statefulset.yaml) so both topologies always have the same config knobs. */ -}}
+       group toggles, TLS client certs, and the user-supplied extraEnvVars escape hatch.
+       Emits list items at zero indent; the caller trims and nindents. Shared by the
+       standalone exporter Deployment (redis.exporterPodSpec) and the replication exporter
+       sidecar (statefulset.yaml) so both topologies always have the same config knobs. */ -}}
 {{- define "redis.exporterConfigEnv" -}}
 {{- if .Values.exporter.connectionTimeout }}
 - name: REDIS_EXPORTER_CONNECTION_TIMEOUT
@@ -513,7 +513,7 @@ cp /config-ro/sentinel.conf /config-rw/sentinel.conf
 - name: REDIS_EXPORTER_INCLUDE_CONFIG_METRICS
   value: "true"
 {{- end }}
-{{- if .Values.exporter.inclSystemMetrics }}
+{{- if .Values.exporter.includeSystemMetrics }}
 - name: REDIS_EXPORTER_INCL_SYSTEM_METRICS
   value: "true"
 {{- end }}
@@ -524,6 +524,14 @@ cp /config-ro/sentinel.conf /config-rw/sentinel.conf
 {{- if .Values.exporter.disableExporterMetrics }}
 - name: REDIS_EXPORTER_DISABLE_EXPORTER_METRICS
   value: "true"
+{{- end }}
+{{- if .Values.tls.enabled }}
+- name: REDIS_EXPORTER_TLS_CLIENT_KEY_FILE
+  value: /etc/redis/tls/tls.key
+- name: REDIS_EXPORTER_TLS_CLIENT_CERT_FILE
+  value: /etc/redis/tls/tls.crt
+- name: REDIS_EXPORTER_TLS_CA_CERT_FILE
+  value: /etc/redis/tls/ca.crt
 {{- end }}
 {{- with .Values.exporter.extraEnvVars }}
 {{ toYaml . | trim }}
@@ -549,14 +557,6 @@ containers:
       {{- with (include "redis.exporterAuthEnv" . | trim) }}
       {{- . | nindent 6 }}
       {{- end }}
-{{- if .Values.tls.enabled }}
-      - name: REDIS_EXPORTER_TLS_CLIENT_KEY_FILE
-        value: /etc/redis/tls/tls.key
-      - name: REDIS_EXPORTER_TLS_CLIENT_CERT_FILE
-        value: /etc/redis/tls/tls.crt
-      - name: REDIS_EXPORTER_TLS_CA_CERT_FILE
-        value: /etc/redis/tls/ca.crt
-{{- end }}
       {{- with (include "redis.exporterConfigEnv" . | trim) }}
       {{- . | nindent 6 }}
       {{- end }}

--- a/redis/templates/_helpers.tpl
+++ b/redis/templates/_helpers.tpl
@@ -495,6 +495,41 @@ cp /config-ro/sentinel.conf /config-rw/sentinel.conf
 {{- end }}
 {{- end }}
 
+{{- /* Non-auth exporter configuration env vars: connection timeout, log format, metric
+       group toggles, and the user-supplied extraEnvVars escape hatch. Emits list items at
+       zero indent; the caller trims and nindents. Shared by the standalone exporter
+       Deployment (redis.exporterPodSpec) and the replication exporter sidecar
+       (statefulset.yaml) so both topologies always have the same config knobs. */ -}}
+{{- define "redis.exporterConfigEnv" -}}
+{{- if .Values.exporter.connectionTimeout }}
+- name: REDIS_EXPORTER_CONNECTION_TIMEOUT
+  value: {{ .Values.exporter.connectionTimeout | quote }}
+{{- end }}
+{{- if and .Values.exporter.logFormat (ne .Values.exporter.logFormat "txt") }}
+- name: REDIS_EXPORTER_LOG_FORMAT
+  value: {{ .Values.exporter.logFormat | quote }}
+{{- end }}
+{{- if .Values.exporter.includeConfigMetrics }}
+- name: REDIS_EXPORTER_INCLUDE_CONFIG_METRICS
+  value: "true"
+{{- end }}
+{{- if .Values.exporter.inclSystemMetrics }}
+- name: REDIS_EXPORTER_INCL_SYSTEM_METRICS
+  value: "true"
+{{- end }}
+{{- if .Values.exporter.exportClientList }}
+- name: REDIS_EXPORTER_EXPORT_CLIENT_LIST
+  value: "true"
+{{- end }}
+{{- if .Values.exporter.disableExporterMetrics }}
+- name: REDIS_EXPORTER_DISABLE_EXPORTER_METRICS
+  value: "true"
+{{- end }}
+{{- with .Values.exporter.extraEnvVars }}
+{{ toYaml . | trim }}
+{{- end }}
+{{- end }}
+
 {{- define "redis.exporterPodSpec" -}}
 securityContext:
   {{- toYaml .Values.exporter.podSecurityContext | nindent 2 }}
@@ -522,6 +557,9 @@ containers:
       - name: REDIS_EXPORTER_TLS_CA_CERT_FILE
         value: /etc/redis/tls/ca.crt
 {{- end }}
+      {{- with (include "redis.exporterConfigEnv" . | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
     ports:
       - name: metrics
         containerPort: 9121

--- a/redis/templates/statefulset.yaml
+++ b/redis/templates/statefulset.yaml
@@ -294,14 +294,6 @@ spec:
             {{- with (include "redis.exporterAuthEnv" . | trim) }}
             {{- . | nindent 12 }}
             {{- end }}
-            {{- if .Values.tls.enabled }}
-            - name: REDIS_EXPORTER_TLS_CLIENT_KEY_FILE
-              value: /etc/redis/tls/tls.key
-            - name: REDIS_EXPORTER_TLS_CLIENT_CERT_FILE
-              value: /etc/redis/tls/tls.crt
-            - name: REDIS_EXPORTER_TLS_CA_CERT_FILE
-              value: /etc/redis/tls/ca.crt
-            {{- end }}
             {{- with (include "redis.exporterConfigEnv" . | trim) }}
             {{- . | nindent 12 }}
             {{- end }}

--- a/redis/templates/statefulset.yaml
+++ b/redis/templates/statefulset.yaml
@@ -302,6 +302,9 @@ spec:
             - name: REDIS_EXPORTER_TLS_CA_CERT_FILE
               value: /etc/redis/tls/ca.crt
             {{- end }}
+            {{- with (include "redis.exporterConfigEnv" . | trim) }}
+            {{- . | nindent 12 }}
+            {{- end }}
           ports:
             - name: metrics
               containerPort: 9121

--- a/redis/tests/unit/exporter_test.yaml
+++ b/redis/tests/unit/exporter_test.yaml
@@ -89,6 +89,42 @@ tests:
             name: REDIS_EXPORTER_INCLUDE_CONFIG_METRICS
             value: "true"
 
+  - it: includeSystemMetrics true sets env
+    values:
+      - ../values-full-test.yaml
+    set:
+      exporter.includeSystemMetrics: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_EXPORTER_INCL_SYSTEM_METRICS
+            value: "true"
+
+  - it: exportClientList true sets env
+    values:
+      - ../values-full-test.yaml
+    set:
+      exporter.exportClientList: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_EXPORTER_EXPORT_CLIENT_LIST
+            value: "true"
+
+  - it: disableExporterMetrics true sets env
+    values:
+      - ../values-full-test.yaml
+    set:
+      exporter.disableExporterMetrics: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_EXPORTER_DISABLE_EXPORTER_METRICS
+            value: "true"
+
   - it: all metric toggles false emits none of them
     values:
       - ../values-full-test.yaml
@@ -114,7 +150,7 @@ tests:
             name: REDIS_EXPORTER_DISABLE_EXPORTER_METRICS
             value: "true"
 
-  - it: extraEnvVars are passed through to the exporter container
+  - it: extraEnvVars value form is passed through to the exporter container
     values:
       - ../values-exporter-extras.yaml
     asserts:
@@ -123,3 +159,16 @@ tests:
           content:
             name: REDIS_EXPORTER_SCRIPT
             value: /scripts/custom.lua
+
+  - it: extraEnvVars valueFrom form is passed through to the exporter container
+    values:
+      - ../values-exporter-extras.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_EXPORTER_SECRET_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-extra-secret
+                key: token

--- a/redis/tests/unit/exporter_test.yaml
+++ b/redis/tests/unit/exporter_test.yaml
@@ -42,3 +42,84 @@ tests:
               secretKeyRef:
                 name: my-secret
                 key: redis-password
+
+  - it: connectionTimeout sets REDIS_EXPORTER_CONNECTION_TIMEOUT env
+    values:
+      - ../values-full-test.yaml
+    set:
+      exporter.connectionTimeout: "30s"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_EXPORTER_CONNECTION_TIMEOUT
+            value: "30s"
+
+  - it: logFormat json sets REDIS_EXPORTER_LOG_FORMAT env
+    values:
+      - ../values-full-test.yaml
+    set:
+      exporter.logFormat: "json"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_EXPORTER_LOG_FORMAT
+            value: "json"
+
+  - it: default logFormat txt emits no REDIS_EXPORTER_LOG_FORMAT env
+    values:
+      - ../values-full-test.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_EXPORTER_LOG_FORMAT
+            value: "txt"
+
+  - it: includeConfigMetrics true sets env
+    values:
+      - ../values-full-test.yaml
+    set:
+      exporter.includeConfigMetrics: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_EXPORTER_INCLUDE_CONFIG_METRICS
+            value: "true"
+
+  - it: all metric toggles false emits none of them
+    values:
+      - ../values-full-test.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_EXPORTER_INCLUDE_CONFIG_METRICS
+            value: "true"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_EXPORTER_INCL_SYSTEM_METRICS
+            value: "true"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_EXPORTER_EXPORT_CLIENT_LIST
+            value: "true"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_EXPORTER_DISABLE_EXPORTER_METRICS
+            value: "true"
+
+  - it: extraEnvVars are passed through to the exporter container
+    values:
+      - ../values-exporter-extras.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_EXPORTER_SCRIPT
+            value: /scripts/custom.lua

--- a/redis/tests/unit/statefulset_test.yaml
+++ b/redis/tests/unit/statefulset_test.yaml
@@ -295,3 +295,54 @@ tests:
           content:
             name: REDIS_EXPORTER_LOG_FORMAT
             value: "txt"
+
+  - it: replication - logFormat json sets env in sidecar
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      exporter.logFormat: "json"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="redis-exporter")].env
+          content:
+            name: REDIS_EXPORTER_LOG_FORMAT
+            value: "json"
+
+  - it: replication - includeSystemMetrics true sets env in sidecar
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      exporter.includeSystemMetrics: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="redis-exporter")].env
+          content:
+            name: REDIS_EXPORTER_INCL_SYSTEM_METRICS
+            value: "true"
+
+  - it: replication - exportClientList true sets env in sidecar
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      exporter.exportClientList: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="redis-exporter")].env
+          content:
+            name: REDIS_EXPORTER_EXPORT_CLIENT_LIST
+            value: "true"
+
+  - it: replication - extraEnvVars are injected into sidecar
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+      - ../values-exporter-extras-replication.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="redis-exporter")].env
+          content:
+            name: REDIS_EXPORTER_SCRIPT
+            value: /scripts/custom.lua

--- a/redis/tests/unit/statefulset_test.yaml
+++ b/redis/tests/unit/statefulset_test.yaml
@@ -265,3 +265,33 @@ tests:
           content:
             name: data
             mountPath: /data
+
+  # --- exporter config env in replication sidecar (#88) ---
+  - it: replication - connectionTimeout sets REDIS_EXPORTER_CONNECTION_TIMEOUT in sidecar
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    set:
+      exporter.connectionTimeout: "30s"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="redis-exporter")].env
+          content:
+            name: REDIS_EXPORTER_CONNECTION_TIMEOUT
+            value: "30s"
+
+  - it: replication - default values emit no optional REDIS_EXPORTER_ vars in sidecar
+    template: templates/statefulset.yaml
+    values:
+      - ../values-replication.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="redis-exporter")].env
+          content:
+            name: REDIS_EXPORTER_CONNECTION_TIMEOUT
+            value: ""
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="redis-exporter")].env
+          content:
+            name: REDIS_EXPORTER_LOG_FORMAT
+            value: "txt"

--- a/redis/tests/values-exporter-extras-replication.yaml
+++ b/redis/tests/values-exporter-extras-replication.yaml
@@ -1,0 +1,4 @@
+exporter:
+  extraEnvVars:
+    - name: REDIS_EXPORTER_SCRIPT
+      value: /scripts/custom.lua

--- a/redis/tests/values-exporter-extras.yaml
+++ b/redis/tests/values-exporter-extras.yaml
@@ -7,9 +7,14 @@ exporter:
   connectionTimeout: "30s"
   logFormat: "json"
   includeConfigMetrics: true
-  inclSystemMetrics: true
+  includeSystemMetrics: true
   exportClientList: true
   disableExporterMetrics: true
   extraEnvVars:
     - name: REDIS_EXPORTER_SCRIPT
       value: /scripts/custom.lua
+    - name: REDIS_EXPORTER_SECRET_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: my-extra-secret
+          key: token

--- a/redis/tests/values-exporter-extras.yaml
+++ b/redis/tests/values-exporter-extras.yaml
@@ -1,0 +1,15 @@
+architecture: standalone
+redis:
+  auth:
+    enabled: false
+exporter:
+  enabled: true
+  connectionTimeout: "30s"
+  logFormat: "json"
+  includeConfigMetrics: true
+  inclSystemMetrics: true
+  exportClientList: true
+  disableExporterMetrics: true
+  extraEnvVars:
+    - name: REDIS_EXPORTER_SCRIPT
+      value: /scripts/custom.lua

--- a/redis/values.schema.json
+++ b/redis/values.schema.json
@@ -148,7 +148,14 @@
               "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
             }
           }
-        }
+        },
+        "logFormat": {
+          "enum": ["txt", "json"]
+        },
+        "includeConfigMetrics": { "type": "boolean" },
+        "inclSystemMetrics":    { "type": "boolean" },
+        "exportClientList":     { "type": "boolean" },
+        "disableExporterMetrics": { "type": "boolean" }
       }
     },
     "service": {

--- a/redis/values.schema.json
+++ b/redis/values.schema.json
@@ -149,13 +149,15 @@
             }
           }
         },
+        "connectionTimeout": { "type": "string" },
         "logFormat": {
-          "enum": ["txt", "json"]
+          "enum": ["", "txt", "json"]
         },
-        "includeConfigMetrics": { "type": "boolean" },
-        "inclSystemMetrics":    { "type": "boolean" },
-        "exportClientList":     { "type": "boolean" },
-        "disableExporterMetrics": { "type": "boolean" }
+        "includeConfigMetrics":   { "type": "boolean" },
+        "includeSystemMetrics":   { "type": "boolean" },
+        "exportClientList":       { "type": "boolean" },
+        "disableExporterMetrics": { "type": "boolean" },
+        "extraEnvVars": { "type": "array" }
       }
     },
     "service": {

--- a/redis/values.yaml
+++ b/redis/values.yaml
@@ -267,6 +267,26 @@ exporter:
     additionalLabels: {}
     rules: []
 
+  # Connection timeout for the exporter when connecting to Redis.
+  # Uses Go duration syntax (e.g. "5s", "15s"). Empty leaves the exporter default (15s).
+  connectionTimeout: ""
+  # Log format emitted by the exporter: txt (logfmt, default) or json.
+  logFormat: "txt"
+  # Metric group toggles (all off by default; enabling adds scrape overhead / cardinality).
+  # Include metrics derived from CONFIG GET.
+  includeConfigMetrics: false
+  # Include system-level metrics from INFO (cpu/mem used by the redis process).
+  inclSystemMetrics: false
+  # Export per-client metrics via CLIENT LIST (expensive on large connection counts).
+  exportClientList: false
+  # Disable go-runtime metrics emitted by the exporter process itself.
+  disableExporterMetrics: false
+  # Additional env vars for the exporter container (escape hatch for less-common flags).
+  # Supports both value and valueFrom forms.
+  extraEnvVars: []
+  # - name: REDIS_EXPORTER_SCRIPT
+  #   value: /scripts/custom.lua
+
 service:
   type: ClusterIP
   port: 6379

--- a/redis/values.yaml
+++ b/redis/values.yaml
@@ -276,7 +276,7 @@ exporter:
   # Include metrics derived from CONFIG GET.
   includeConfigMetrics: false
   # Include system-level metrics from INFO (cpu/mem used by the redis process).
-  inclSystemMetrics: false
+  includeSystemMetrics: false
   # Export per-client metrics via CLIENT LIST (expensive on large connection counts).
   exportClientList: false
   # Disable go-runtime metrics emitted by the exporter process itself.


### PR DESCRIPTION
## Summary

- Expose `exporter.connectionTimeout`, `exporter.logFormat`, four metric group toggles (`includeConfigMetrics`, `inclSystemMetrics`, `exportClientList`, `disableExporterMetrics`), and `exporter.extraEnvVars` for the `redis_exporter` container
- All new values default to the exporter's own defaults — existing installs render byte-identically
- Shared `redis.exporterConfigEnv` helper applies to both the replication per-pod sidecar and the standalone exporter Deployment so neither topology can diverge
- `logFormat` constrained to `[txt, json]` in `values.schema.json`

## Test plan

- [ ] `helm unittest redis -f "tests/unit/*.yaml"` — 104/104
- [ ] `helm lint redis` — clean
- [ ] `helm template` with all toggles enabled — verify all 6 `REDIS_EXPORTER_*` vars appear in both architectures
- [ ] `helm template` with defaults — verify no optional vars emitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Redis exporter configuration options for connection timeout, log format, metric-group selection, per-client export, exporter self-metrics control, and extra environment variables.
  * Options apply consistently to both the standalone exporter and replication sidecars.
* **Documentation**
  * Updated the chart README with a new “Exporter tuning” section and expanded exporter parameter tables.
* **Bug Fixes**
  * Kept all new optional exporter settings unset by default to preserve existing output.
* **Tests**
  * Expanded unit tests to validate exporter env-var wiring and extra env-var passthrough.
* **Chores**
  * Bumped chart version to **1.3.0** and updated the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->