### PR TITLE
fix(pg,pgvector): refresh repmgr image to clear scan CVEs (1.2.6, trixie-5.5.0-27)

### DIFF
--- a/images/repmgr/Dockerfile
+++ b/images/repmgr/Dockerfile
@@ -18,8 +18,11 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GOFLAGS=-mod=vendor GOPROXY=off 
 #   docker buildx imagetools inspect debian:trixie-slim
 FROM debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
+# Install system dependencies. `apt-get upgrade` first so the digest-pinned base
+# picks up Debian security updates released after the base snapshot (e.g. the
+# libssh2 CVE-2026-7598 / CVE-2026-55200 fix in 1.11.1-1+deb13u1) instead of
+# shipping the stale pre-installed versions.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     curl \
     gnupg \
     lsb-release \
@@ -42,8 +45,12 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install kubectl for the service-updater sidecar (repmgrd mode). Pinned version
-# (matches client-go's API minor) + checksum verification -- no floating stable.txt.
-ARG KUBECTL_VERSION=v1.31.3
+# + checksum verification -- no floating stable.txt. Kept on a current release so
+# the vendored Go stdlib / golang.org/x/net it links carry their CVE fixes (older
+# kubectl builds linked Go 1.22 + x/net 0.26, flagged Critical/High by Trivy).
+# Independent of the agent's client-go (a separate binary); only the core verbs
+# get/patch/label/exec/rollout are used, so cluster version skew is a non-issue.
+ARG KUBECTL_VERSION=v1.36.2
 RUN ARCH=$(dpkg --print-architecture) && \
     curl -fsSLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" && \
     curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256" -o kubectl.sha256 && \

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,26 @@
 # pg chart changelog
 
+## 1.2.6 - 2026-06-26
+
+Image security refresh: repmgr image `trixie-5.5.0-26` → `trixie-5.5.0-27`. No chart
+template or behavior change — only the bundled image is updated.
+
+### Fixed
+
+- **Bundled `kubectl` upgraded `v1.31.3` → `v1.36.2` to clear its image-scan CVEs.**
+  kubectl 1.31.3 linked Go 1.22.8 and `golang.org/x/net` 0.26.0, which Trivy flagged as
+  1 Critical (`CVE-2025-68121`, Go stdlib) plus ~24 High (Go stdlib / `x/net` / `x/oauth2`
+  / `moby/spdystream`). The current release links a patched Go 1.25 stdlib and recent
+  modules. kubectl is only used by the service-updater for core verbs
+  (`get`/`patch`/`label`/`exec`/`rollout`), so the version skew is immaterial.
+- **Debian security updates now applied at build time (`apt-get upgrade`).** The
+  digest-pinned base shipped stale pre-installed packages; the build now picks up released
+  fixes such as `libssh2` `1.11.1-1+deb13u1` (`CVE-2026-7598`, `CVE-2026-55200`, High).
+
+The remaining image-scan findings are Debian packages with no upstream fix yet (the Perl
+`CVE-2026-42496` / `CVE-2026-8376` Criticals, plus `libexpat1`/`curl`/`gnupg`/`ncurses`
+Highs); they are tracked and will clear on a future rebuild once Debian ships patches.
+
 ## 1.2.5 - 2026-06-25
 
 Chart-only correctness fixes for four edge cases in the repmgr/pgBackRest paths

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: PostgreSQL with repmgr replication and optional PGPool-II
 type: application
-version: 1.2.5
+version: 1.2.6
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/README.md
+++ b/pg/README.md
@@ -195,7 +195,7 @@ When `repmgr.enabled` is true, `additionalCommands` automatically discover the c
 |-----------|-------------|---------|
 | `repmgr.enabled` | Enable repmgr | `true` |
 | `repmgr.image.repository` | Repmgr image repository | `cagriekin/repmgr` |
