### PR TITLE
ci: fast-track release/docs-only PRs past the kind matrix

### DIFF
--- a/.github/workflows/kafka-test.yaml
+++ b/.github/workflows/kafka-test.yaml
@@ -32,17 +32,35 @@ jobs:
         id: detect
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD)
-            # Documentation-only changes (*.md) never affect rendering, so exclude them:
-            # a PR touching only Markdown leaves nothing to match and the suite is skipped.
-            if printf '%s\n' "$files" | grep -vE '\.md$' | grep -qE '^(kafka/|\.github/workflows/kafka-test\.yaml)'; then
-              echo "kafka=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "kafka=false" >> "$GITHUB_OUTPUT"
-            fi
-          else
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # push to master is already path-filtered upstream; always run.
             echo "kafka=true" >> "$GITHUB_OUTPUT"
+            echo "kafka changed: $(grep kafka= "$GITHUB_OUTPUT")"
+            exit 0
+          fi
+          base="${{ github.event.pull_request.base.sha }}"
+          files=$(git diff --name-only "$base" HEAD)
+          # Build the render-affecting set by removing changes that cannot affect what
+          # the chart renders, so release/docs-only PRs skip the kind matrix and are
+          # gated by `lint` (always-on) alone:
+          #   - Markdown (*.md): docs never affect rendering.
+          #   - kafka/Chart.yaml when ONLY version:/appVersion: changed (a pure release
+          #     bump). Any other Chart.yaml edit (dependencies, description, ...) is
+          #     kept and still runs the full suite. helm lint validates Chart.yaml on
+          #     every PR regardless.
+          render_files=$(printf '%s\n' "$files" | grep -vE '\.md$' || true)
+          if printf '%s\n' "$render_files" | grep -qxE 'kafka/Chart\.yaml'; then
+            non_version=$(git diff "$base" HEAD -- kafka/Chart.yaml \
+              | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
+              | grep -vE '^[+-](version|appVersion):' || true)
+            if [ -z "$non_version" ]; then
+              render_files=$(printf '%s\n' "$render_files" | grep -vxE 'kafka/Chart\.yaml' || true)
+            fi
+          fi
+          if printf '%s\n' "$render_files" | grep -qE '^(kafka/|\.github/workflows/kafka-test\.yaml)'; then
+            echo "kafka=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "kafka=false" >> "$GITHUB_OUTPUT"
           fi
 
   test:

--- a/.github/workflows/pg-test.yaml
+++ b/.github/workflows/pg-test.yaml
@@ -30,17 +30,35 @@ jobs:
         id: detect
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD)
-            # Documentation-only changes (*.md) never affect rendering, so exclude them:
-            # a PR touching only Markdown leaves nothing to match and the suite is skipped.
-            if printf '%s\n' "$files" | grep -vE '\.md$' | grep -qE '^(pg/|images/repmgr/|etcd/|\.github/workflows/pg-test\.yaml)'; then
-              echo "pg=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "pg=false" >> "$GITHUB_OUTPUT"
-            fi
-          else
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # push to master is already path-filtered upstream; always run.
             echo "pg=true" >> "$GITHUB_OUTPUT"
+            echo "pg changed: $(grep pg= "$GITHUB_OUTPUT")"
+            exit 0
+          fi
+          base="${{ github.event.pull_request.base.sha }}"
+          files=$(git diff --name-only "$base" HEAD)
+          # Build the render-affecting set by removing changes that cannot affect what
+          # the chart renders, so release/docs-only PRs skip the kind matrix and are
+          # gated by `lint` (always-on) alone:
+          #   - Markdown (*.md): docs never affect rendering.
+          #   - pg/Chart.yaml when ONLY version:/appVersion: changed (a pure release
+          #     bump). Any other Chart.yaml edit (dependencies, description, ...) is
+          #     kept and still runs the full suite. helm lint validates Chart.yaml on
+          #     every PR regardless.
+          render_files=$(printf '%s\n' "$files" | grep -vE '\.md$' || true)
+          if printf '%s\n' "$render_files" | grep -qxE 'pg/Chart\.yaml'; then
+            non_version=$(git diff "$base" HEAD -- pg/Chart.yaml \
+              | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
+              | grep -vE '^[+-](version|appVersion):' || true)
+            if [ -z "$non_version" ]; then
+              render_files=$(printf '%s\n' "$render_files" | grep -vxE 'pg/Chart\.yaml' || true)
+            fi
+          fi
+          if printf '%s\n' "$render_files" | grep -qE '^(pg/|images/repmgr/|etcd/|\.github/workflows/pg-test\.yaml)'; then
+            echo "pg=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pg=false" >> "$GITHUB_OUTPUT"
           fi
           echo "pg changed: $(grep pg= "$GITHUB_OUTPUT")"
 

