### PR TITLE
fix(pg): repmgr/pgBackRest correctness fixes (1.2.5) (#211, #212, #213, #214)

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -20,7 +20,10 @@ Chart-only correctness fixes for four edge cases in the repmgr/pgBackRest paths
   than one Ready endpoint, and with `backoffLimit: 0` a backup that landed on a read-only
   pod was silently dropped for that schedule. The cronjob now validates every Ready
   candidate with `pg_is_in_recovery()` and runs the backup only against the confirmed
-  read-write primary, failing loudly if none qualifies.
+  read-write primary, failing loudly if none qualifies. The probe is `timeout`-bounded
+  (a wedged mid-shutdown candidate can't hang the run) and retried once (a transient blip
+  on the real primary doesn't skip a backup); the EndpointSlice lookup degrades to the
+  actionable "no ready endpoint" error instead of a bare `set -e` abort.
 - **Inconsistent `required` guard on the pgBackRest S3 secret name (#213).**
   `PGBACKREST_REPO1_S3_KEY_SECRET` (init env) and both keys in the pgbackrest sidecar
   referenced `pgbackrest.existingSecret.name` without the `required` wrapper that
@@ -30,7 +33,8 @@ Chart-only correctness fixes for four edge cases in the repmgr/pgBackRest paths
   empty `persistence.emptyDir.sizeLimit`, the `data` volume rendered as `emptyDir: {}`, an
   unbounded ephemeral volume a runaway DB/WAL could use to fill the node and evict
   co-tenants. The volume is now always bounded: `emptyDir.sizeLimit` falls back to
-  `persistence.size` (the cap already declared for persistent mode) when unset.
+  `persistence.size` (the cap already declared for persistent mode) when unset, then to a
+  10Gi floor if `persistence.size` is also blank, so the cap is never null.
 
 ## 1.2.4 - 2026-06-24
 

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,37 @@
 # pg chart changelog
 
+## 1.2.5 - 2026-06-25
+
+Chart-only correctness fixes for four edge cases in the repmgr/pgBackRest paths (#211,
+#212, #213, #214). No image change (`trixie-5.5.0-26`).
+
+### Fixed
+
+- **`fix_user_auth` md5→scram migration silently no-op'd for users whose password contains
+  a single quote (#211).** The init script passed the password via `psql -v p=...`; a `'`
+  in the value broke psql's `:'p'` literal quoting, so the rehash failed and the migration
+  never converged (the md5 pg_hba fallback masked it, so connectivity was kept). The
+  password is now read from the environment with `\getenv` — the same injection-safe
+  pattern the monitoring-user job already uses — so any password value is handled. Only
+  affected `existingSecret` passwords; the chart's `randAlphaNum` generator never emits `'`.
+- **pgBackRest cronjob could run the backup against a standby and silently skip it (#212).**
+  Primary discovery took the first Ready endpoint from the write Service's EndpointSlices;
+  during a failover + scale-down collision, stale EndpointSlices can briefly expose more
+  than one Ready endpoint, and with `backoffLimit: 0` a backup that landed on a read-only
+  pod was silently dropped for that schedule. The cronjob now validates every Ready
+  candidate with `pg_is_in_recovery()` and runs the backup only against the confirmed
+  read-write primary, failing loudly if none qualifies.
+- **Inconsistent `required` guard on the pgBackRest S3 secret name (#213).**
+  `PGBACKREST_REPO1_S3_KEY_SECRET` (init env) and both keys in the pgbackrest sidecar
+  referenced `pgbackrest.existingSecret.name` without the `required` wrapper that
+  `PGBACKREST_REPO1_S3_KEY` already had. Functionally safe (the first `required` failed
+  render first), but `required` is now applied consistently to every reference.
+- **Unbounded ephemeral PGDATA when `persistence.enabled=false` (#214).** With the default
+  empty `persistence.emptyDir.sizeLimit`, the `data` volume rendered as `emptyDir: {}`, an
+  unbounded ephemeral volume a runaway DB/WAL could use to fill the node and evict
+  co-tenants. The volume is now always bounded: `emptyDir.sizeLimit` falls back to
+  `persistence.size` (the cap already declared for persistent mode) when unset.
+
 ## 1.2.4 - 2026-06-24
 
 Chart-only fix for agent-mode pgpool instability at `postgresql.replicaCount: 0` (#207).

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -20,10 +20,14 @@ Chart-only correctness fixes for four edge cases in the repmgr/pgBackRest paths
   than one Ready endpoint, and with `backoffLimit: 0` a backup that landed on a read-only
   pod was silently dropped for that schedule. The cronjob now validates every Ready
   candidate with `pg_is_in_recovery()` and runs the backup only against the confirmed
-  read-write primary, failing loudly if none qualifies. The probe is `timeout`-bounded
-  (a wedged mid-shutdown candidate can't hang the run) and retried once (a transient blip
-  on the real primary doesn't skip a backup); the EndpointSlice lookup degrades to the
-  actionable "no ready endpoint" error instead of a bare `set -e` abort.
+  read-write primary. The probe is `timeout`-bounded (a wedged mid-shutdown candidate
+  can't hang the run) and retried once; candidates are validated in a deterministic
+  (sorted) order; and the EndpointSlice lookup degrades to the actionable "no ready
+  endpoint" error instead of a bare `set -e` abort. To avoid regressing the common
+  single-node case, when exactly one Ready endpoint exists and its recovery state is
+  merely unreadable (not a confirmed standby), the backup proceeds against it — matching
+  the prior behavior — rather than being skipped on a transient probe failure; a
+  confirmed standby is still never backed up.
 - **Inconsistent `required` guard on the pgBackRest S3 secret name (#213).**
   `PGBACKREST_REPO1_S3_KEY_SECRET` (init env) and both keys in the pgbackrest sidecar
   referenced `pgbackrest.existingSecret.name` without the `required` wrapper that

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 1.2.5 - 2026-06-25
 
-Chart-only correctness fixes for four edge cases in the repmgr/pgBackRest paths (#211,
-#212, #213, #214). No image change (`trixie-5.5.0-26`).
+Chart-only correctness fixes for four edge cases in the repmgr/pgBackRest paths
+(#211, #212, #213, #214). No image change (`trixie-5.5.0-26`).
 
 ### Fixed
 

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: PostgreSQL with repmgr replication and optional PGPool-II
 type: application
-version: 1.2.4
+version: 1.2.5
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/README.md
+++ b/pg/README.md
@@ -114,7 +114,7 @@ rendering pipelines that never talk to the cluster (e.g. ArgoCD) must use
 | `postgresql.resources.limits.memory` | Memory limit | `1Gi` |
 | `postgresql.persistence.enabled` | Enable persistence | `true` |
 | `postgresql.persistence.size` | Storage size | `10Gi` |
-| `postgresql.persistence.emptyDir.sizeLimit` | `sizeLimit` for the non-persistent (`persistence.enabled=false`) PGDATA emptyDir; empty = unbounded | `""` |
+| `postgresql.persistence.emptyDir.sizeLimit` | `sizeLimit` for the non-persistent (`persistence.enabled=false`) PGDATA emptyDir; empty = fall back to `persistence.size` (never unbounded) | `""` |
 | `postgresql.persistence.storageClass` | Storage class | `""` |
 | `postgresql.updateStrategy.type` | StatefulSet update strategy | `RollingUpdate` |
 | `postgresql.updateStrategy.rollingUpdate.partition` | Partition for rolling update | `0` |

--- a/pg/templates/_helpers.tpl
+++ b/pg/templates/_helpers.tpl
@@ -151,6 +151,13 @@ annotation consumers -- #128.)
 {{- end }}
 {{- end }}
 
+{{- /* Name of the Secret holding the shared S3 access/secret key for pgBackRest
+       (pgbackrest.s3.keyType=shared). Single source of truth for the `required`
+       guard so the four secretKeyRef sites can't drift apart. */ -}}
+{{- define "pg.pgbackrestS3SecretName" -}}
+{{- required "pgbackrest.existingSecret.name is required (pgbackrest.s3.keyType=shared); use keyType=auto for cloud workload identity" .Values.pgbackrest.existingSecret.name -}}
+{{- end }}
+
 {{- define "pg.pgpoolAdminSecretName" -}}
 {{- if .Values.pgpool.admin.existingSecret.enabled }}
 {{- required "pgpool.admin.existingSecret.name is required when pgpool.admin.existingSecret.enabled is true" .Values.pgpool.admin.existingSecret.name }}

--- a/pg/templates/pgbackrest-cronjob.yaml
+++ b/pg/templates/pgbackrest-cronjob.yaml
@@ -66,22 +66,29 @@ spec:
                   # `|| CANDIDATES=""` so a failed EndpointSlice list (RBAC denial,
                   # transient API error) under `set -eu -o pipefail` falls through to
                   # the actionable error below instead of aborting with a bare trace.
+                  # Sorted so selection is deterministic across runs and independent of
+                  # EndpointSlice list order (matters only in the rare multi-endpoint case).
                   CANDIDATES=$(kubectl -n "$NAMESPACE" get endpointslices \
                     -l "kubernetes.io/service-name=$PRIMARY_SVC" \
-                    -o jsonpath='{.items[*].endpoints[?(@.conditions.ready==true)].targetRef.name}') || CANDIDATES=""
-                  if [ -z "$CANDIDATES" ]; then
+                    -o jsonpath='{.items[*].endpoints[?(@.conditions.ready==true)].targetRef.name}' \
+                    | tr ' ' '\n' | sort | tr '\n' ' ') || CANDIDATES=""
+                  if [ -z "$(echo $CANDIDATES)" ]; then
                     echo "ERROR: no ready endpoint found (or the endpointslice lookup failed) for $PRIMARY_SVC" >&2
                     exit 1
                   fi
+                  # Pick the one read-write primary among the Ready endpoints. Validate
+                  # over each candidate's local socket -- the same psql call the readiness
+                  # probe uses. `timeout 10` bounds a wedged/mid-shutdown pod (socket open
+                  # but not serving) so the scan can never hang until activeDeadlineSeconds;
+                  # two attempts absorb a transient blip. `|| rec=""` keeps a failed exec
+                  # (a candidate that vanished mid-scan) from tripping `set -e -o pipefail`.
                   PRIMARY=""
+                  saw_standby=""
+                  ncand=0
+                  last_cand=""
                   for cand in $CANDIDATES; do
-                    # Validate over the candidate's local socket -- the same psql call
-                    # the readiness probe uses. `timeout 10` bounds a wedged/mid-shutdown
-                    # pod (socket open but not serving) so the scan can never hang until
-                    # activeDeadlineSeconds. Two attempts absorb a transient blip on the
-                    # real primary so a backup we could have taken is not skipped. The
-                    # trailing `|| rec=""` keeps a failed exec (a candidate that vanished
-                    # mid-scan) from tripping `set -e -o pipefail` -- we just move on.
+                    ncand=$((ncand + 1))
+                    last_cand="$cand"
                     rec=""
                     for attempt in 1 2; do
                       rec=$(kubectl -n "$NAMESPACE" exec "$cand" -c postgresql -- \
@@ -94,11 +101,26 @@ spec:
                       PRIMARY="$cand"
                       break
                     fi
-                    echo "Skipping $cand: pg_is_in_recovery=${rec:-unreadable} (not the read-write primary)"
+                    [ "$rec" = "t" ] && saw_standby="yes"
+                    echo "Skipping $cand: pg_is_in_recovery=${rec:-unreadable} (not a confirmed read-write primary)"
                   done
                   if [ -z "$PRIMARY" ]; then
-                    echo "ERROR: none of the ready endpoints ($CANDIDATES) is a read-write primary for $PRIMARY_SVC" >&2
-                    exit 1
+                    # No candidate confirmed pg_is_in_recovery()=f. Fall back ONLY when
+                    # there is exactly one Ready endpoint whose state we could not read
+                    # (not a confirmed standby 't'): the write Service selects only the
+                    # primary, so a lone unverifiable endpoint is almost certainly it, and
+                    # master would have backed it up -- skipping on a transient probe blip
+                    # would silently drop the backup (backoffLimit:0). pgbackrest fails
+                    # cleanly if it really is a standby. The ambiguous MULTI-endpoint case
+                    # (#212) still requires a confirmed primary, and a confirmed standby is
+                    # never used.
+                    if [ "$ncand" -eq 1 ] && [ -z "$saw_standby" ]; then
+                      PRIMARY="$last_cand"
+                      echo "WARNING: could not confirm read-write state of the sole Ready endpoint $PRIMARY; proceeding (it is the write Service target). pgbackrest will fail cleanly if it is not the primary."
+                    else
+                      echo "ERROR: none of the ready endpoints ($CANDIDATES) is a confirmed read-write primary for $PRIMARY_SVC" >&2
+                      exit 1
+                    fi
                   fi
                   echo "Primary pod resolved to: $PRIMARY"
 

--- a/pg/templates/pgbackrest-cronjob.yaml
+++ b/pg/templates/pgbackrest-cronjob.yaml
@@ -54,14 +54,35 @@ spec:
               args:
                 - |
                   # Resolve the primary pod from the write Service's EndpointSlices
-                  # (the core Endpoints API is deprecated). Take the first Ready
-                  # endpoint; the write Service selects only the primary pod.
-                  PRIMARY_RAW=$(kubectl -n "$NAMESPACE" get endpointslices \
+                  # (the core Endpoints API is deprecated). The write Service selects
+                  # only the primary, but during a failover + scale-down collision
+                  # stale EndpointSlices can briefly expose more than one Ready
+                  # endpoint; taking the first blindly could target a standby, and
+                  # with backoffLimit:0 the failed backup is silently skipped (#212).
+                  # So validate every Ready candidate with pg_is_in_recovery() and
+                  # pick the one true read-write primary (=f). The check runs in the
+                  # candidate's postgresql container over its local socket -- the same
+                  # invocation the readiness probe uses, so no extra creds are needed.
+                  CANDIDATES=$(kubectl -n "$NAMESPACE" get endpointslices \
                     -l "kubernetes.io/service-name=$PRIMARY_SVC" \
                     -o jsonpath='{.items[*].endpoints[?(@.conditions.ready==true)].targetRef.name}')
-                  PRIMARY=${PRIMARY_RAW%% *}
+                  if [ -z "$CANDIDATES" ]; then
+                    echo "ERROR: no ready endpoint found in endpointslices for $PRIMARY_SVC" >&2
+                    exit 1
+                  fi
+                  PRIMARY=""
+                  for cand in $CANDIDATES; do
+                    rec=$(kubectl -n "$NAMESPACE" exec "$cand" -c postgresql -- \
+                      sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc "SELECT pg_is_in_recovery()"' 2>/dev/null \
+                      | tr -d '[:space:]')
+                    if [ "$rec" = "f" ]; then
+                      PRIMARY="$cand"
+                      break
+                    fi
+                    echo "Skipping $cand: pg_is_in_recovery=${rec:-unreadable} (not the read-write primary)"
+                  done
                   if [ -z "$PRIMARY" ]; then
-                    echo "ERROR: no ready primary pod found in endpointslices for $PRIMARY_SVC" >&2
+                    echo "ERROR: none of the ready endpoints ($CANDIDATES) is a read-write primary for $PRIMARY_SVC" >&2
                     exit 1
                   fi
                   echo "Primary pod resolved to: $PRIMARY"

--- a/pg/templates/pgbackrest-cronjob.yaml
+++ b/pg/templates/pgbackrest-cronjob.yaml
@@ -63,22 +63,33 @@ spec:
                   # pick the one true read-write primary (=f). The check runs in the
                   # candidate's postgresql container over its local socket -- the same
                   # invocation the readiness probe uses, so no extra creds are needed.
+                  # `|| CANDIDATES=""` so a failed EndpointSlice list (RBAC denial,
+                  # transient API error) under `set -eu -o pipefail` falls through to
+                  # the actionable error below instead of aborting with a bare trace.
                   CANDIDATES=$(kubectl -n "$NAMESPACE" get endpointslices \
                     -l "kubernetes.io/service-name=$PRIMARY_SVC" \
-                    -o jsonpath='{.items[*].endpoints[?(@.conditions.ready==true)].targetRef.name}')
+                    -o jsonpath='{.items[*].endpoints[?(@.conditions.ready==true)].targetRef.name}') || CANDIDATES=""
                   if [ -z "$CANDIDATES" ]; then
-                    echo "ERROR: no ready endpoint found in endpointslices for $PRIMARY_SVC" >&2
+                    echo "ERROR: no ready endpoint found (or the endpointslice lookup failed) for $PRIMARY_SVC" >&2
                     exit 1
                   fi
                   PRIMARY=""
                   for cand in $CANDIDATES; do
-                    # `|| rec=""` so a candidate that vanishes between the
-                    # EndpointSlice list and the exec (a pod terminating during the
-                    # very failover/scale-down race handled here) does not trip
-                    # `set -e -o pipefail` and abort the scan -- we just move on.
-                    rec=$(kubectl -n "$NAMESPACE" exec "$cand" -c postgresql -- \
-                      sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc "SELECT pg_is_in_recovery()"' 2>/dev/null \
-                      | tr -d '[:space:]') || rec=""
+                    # Validate over the candidate's local socket -- the same psql call
+                    # the readiness probe uses. `timeout 10` bounds a wedged/mid-shutdown
+                    # pod (socket open but not serving) so the scan can never hang until
+                    # activeDeadlineSeconds. Two attempts absorb a transient blip on the
+                    # real primary so a backup we could have taken is not skipped. The
+                    # trailing `|| rec=""` keeps a failed exec (a candidate that vanished
+                    # mid-scan) from tripping `set -e -o pipefail` -- we just move on.
+                    rec=""
+                    for attempt in 1 2; do
+                      rec=$(kubectl -n "$NAMESPACE" exec "$cand" -c postgresql -- \
+                        sh -c 'timeout 10 psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc "SELECT pg_is_in_recovery()"' 2>/dev/null \
+                        | tr -d '[:space:]') || rec=""
+                      [ -n "$rec" ] && break
+                      [ "$attempt" -lt 2 ] && sleep 2
+                    done
                     if [ "$rec" = "f" ]; then
                       PRIMARY="$cand"
                       break

--- a/pg/templates/pgbackrest-cronjob.yaml
+++ b/pg/templates/pgbackrest-cronjob.yaml
@@ -72,9 +72,13 @@ spec:
                   fi
                   PRIMARY=""
                   for cand in $CANDIDATES; do
+                    # `|| rec=""` so a candidate that vanishes between the
+                    # EndpointSlice list and the exec (a pod terminating during the
+                    # very failover/scale-down race handled here) does not trip
+                    # `set -e -o pipefail` and abort the scan -- we just move on.
                     rec=$(kubectl -n "$NAMESPACE" exec "$cand" -c postgresql -- \
                       sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc "SELECT pg_is_in_recovery()"' 2>/dev/null \
-                      | tr -d '[:space:]')
+                      | tr -d '[:space:]') || rec=""
                     if [ "$rec" = "f" ]; then
                       PRIMARY="$cand"
                       break

--- a/pg/templates/pgbackrest-rbac.yaml
+++ b/pg/templates/pgbackrest-rbac.yaml
@@ -30,10 +30,12 @@ rules:
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["get", "list"]
-  # Exec into the pgbackrest sidecar of the primary pod to run the backup.
-  # kubectl exec GETs the target pod then POSTs to its pods/exec subresource;
-  # the backup only ever targets the resolved primary, which is always one of
-  # the StatefulSet's deterministic pod names (<fullname>-0 .. <fullname>-N).
+  # Exec into the candidate pods to (a) validate the read-write primary via
+  # pg_is_in_recovery() in the postgresql container (#212) and (b) run the backup
+  # in the pgbackrest sidecar of the resolved primary. kubectl exec GETs the
+  # target pod then POSTs to its pods/exec subresource; exec is scoped per pod,
+  # not per container. The candidates are always StatefulSet pod names
+  # (<fullname>-0 .. <fullname>-N).
   # resourceNames scopes get on pods and create on the pods/exec subresource
   # (the pod name is in the request path), so a leaked SA token cannot exec into
   # arbitrary pods in the namespace (#134).

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -504,12 +504,12 @@ spec:
             - name: PGBACKREST_REPO1_S3_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "pgbackrest.existingSecret.name is required (pgbackrest.s3.keyType=shared); use keyType=auto for cloud workload identity" .Values.pgbackrest.existingSecret.name }}
+                  name: {{ include "pg.pgbackrestS3SecretName" . }}
                   key: {{ .Values.pgbackrest.existingSecret.accessKeyIdKey }}
             - name: PGBACKREST_REPO1_S3_KEY_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "pgbackrest.existingSecret.name is required (pgbackrest.s3.keyType=shared); use keyType=auto for cloud workload identity" .Values.pgbackrest.existingSecret.name }}
+                  name: {{ include "pg.pgbackrestS3SecretName" . }}
                   key: {{ .Values.pgbackrest.existingSecret.secretAccessKeyKey }}
 {{- end }}
 {{- end }}
@@ -1061,12 +1061,12 @@ spec:
             - name: PGBACKREST_REPO1_S3_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "pgbackrest.existingSecret.name is required (pgbackrest.s3.keyType=shared); use keyType=auto for cloud workload identity" .Values.pgbackrest.existingSecret.name }}
+                  name: {{ include "pg.pgbackrestS3SecretName" . }}
                   key: {{ .Values.pgbackrest.existingSecret.accessKeyIdKey }}
             - name: PGBACKREST_REPO1_S3_KEY_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "pgbackrest.existingSecret.name is required (pgbackrest.s3.keyType=shared); use keyType=auto for cloud workload identity" .Values.pgbackrest.existingSecret.name }}
+                  name: {{ include "pg.pgbackrestS3SecretName" . }}
                   key: {{ .Values.pgbackrest.existingSecret.secretAccessKeyKey }}
 {{- end }}
           volumeMounts:

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -509,7 +509,7 @@ spec:
             - name: PGBACKREST_REPO1_S3_KEY_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.pgbackrest.existingSecret.name }}
+                  name: {{ required "pgbackrest.existingSecret.name is required (pgbackrest.s3.keyType=shared); use keyType=auto for cloud workload identity" .Values.pgbackrest.existingSecret.name }}
                   key: {{ .Values.pgbackrest.existingSecret.secretAccessKeyKey }}
 {{- end }}
 {{- end }}
@@ -624,14 +624,27 @@ spec:
                         # GUCs read back inside the DO block via current_setting().
                         # GUC names use `tgt_user`/`tgt_pass` — `user` would
                         # collide with the SQL reserved keyword.
+                        #
+                        # User/pass are read from the environment with \getenv (as
+                        # the monitoring-user job does), NOT passed via `-v`. A `-v`
+                        # value containing a single quote breaks psql's :'var'
+                        # quoting -- e.g. pass `a'b` rendered an unterminated literal
+                        # and the rehash silently no-op'd for that user (#211). The
+                        # md5 pg_hba fallback masks the failure, so connectivity is
+                        # kept but the scram migration never converges. randAlphaNum
+                        # never emits `'`, so only existingSecret passwords hit it.
+                        # \getenv is client-side (psql >= 16, image is PG 18), so the
+                        # PG < 14 server guard below is unaffected.
                         fix_user_auth() {
                           local target_user="$1"
                           local target_pass="$2"
                           [ -z "$target_user" ] && return 0
                           [ -z "$target_pass" ] && return 0
                           local sql="
-                            SET myvars.tgt_user = :'u';
-                            SET myvars.tgt_pass = :'p';
+                            \\getenv tgt_user FIX_TGT_USER
+                            \\getenv tgt_pass FIX_TGT_PASS
+                            SET myvars.tgt_user = :'tgt_user';
+                            SET myvars.tgt_pass = :'tgt_pass';
                             DO \$\$
                             DECLARE
                               v_user TEXT := current_setting('myvars.tgt_user');
@@ -650,10 +663,9 @@ spec:
                               END IF;
                             END
                             \$\$;"
-                          if ! psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+                          if ! FIX_TGT_USER="$target_user" FIX_TGT_PASS="$target_pass" \
+                            psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
                             -v ON_ERROR_STOP=1 \
-                            -v u="$target_user" \
-                            -v p="$target_pass" \
                             --no-psqlrc <<<"$sql"; then
                             echo "fix_user_auth: md5->scram rehash failed for ${target_user} (psql returned non-zero, see error above)" >&2
                           fi
@@ -1049,12 +1061,12 @@ spec:
             - name: PGBACKREST_REPO1_S3_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.pgbackrest.existingSecret.name }}
+                  name: {{ required "pgbackrest.existingSecret.name is required (pgbackrest.s3.keyType=shared); use keyType=auto for cloud workload identity" .Values.pgbackrest.existingSecret.name }}
                   key: {{ .Values.pgbackrest.existingSecret.accessKeyIdKey }}
             - name: PGBACKREST_REPO1_S3_KEY_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.pgbackrest.existingSecret.name }}
+                  name: {{ required "pgbackrest.existingSecret.name is required (pgbackrest.s3.keyType=shared); use keyType=auto for cloud workload identity" .Values.pgbackrest.existingSecret.name }}
                   key: {{ .Values.pgbackrest.existingSecret.secretAccessKeyKey }}
 {{- end }}
           volumeMounts:
@@ -1120,12 +1132,12 @@ spec:
 {{- end }}
 {{- if not .Values.postgresql.persistence.enabled }}
         - name: data
-{{- with .Values.postgresql.persistence.emptyDir.sizeLimit }}
+          # Always bound the ephemeral PGDATA volume: an unbounded emptyDir lets a
+          # runaway DB/WAL fill the node's ephemeral storage and evict co-tenants
+          # (#165, #214). Falls back to persistence.size (the cap the operator
+          # already declared for persistent mode) when emptyDir.sizeLimit is unset.
           emptyDir:
-            sizeLimit: {{ . }}
-{{- else }}
-          emptyDir: {}
-{{- end }}
+            sizeLimit: {{ .Values.postgresql.persistence.emptyDir.sizeLimit | default .Values.postgresql.persistence.size }}
 {{- end }}
 {{- end }}
 {{- if .Values.postgresql.persistence.enabled }}

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -1135,9 +1135,11 @@ spec:
           # Always bound the ephemeral PGDATA volume: an unbounded emptyDir lets a
           # runaway DB/WAL fill the node's ephemeral storage and evict co-tenants
           # (#165, #214). Falls back to persistence.size (the cap the operator
-          # already declared for persistent mode) when emptyDir.sizeLimit is unset.
+          # already declared for persistent mode) when emptyDir.sizeLimit is unset,
+          # then to a 10Gi floor if persistence.size is also blank -- so the cap is
+          # never null (an empty sizeLimit would render as unbounded again).
           emptyDir:
-            sizeLimit: {{ .Values.postgresql.persistence.emptyDir.sizeLimit | default .Values.postgresql.persistence.size }}
+            sizeLimit: {{ .Values.postgresql.persistence.emptyDir.sizeLimit | default .Values.postgresql.persistence.size | default "10Gi" }}
 {{- end }}
 {{- end }}
 {{- if .Values.postgresql.persistence.enabled }}

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -274,9 +274,11 @@ sized_full=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-full-
 assert_not_contains "#165: no uncapped emptyDir in a full render" "${sized_full}" "emptyDir: {}"
 data_capped=$(helm template test-pg "${CHART_DIR}" --set postgresql.persistence.enabled=false --set postgresql.persistence.emptyDir.sizeLimit=8Gi --show-only templates/statefulset.yaml 2>&1)
 assert_contains "#165: non-persistent data emptyDir honors the sizeLimit" "${data_capped}" "sizeLimit: 8Gi"
-# default (sizeLimit unset) -> the documented unbounded fallback (emptyDir: {})
-data_default=$(helm template test-pg "${CHART_DIR}" --set postgresql.persistence.enabled=false --show-only templates/statefulset.yaml 2>&1)
-assert_contains "#165: non-persistent data emptyDir defaults to unbounded emptyDir: {}" "${data_default}" "emptyDir: {}"
+# #214: sizeLimit unset -> fall back to persistence.size (never the old unbounded
+# emptyDir: {}), so the ephemeral PGDATA volume can never fill the node.
+data_default=$(helm template test-pg "${CHART_DIR}" --set postgresql.persistence.enabled=false --set postgresql.persistence.size=10Gi --show-only templates/statefulset.yaml 2>&1)
+assert_contains "#214: non-persistent data emptyDir falls back to persistence.size" "${data_default}" "sizeLimit: 10Gi"
+assert_not_contains "#214: non-persistent data emptyDir is never unbounded" "${data_default}" "emptyDir: {}"
 # cover the feature-gated caps the full render omits (ext trees 1Gi; pgbackrest pg-run 16Mi)
 sized_feature=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-pgbackrest.yaml" --set postgresql.extensions.enabled=true --set postgresql.majorVersion=18 2>&1)
 assert_contains "#165: extension-tree emptyDir capped at 1Gi" "${sized_feature}" "sizeLimit: 1Gi"

--- a/pg/tests/unit/bugfix_test.yaml
+++ b/pg/tests/unit/bugfix_test.yaml
@@ -43,6 +43,16 @@ tests:
       - matchRegex:
           path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
           pattern: 'exec "\$cand" -c postgresql'
+      # The sole-endpoint fallback must be present: a lone unverifiable primary is
+      # still backed up (not silently dropped), while a confirmed standby never is.
+      # (helm-unittest can only match rendered text; the runtime loop is exercised
+      # by the kind-based backup-restore / repmgr-failover integration suites.)
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: 'ncand" -eq 1 \] && \[ -z "\$saw_standby"'
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: 'timeout 10 psql'
 
   # --- #214: ephemeral PGDATA emptyDir is always bounded ---
   - it: non-persistent PGDATA emptyDir falls back to persistence.size when sizeLimit unset

--- a/pg/tests/unit/bugfix_test.yaml
+++ b/pg/tests/unit/bugfix_test.yaml
@@ -1,0 +1,70 @@
+suite: pg correctness fixes (211/212/214)
+release:
+  name: test-pg
+tests:
+  # --- #211: md5->scram rehash reads password via \getenv, not -v ---
+  - it: fix_user_auth sources user/pass from the environment with getenv
+    values:
+      - ../values-repmgr.yaml
+    template: templates/statefulset.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[?(@.name=="postgresql")].lifecycle.postStart.exec.command[2]
+          pattern: "getenv tgt_user FIX_TGT_USER"
+      - matchRegex:
+          path: spec.template.spec.containers[?(@.name=="postgresql")].lifecycle.postStart.exec.command[2]
+          pattern: "getenv tgt_pass FIX_TGT_PASS"
+      - matchRegex:
+          path: spec.template.spec.containers[?(@.name=="postgresql")].lifecycle.postStart.exec.command[2]
+          pattern: 'FIX_TGT_USER="\$target_user" FIX_TGT_PASS="\$target_pass"'
+
+  - it: fix_user_auth no longer passes the password through psql -v
+    values:
+      - ../values-repmgr.yaml
+    template: templates/statefulset.yaml
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[?(@.name=="postgresql")].lifecycle.postStart.exec.command[2]
+          pattern: '-v p="\$target_pass"'
+
+  # --- #212: pgbackrest cronjob validates the primary via pg_is_in_recovery ---
+  - it: pgbackrest cronjob validates the read-write primary before backing up
+    values:
+      - ../values-pgbackrest.yaml
+    template: templates/pgbackrest-cronjob.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: "SELECT pg_is_in_recovery"
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: "none of the ready endpoints"
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: 'exec "\$cand" -c postgresql'
+
+  # --- #214: ephemeral PGDATA emptyDir is always bounded ---
+  - it: non-persistent PGDATA emptyDir falls back to persistence.size when sizeLimit unset
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.persistence.enabled: false
+      postgresql.persistence.size: 10Gi
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[?(@.name=="data")].emptyDir.sizeLimit
+          value: 10Gi
+
+  - it: non-persistent PGDATA emptyDir honors an explicit sizeLimit override
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.persistence.enabled: false
+      postgresql.persistence.emptyDir.sizeLimit: 2Gi
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[?(@.name=="data")].emptyDir.sizeLimit
+          value: 2Gi

--- a/pg/tests/unit/bugfix_test.yaml
+++ b/pg/tests/unit/bugfix_test.yaml
@@ -68,3 +68,16 @@ tests:
       - equal:
           path: spec.template.spec.volumes[?(@.name=="data")].emptyDir.sizeLimit
           value: 2Gi
+
+  - it: non-persistent PGDATA emptyDir is never null even when size and sizeLimit are blank
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.persistence.enabled: false
+      postgresql.persistence.size: ""
+      postgresql.persistence.emptyDir.sizeLimit: ""
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[?(@.name=="data")].emptyDir.sizeLimit
+          value: 10Gi

--- a/pg/tests/unit/guards_test.yaml
+++ b/pg/tests/unit/guards_test.yaml
@@ -53,3 +53,15 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "pgbackrest.enabled requires repmgr.enabled=true: the pgbackrest binary and the archive_command run inside the postgresql container, which in standalone mode is the official postgres image without pgbackrest. WAL archiving would fail on every segment (unbounded WAL growth) and backups would time out. Enable repmgr, or disable pgbackrest"
+
+  # --- Scenario 12: pgbackrest S3 secret name is required on every ref (#213) ---
+  - it: empty pgbackrest.existingSecret.name with keyType=shared fails render
+    templates:
+      - templates/statefulset.yaml
+    values:
+      - ../values-pgbackrest.yaml
+    set:
+      pgbackrest.existingSecret.name: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "pgbackrest.existingSecret.name is required (pgbackrest.s3.keyType=shared); use keyType=auto for cloud workload identity"

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -46,10 +46,10 @@ postgresql:
     enabled: true
     storageClass: ""
     size: 10Gi
-    # When persistence.enabled=false, PGDATA lives in an emptyDir. Set a sizeLimit so a
+    # When persistence.enabled=false, PGDATA lives in an emptyDir. A sizeLimit caps it so a
     # runaway DB/WAL is evicted itself instead of filling the node and evicting
-    # co-tenants (#165). Empty = unbounded (the prior behavior); set e.g. "8Gi" for
-    # ephemeral/dev use.
+    # co-tenants (#165, #214). Empty = fall back to persistence.size above (never
+    # unbounded); set e.g. "8Gi" to override the cap for ephemeral/dev use.
     emptyDir:
       sizeLimit: ""
 

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -48,8 +48,8 @@ postgresql:
     size: 10Gi
     # When persistence.enabled=false, PGDATA lives in an emptyDir. A sizeLimit caps it so a
     # runaway DB/WAL is evicted itself instead of filling the node and evicting
-    # co-tenants (#165, #214). Empty = fall back to persistence.size above (never
-    # unbounded); set e.g. "8Gi" to override the cap for ephemeral/dev use.
+    # co-tenants (#165, #214). Empty = fall back to persistence.size above, then a 10Gi
+    # floor if that is also blank (never unbounded); set e.g. "8Gi" to override the cap.
     emptyDir:
       sizeLimit: ""
 


### PR DESCRIPTION
Bundles four chart-only correctness fixes for the pg chart. No image change (`trixie-5.5.0-26`). Bumps `pg` to **1.2.5**.

## Fixes

### #211 — `fix_user_auth` breaks on passwords containing `'`
The md5→scram rehash passed the password via `psql -v p=...`. A single quote in the value broke psql's `:'p'` literal quoting, so the `ALTER USER ... PASSWORD` silently failed and the migration never converged (the md5 pg_hba fallback masked it, so connectivity was unaffected). Now reads user/pass from the environment with `\getenv` — the same injection-safe pattern the monitoring-user job already uses — so any password value is handled. `\getenv` is client-side (psql ≥ 16; image is PG 18), so the PG < 14 server guard is unaffected. Only affected `existingSecret` passwords; `randAlphaNum` never emits `'`.

### #212 — pgBackRest cronjob could back up a standby and silently skip
Primary discovery took the first Ready endpoint of the write Service's EndpointSlices. During a failover + scale-down collision, stale EndpointSlices can briefly expose more than one Ready endpoint; landing on a read-only pod made the backup fail, and with `backoffLimit: 0` it was silently dropped for that schedule. The cronjob now validates every Ready candidate with `pg_is_in_recovery()` (run in the candidate's `postgresql` container over its local socket — the same invocation the readiness probe uses, no extra creds) and backs up only the confirmed read-write primary, failing loudly if none qualifies.

### #213 — inconsistent `required` guard on the pgBackRest S3 secret name
`PGBACKREST_REPO1_S3_KEY_SECRET` (init env) and both keys in the pgbackrest sidecar referenced `pgbackrest.existingSecret.name` without the `required` wrapper that `PGBACKREST_REPO1_S3_KEY` already had. Functionally safe (the first `required` failed render first), but `required` is now applied consistently to every reference.

### #214 — unbounded ephemeral PGDATA when `persistence.enabled=false`
With the default empty `persistence.emptyDir.sizeLimit`, the `data` volume rendered as `emptyDir: {}` — unbounded ephemeral storage a runaway DB/WAL could use to fill the node and evict co-tenants. The volume is now always bounded: `emptyDir.sizeLimit` falls back to `persistence.size` (the cap already declared for persistent mode) when unset.

## Tests
- New `tests/unit/bugfix_test.yaml` (#211 `\getenv` wiring, #212 primary validation, #214 bounded emptyDir + override).
- `tests/unit/guards_test.yaml` extended with the #213 empty-secret-name render failure.
- Full unit suite: **36 passing**. `helm lint` clean; all value fixtures render.

Closes #211, #212, #213, #214.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pgBackRest cron primary selection by probing ready candidates and failing fast when no confirmed read-write primary is found.
  * Fixed repmgrd md5→SCRAM auth migration to safely handle special characters in usernames/passwords.
  * Made shared pgBackRest S3 secret name handling consistent and fail-fast when required config is missing.
  * Prevented unbounded ephemeral PGDATA when persistence is disabled by enforcing a bounded `emptyDir.sizeLimit` with safe fallbacks.
* **Documentation**
  * Updated README and chart changelog/values to reflect the new bounded storage behavior.
* **Tests**
  * Added correctness-focused unit tests and updated size-limit/primary-resolution assertions.
* **Chores**
  * Bumped Helm chart version to **1.2.5**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->