-| `repmgr.image.tag` | Repmgr image tag | `trixie-5.5.0-26` |
+| `repmgr.image.tag` | Repmgr image tag | `trixie-5.5.0-27` |
 | `repmgr.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `repmgr.image.majorVersion` | PostgreSQL major bundled in the repmgr image. In repmgr mode the server always runs this major; `postgresql.majorVersion` must match or the chart fails to render. Bump with `repmgr.image.tag` when moving to an image built for a new PG major. | `"18"` |
 | `repmgr.username` | Repmgr database user | `repmgr` |
@@ -1015,8 +1015,8 @@ kubectl scale statefulset my-postgres-pg --replicas=0
 # cloud-role annotation; the namespace default SA does not), and ensure the pod lands
 # where your IRSA/WI webhook injects the token; pgbackrest then uses the credential chain.
 kubectl run pg-restore --rm -it \
-  --image=cagriekin/repmgr:trixie-5.5.0-26 \
-  --overrides='{ "spec": { "securityContext": { "runAsUser": 101, "runAsGroup": 103, "fsGroup": 103, "runAsNonRoot": true, "seccompProfile": { "type": "RuntimeDefault" } }, "containers": [{ "name": "restore", "image": "cagriekin/repmgr:trixie-5.5.0-26", "command": ["bash"], "stdin": true, "tty": true, "securityContext": { "allowPrivilegeEscalation": false, "capabilities": { "drop": ["ALL"] } }, "volumeMounts": [{ "name": "data", "mountPath": "/var/lib/postgresql/data" }, { "name": "pgbackrest-config", "mountPath": "/etc/pgbackrest/pgbackrest.conf", "subPath": "pgbackrest.conf", "readOnly": true }], "env": [{ "name": "PGBACKREST_REPO1_S3_KEY", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "access-key-id" } } }, { "name": "PGBACKREST_REPO1_S3_KEY_SECRET", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "secret-access-key" } } }] }], "volumes": [{ "name": "data", "persistentVolumeClaim": { "claimName": "data-my-postgres-pg-0" } }, { "name": "pgbackrest-config", "configMap": { "name": "my-postgres-pg-pgbackrest" } }] } }'
+  --image=cagriekin/repmgr:trixie-5.5.0-27 \
+  --overrides='{ "spec": { "securityContext": { "runAsUser": 101, "runAsGroup": 103, "fsGroup": 103, "runAsNonRoot": true, "seccompProfile": { "type": "RuntimeDefault" } }, "containers": [{ "name": "restore", "image": "cagriekin/repmgr:trixie-5.5.0-27", "command": ["bash"], "stdin": true, "tty": true, "securityContext": { "allowPrivilegeEscalation": false, "capabilities": { "drop": ["ALL"] } }, "volumeMounts": [{ "name": "data", "mountPath": "/var/lib/postgresql/data" }, { "name": "pgbackrest-config", "mountPath": "/etc/pgbackrest/pgbackrest.conf", "subPath": "pgbackrest.conf", "readOnly": true }], "env": [{ "name": "PGBACKREST_REPO1_S3_KEY", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "access-key-id" } } }, { "name": "PGBACKREST_REPO1_S3_KEY_SECRET", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "secret-access-key" } } }] }], "volumes": [{ "name": "data", "persistentVolumeClaim": { "claimName": "data-my-postgres-pg-0" } }, { "name": "pgbackrest-config", "configMap": { "name": "my-postgres-pg-pgbackrest" } }] } }'
 
 # 3. Inside the restore pod, run (stanza = pgbackrest.stanza, default "db").
 # --type=time is REQUIRED with --target (pgbackrest rejects --target otherwise);
@@ -1247,7 +1247,8 @@ Each chart is tagged `<chart>-<version>` (e.g. `pg-1.1.0`); `pg` and `pgvector` 
 
 | `pg` / `pgvector` | repmgr image | PostgreSQL | Kubernetes |
 |-------------------|--------------|-----------|-----------|
-| 1.2.2 *(current)* | `trixie-5.5.0-26` | 18.x | ≥ 1.21 (PDB `policy/v1`); ≥ 1.27 for the agent-mode PDB `unhealthyPodEvictionPolicy` |
+| 1.2.6 *(current)* | `trixie-5.5.0-27` | 18.x | ≥ 1.21 (PDB `policy/v1`); ≥ 1.27 for the agent-mode PDB `unhealthyPodEvictionPolicy` |
+| 1.2.2 – 1.2.5 | `trixie-5.5.0-26` | 18.x | as above |
 | 1.2.0 – 1.2.1 | `trixie-5.5.0-25` | 18.x | as above |
 | 1.0.0 – 1.1.8 | `trixie-5.5.0-16` … `-24` | 18.x | as above |
 | 0.5.88 / 0.6.90 *(last 0.x)* | `trixie-5.5.0-15` | 18.x | ≥ 1.21 (PDB `policy/v1`) |
@@ -1261,7 +1262,7 @@ helm repo update
 helm upgrade my-postgres cagriekin/pg   # add -f your-values.yaml
 ```
 