--- a/.github/workflows/redis-test.yaml
+++ b/.github/workflows/redis-test.yaml
@@ -33,17 +33,35 @@ jobs:
         id: detect
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD)
-            # Documentation-only changes (*.md) never affect rendering, so exclude them:
-            # a PR touching only Markdown leaves nothing to match and the suite is skipped.
-            if printf '%s\n' "$files" | grep -vE '\.md$' | grep -qE '^(redis/|\.github/workflows/redis-test\.yaml)'; then
-              echo "redis=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "redis=false" >> "$GITHUB_OUTPUT"
-            fi
-          else
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # push to master is already path-filtered upstream; always run.
             echo "redis=true" >> "$GITHUB_OUTPUT"
+            echo "redis changed: $(grep redis= "$GITHUB_OUTPUT")"
+            exit 0
+          fi
+          base="${{ github.event.pull_request.base.sha }}"
+          files=$(git diff --name-only "$base" HEAD)
+          # Build the render-affecting set by removing changes that cannot affect what
+          # the chart renders, so release/docs-only PRs skip the kind matrix and are
+          # gated by `lint` (always-on) alone:
+          #   - Markdown (*.md): docs never affect rendering.
+          #   - redis/Chart.yaml when ONLY version:/appVersion: changed (a pure release
+          #     bump). Any other Chart.yaml edit (dependencies, description, ...) is
+          #     kept and still runs the full suite. helm lint validates Chart.yaml on
+          #     every PR regardless.
+          render_files=$(printf '%s\n' "$files" | grep -vE '\.md$' || true)
+          if printf '%s\n' "$render_files" | grep -qxE 'redis/Chart\.yaml'; then
+            non_version=$(git diff "$base" HEAD -- redis/Chart.yaml \
+              | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
+              | grep -vE '^[+-](version|appVersion):' || true)
+            if [ -z "$non_version" ]; then
+              render_files=$(printf '%s\n' "$render_files" | grep -vxE 'redis/Chart\.yaml' || true)
+            fi
+          fi
+          if printf '%s\n' "$render_files" | grep -qE '^(redis/|\.github/workflows/redis-test\.yaml)'; then
+            echo "redis=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "redis=false" >> "$GITHUB_OUTPUT"
           fi
 
   test:


### PR DESCRIPTION
## Problem

Each chart's test workflow already excludes `*.md` from change detection, so **CHANGELOG-/README-only PRs already skip the integration suites**. But a **`Chart.yaml` version bump** matched the render-path glob (`^pg/`, `^redis/`, `^kafka/`) and triggered the full ~20-minute kind matrix — even though bumping `version:` can't change what the chart renders. That's exactly what slowed down cutting releases this week (e.g. the pgvector 1.2.5 bump).

## Change

Extend the `changes` detection in `pg-test.yaml`, `redis-test.yaml`, and `kafka-test.yaml` so a `Chart.yaml` edit is treated as **non-render when its diff touches only `version:`/`appVersion:`** (a pure release bump):

- A release PR (version bump + CHANGELOG + README) now leaves nothing matching the render glob → the per-chart gate self-passes → the PR is gated by **`lint` alone** (always-on required check that renders the chart with `helm lint`) and merges in well under a minute.
- **Conservative**: any *other* `Chart.yaml` edit — `dependencies`, `description`, inline values, etc. — is still kept and runs the full suite. Only the exact version/appVersion bump skips.
- `helm lint` still validates `Chart.yaml` on every PR regardless, so a malformed bump is still caught.

## Verification

Detection logic was checked against real commits before committing:

| Change | Result |
|---|---|
| pgvector version-only bump (`50b10d2`) | skip ✅ |
| pg template fix (`58d5d38`) | full ✅ |
| synthetic `version:` + `dependencies:` bump | full ✅ |
| synthetic `description:` change | full ✅ |

All three workflow files parse as YAML and the embedded detect scripts pass `bash -n`. This PR touches the workflow files themselves, so it runs the full matrix for all three charts — exercising the changed detection end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection for Kafka, PG, and Redis test workflows so they run more accurately based on the files in a pull request.
  * Markdown-only updates no longer trigger these test suites.
  * Chart metadata-only edits are ignored, helping avoid unnecessary test runs when only version fields change.
  * Non-pull-request updates still continue to run the related tests as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
