### PR TITLE
fix(redis): hardening fixes — operatorUser validation + standalone startup probe

### DIFF
--- a/redis/templates/_helpers.tpl
+++ b/redis/templates/_helpers.tpl
@@ -295,6 +295,9 @@ exec redis-server /config-rw/redis.conf
 {{- fail "redis.auth.acl.enabled requires redis.auth.enabled" }}
 {{- end }}
 {{- $op := include "redis.operatorUser" . }}
+{{- if and (ne $op "default") (not (regexMatch "^[A-Za-z0-9_.-]+$" $op)) }}
+{{- fail (printf "redis.auth.acl.operatorUser %q must match ^[A-Za-z0-9_.-]+$ (no spaces or shell-significant characters)" $op) }}
+{{- end }}
 {{- $names := list }}
 {{- range .Values.redis.auth.acl.users }}
 {{- if not (regexMatch "^[A-Za-z0-9_.-]+$" .name) }}

--- a/redis/templates/statefulset.yaml
+++ b/redis/templates/statefulset.yaml
@@ -463,6 +463,17 @@ spec:
             periodSeconds: {{ .Values.redis.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.redis.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.redis.readinessProbe.failureThreshold }}
+          {{- if .Values.redis.startupProbe.enabled }}
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli {{ $cliUser }}{{ $saAuth }}ping
+            periodSeconds: {{ .Values.redis.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.redis.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.redis.startupProbe.failureThreshold }}
+          {{- end }}
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
- **standalone mode**: add missing `startupProbe` block, honoring `redis.startupProbe.enabled` (previously only rendered in replication mode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional startup health check for Redis in standalone mode, using the configured startup probe settings.
* **Bug Fixes**
  * Improved validation for ACL operator usernames when ACL is enabled, rejecting invalid characters and clearer malformed values.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->