-Within the 1.x line the default is agent mode, and successive releases (e.g. `1.0.0` → `1.2.2`) are backward-compatible: `helm upgrade` rolls the pods once for the new image (`trixie-5.5.0-26` at 1.2.2) and the agent re-establishes leadership with no manual step. **Read every `Migrating from X.Y.Z` entry in [`CHANGELOG.md`](CHANGELOG.md) between your current version and the target** — some releases (credential, `pg_hba`, or image changes) carry one-time steps. The CHANGELOG keeps an unbroken trail back through the 0.x line.
+Within the 1.x line the default is agent mode, and successive releases (e.g. `1.0.0` → `1.2.6`) are backward-compatible: `helm upgrade` rolls the pods once for the new image (`trixie-5.5.0-27` at 1.2.6) and the agent re-establishes leadership with no manual step. **Read every `Migrating from X.Y.Z` entry in [`CHANGELOG.md`](CHANGELOG.md) between your current version and the target** — some releases (credential, `pg_hba`, or image changes) carry one-time steps. The CHANGELOG keeps an unbroken trail back through the 0.x line.
 
 ### Crossing the 0.x → 1.x boundary (agent mode is now the default)
 

--- a/pg/tests/values-agent-pgpool.yaml
+++ b/pg/tests/values-agent-pgpool.yaml
@@ -27,7 +27,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-26
+    tag: trixie-5.5.0-27
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/tests/values-agent.yaml
+++ b/pg/tests/values-agent.yaml
@@ -47,7 +47,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-26
+    tag: trixie-5.5.0-27
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/tests/values-config-repmgr.yaml
+++ b/pg/tests/values-config-repmgr.yaml
@@ -60,7 +60,7 @@ repmgr:
   failoverMode: repmgrd
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-26
+    tag: trixie-5.5.0-27
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/tests/values-full-test.yaml
+++ b/pg/tests/values-full-test.yaml
@@ -55,7 +55,7 @@ repmgr:
   failoverMode: repmgrd
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-26
+    tag: trixie-5.5.0-27
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/tests/values-pgbackrest-minio.yaml
+++ b/pg/tests/values-pgbackrest-minio.yaml
@@ -34,7 +34,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-26
+    tag: trixie-5.5.0-27
     pullPolicy: IfNotPresent
   enabled: true
   failoverMode: repmgrd

--- a/pg/tests/values-pgbackrest.yaml
+++ b/pg/tests/values-pgbackrest.yaml
@@ -16,7 +16,7 @@ repmgr:
   failoverMode: repmgrd
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-26
+    tag: trixie-5.5.0-27
   enabled: true
 
 pgpool:

--- a/pg/tests/values-repmgr.yaml
+++ b/pg/tests/values-repmgr.yaml
@@ -54,7 +54,7 @@ repmgr:
   failoverMode: repmgrd
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-26
+    tag: trixie-5.5.0-27
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/tests/values-tls.yaml
+++ b/pg/tests/values-tls.yaml
@@ -5,7 +5,7 @@
 # and the exporter scraping over TLS as the (exempt) monitoring user.
 repmgr:
   image:
-    tag: trixie-5.5.0-26
+    tag: trixie-5.5.0-27
     pullPolicy: IfNotPresent
 
 postgresql:

--- a/pg/tests/values-upgrade-from.yaml
+++ b/pg/tests/values-upgrade-from.yaml
@@ -52,7 +52,7 @@ repmgr:
   failoverMode: repmgrd
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-26
+    tag: trixie-5.5.0-27
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/tests/values-upgrade-to.yaml
+++ b/pg/tests/values-upgrade-to.yaml
@@ -49,7 +49,7 @@ repmgr:
   failoverMode: repmgrd
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-26
+    tag: trixie-5.5.0-27
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -192,7 +192,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-26
+    tag: trixie-5.5.0-27
     # Optional digest pin (e.g. "sha256:..."). When set it is appended as
     # repository:tag@digest, so the cosign-signed / provenance-attested image is
     # pinned at deploy time and a mutable-tag repush cannot silently change it.
@@ -733,4 +733,4 @@ etcd:
   # The bundled etcd's RBAC-bootstrap Job runs the pg-ha-agent (repmgr) image, so keep
   # this in lockstep with repmgr.image.tag above; the subchart's own default can lag.
   bootstrapImage:
-    tag: trixie-5.5.0-26
+    tag: trixie-5.5.0-27

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,17 @@
 # pgvector chart changelog
 
+## 1.2.6 - 2026-06-26
+
+Image security refresh: repmgr image `trixie-5.5.0-26` → `trixie-5.5.0-27`. No chart
+template or behavior change. See the pg CHANGELOG for full detail.
+
+### Fixed
+
+- **Bundled `kubectl` upgraded `v1.31.3` → `v1.36.2`**, clearing its image-scan CVEs
+  (1 Critical + ~24 High in the old Go 1.22 / `x/net` 0.26 build).
+- **Debian security updates applied at build time (`apt-get upgrade`)**, picking up fixes
+  such as `libssh2` `1.11.1-1+deb13u1` (`CVE-2026-7598`, `CVE-2026-55200`).
+
 ## 1.2.5 - 2026-06-25
 
 Chart-only correctness fixes inherited from pg's symlinked templates (#211, #212, #213,

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with pgvector extension and optional PGPool-II
 type: application
-version: 1.2.5
+version: 1.2.6
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -210,7 +210,7 @@ When `repmgr.enabled` is true, `additionalCommands` automatically discover the c
 |-----------|-------------|---------|
 | `repmgr.enabled` | Enable repmgr | `true` |
 | `repmgr.image.repository` | Repmgr image repository | `cagriekin/repmgr` |
-| `repmgr.image.tag` | Repmgr image tag | `trixie-5.5.0-26` |
+| `repmgr.image.tag` | Repmgr image tag | `trixie-5.5.0-27` |
 | `repmgr.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `repmgr.image.majorVersion` | PostgreSQL major bundled in the repmgr image. In repmgr mode the server always runs this major; `postgresql.majorVersion` must match or the chart fails to render. Bump with `repmgr.image.tag` when moving to an image built for a new PG major. | `"18"` |
 | `repmgr.username` | Repmgr database user | `repmgr` |
@@ -887,8 +887,8 @@ kubectl scale statefulset my-pgvector --replicas=0
 # cloud-role annotation; the namespace default SA does not), and ensure the pod lands
 # where your IRSA/WI webhook injects the token; pgbackrest then uses the credential chain.
 kubectl run pg-restore --rm -it \
-  --image=cagriekin/repmgr:trixie-5.5.0-26 \
-  --overrides='{ "spec": { "securityContext": { "runAsUser": 101, "runAsGroup": 103, "fsGroup": 103, "runAsNonRoot": true, "seccompProfile": { "type": "RuntimeDefault" } }, "containers": [{ "name": "restore", "image": "cagriekin/repmgr:trixie-5.5.0-26", "command": ["bash"], "stdin": true, "tty": true, "securityContext": { "allowPrivilegeEscalation": false, "capabilities": { "drop": ["ALL"] } }, "volumeMounts": [{ "name": "data", "mountPath": "/var/lib/postgresql/data" }, { "name": "pgbackrest-config", "mountPath": "/etc/pgbackrest/pgbackrest.conf", "subPath": "pgbackrest.conf", "readOnly": true }], "env": [{ "name": "PGBACKREST_REPO1_S3_KEY", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "access-key-id" } } }, { "name": "PGBACKREST_REPO1_S3_KEY_SECRET", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "secret-access-key" } } }] }], "volumes": [{ "name": "data", "persistentVolumeClaim": { "claimName": "data-my-pgvector-0" } }, { "name": "pgbackrest-config", "configMap": { "name": "my-pgvector-pgbackrest" } }] } }'
+  --image=cagriekin/repmgr:trixie-5.5.0-27 \
+  --overrides='{ "spec": { "securityContext": { "runAsUser": 101, "runAsGroup": 103, "fsGroup": 103, "runAsNonRoot": true, "seccompProfile": { "type": "RuntimeDefault" } }, "containers": [{ "name": "restore", "image": "cagriekin/repmgr:trixie-5.5.0-27", "command": ["bash"], "stdin": true, "tty": true, "securityContext": { "allowPrivilegeEscalation": false, "capabilities": { "drop": ["ALL"] } }, "volumeMounts": [{ "name": "data", "mountPath": "/var/lib/postgresql/data" }, { "name": "pgbackrest-config", "mountPath": "/etc/pgbackrest/pgbackrest.conf", "subPath": "pgbackrest.conf", "readOnly": true }], "env": [{ "name": "PGBACKREST_REPO1_S3_KEY", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "access-key-id" } } }, { "name": "PGBACKREST_REPO1_S3_KEY_SECRET", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "secret-access-key" } } }] }], "volumes": [{ "name": "data", "persistentVolumeClaim": { "claimName": "data-my-pgvector-0" } }, { "name": "pgbackrest-config", "configMap": { "name": "my-pgvector-pgbackrest" } }] } }'
 
 # 3. Inside the restore pod, run (stanza = pgbackrest.stanza, default "db").
 # --type=time is REQUIRED with --target (pgbackrest rejects --target otherwise);
@@ -934,7 +934,7 @@ helm repo update
 helm upgrade my-pgvector cagriekin/pgvector   # add -f your-values.yaml
 ```
 
-`pgvector` tracks `pg` in lockstep — same version, image, and agent; the earlier 0.6.x ↔ 0.5.x split unified at `1.0.0` (current: `1.2.2`, image `trixie-5.5.0-26`). Within the 1.x line `helm upgrade` rolls the pods once and needs no manual step. The default failover mode is `agent` since `1.0.0` (it was `repmgrd` through 0.x); **only when crossing from a 0.x release** does adopting the agent default need the one-time `--cascade=orphan` recreate — pin `repmgr.failoverMode: repmgrd` to defer. Read the `Migrating from X.Y.Z` entries in [`CHANGELOG.md`](CHANGELOG.md) between your version and the target. For the **compatibility matrix, the version model, and the full 0.x → 1.x migration runbook**, see the [pg chart README — Upgrade and migration](../pg/README.md#upgrade-and-migration) (this chart shares pg's templates and agent).
+`pgvector` tracks `pg` in lockstep — same version, image, and agent; the earlier 0.6.x ↔ 0.5.x split unified at `1.0.0` (current: `1.2.6`, image `trixie-5.5.0-27`). Within the 1.x line `helm upgrade` rolls the pods once and needs no manual step. The default failover mode is `agent` since `1.0.0` (it was `repmgrd` through 0.x); **only when crossing from a 0.x release** does adopting the agent default need the one-time `--cascade=orphan` recreate — pin `repmgr.failoverMode: repmgrd` to defer. Read the `Migrating from X.Y.Z` entries in [`CHANGELOG.md`](CHANGELOG.md) between your version and the target. For the **compatibility matrix, the version model, and the full 0.x → 1.x migration runbook**, see the [pg chart README — Upgrade and migration](../pg/README.md#upgrade-and-migration) (this chart shares pg's templates and agent).
 
 ## pgvector Resources
 

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -178,7 +178,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-26
+    tag: trixie-5.5.0-27
     # Optional digest pin (e.g. "sha256:..."). When set it is appended as
     # repository:tag@digest, so the cosign-signed / provenance-attested image is
     # pinned at deploy time and a mutable-tag repush cannot silently change it.
@@ -704,4 +704,4 @@ etcd:
   # The bundled etcd's RBAC-bootstrap Job runs the pg-ha-agent (repmgr) image, so keep
   # this in lockstep with repmgr.image.tag above; the subchart's own default can lag.
   bootstrapImage:
-    tag: trixie-5.5.0-26
+    tag: trixie-5.5.0-27


### PR DESCRIPTION
Addresses the Artifact Hub / Trivy image-scan findings for the **pg** and **pgvector** charts. The scanned image `cagriekin/repmgr:trixie-5.5.0-26` reported **9 Critical / 63 High**. This refreshes it to `trixie-5.5.0-27` and bumps both charts to **1.2.6** (image-only change — no template or behavior change). The Go `pg-ha-agent` binary already scans clean.

## What was driving the findings

| Source | Critical | High | Action |
|---|---|---|---|
| bundled `kubectl` v1.31.3 (Go 1.22.8, `x/net` 0.26.0) | 1 | 24 | **bump to v1.36.2** |
| Debian `libssh2` (fix released) | 0 | 2 | **`apt-get upgrade`** picks up `1.11.1-1+deb13u1` |
| Debian perl/expat/curl/gnupg/ncurses (no upstream fix) | 8 | 37 | track; clears on future rebuild |

## Changes

- **`kubectl` v1.31.3 → v1.36.2** in `images/repmgr/Dockerfile`. The old build linked Go 1.22.8 + `golang.org/x/net` 0.26.0, the source of the one actionable Critical (`CVE-2025-68121`, Go stdlib) and ~24 of the Highs (Go stdlib / `x/net` / `x/oauth2` / `moby/spdystream`). v1.36.2 links a patched Go 1.25 stdlib and recent modules. kubectl is used only by the service-updater for core verbs (`get`/`patch`/`label`/`exec`/`rollout`), so the cluster version skew is immaterial; it's decoupled from the agent's `client-go` (a separate, scanned-clean binary).
- **`apt-get upgrade` at build time** so the digest-pinned base applies Debian security updates released after the snapshot — notably `libssh2` `1.11.1-1+deb13u1` (`CVE-2026-7598`, `CVE-2026-55200`).
- Image tag `trixie-5.5.0-26` → `-27` across `values.yaml`, all test fixtures, and the READMEs (param tables, restore examples, compatibility matrix). Charts bumped `1.2.5` → `1.2.6`.

## What remains (and why)

The other 8 Criticals + 37 Highs are Debian packages with **no upstream fix yet** — the Perl `CVE-2026-42496` / `CVE-2026-8376` Criticals plus `libexpat1`/`curl`/`gnupg`/`ncurses` Highs. Nothing to do but track upstream; a rebuild picks them up once Debian patches land.

## Verification

- `helm lint` clean for both charts; **37 unit tests**, **789 template assertions** pass.
- CI builds the new repmgr image from source (the build job reads the `-27` tag from `pg/values.yaml`) and runs the full kind matrix, so the kubectl bump + `apt-get upgrade` are exercised end-to-end before merge.

## Release steps after merge

1. Merge this PR.
2. Push the image tag `trixie-5.5.0-27` to publish the rebuilt image.
3. Tag `pg-1.2.6` and `pgvector-1.2.6` to cut the chart releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated bundled runtime images and packages to include security updates.
  * Upgraded the bundled command-line tool version and applied Debian security fixes during build time.
* **Chores**
  * Bumped chart versions to **1.2.6**.
  * Refreshed default image tags and related examples in documentation and test values to match the latest bundled images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->