### PR TITLE
fix(backup): load S3 credentials via mc alias import, not MC_HOST urlencode (1.2.7) (#221)

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,23 @@
 # pg chart changelog
 
+## 1.2.7 - 2026-06-26
+
+Chart-only fix for the legacy `backup.enabled` (pg_dump → S3) path. No image change
+(`trixie-5.5.0-27`).
+
+### Fixed
+
+- **Backup to AWS S3 failed when the secret access key contained `/` or `+` (#221).**
+  #167 moved S3 credentials out of the `mc` argv (where they were visible in
+  `/proc/<pid>/cmdline`) by percent-encoding them into an `MC_HOST_<alias>` URL, but `mc`
+  then signed SigV4 requests with the *encoded* secret — so any key containing URL-reserved
+  characters (common in real AWS keys) produced `The request signature we calculated does
+  not match the signature you provided` and every upload failed. `backup.sh` and
+  `validate.sh` now write a `0600` JSON credential document and load it via `mc alias
+  import`, which feeds the **raw** secret to the signer while still keeping credentials out
+  of the process argv. The integration test now runs the full backup → validation → restore
+  path against a secret key containing `/` and `+` so a regression fails in CI.
+
 ## 1.2.6 - 2026-06-26
 
 Image security refresh: repmgr image `trixie-5.5.0-26` → `trixie-5.5.0-27`. No chart

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: PostgreSQL with repmgr replication and optional PGPool-II
 type: application
-version: 1.2.6
+version: 1.2.7
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/templates/backup-configmap.yaml
+++ b/pg/templates/backup-configmap.yaml
@@ -37,30 +37,49 @@ data:
     # postgres image ships no CA bundle; use the one copied from the mc image
     export SSL_CERT_FILE=/tools/ca-bundle.crt
 
-    # Provide S3 credentials to mc via MC_HOST_<alias> read from the environment,
-    # NOT `mc alias set ... <access> <secret>` which exposes both keys in the
-    # process argv (/proc/<pid>/cmdline, readable via ps) on every run (#167).
-    # Percent-encode the keys so reserved characters (/, +, @, :, found in real
-    # AWS secret keys) survive inside the credential URL.
+    # Provide S3 credentials to mc WITHOUT exposing them in the process argv
+    # (/proc/<pid>/cmdline, readable via ps) -- the reason #167 moved off
+    # `mc alias set ... <access> <secret>`. #167 percent-encoded the keys into an
+    # MC_HOST_<alias> URL, but mc signs SigV4 with the *encoded* secret, so a key
+    # containing '/' or '+' (common in real AWS secret keys) produced a signature
+    # mismatch and every upload failed (#221). Instead write a 0600 credential doc
+    # and import it with `mc alias import`, which feeds the RAW secret to the
+    # signer regardless of character set. mc persists it to $MC_CONFIG_DIR/config.json
+    # (mode 0600); the temporary doc is removed right after the import.
     case "$S3_ENDPOINT" in
       *://*) ;;
       *) echo "ERROR: S3_ENDPOINT must include a scheme (http:// or https://)" >&2; exit 1 ;;
     esac
-    urlencode() {
-      # LC_ALL=C forces byte-wise iteration: under the image's UTF-8 locale
-      # ${#s}/${s:i:1} index by codepoint and would mis-encode a non-ASCII key byte.
-      local LC_ALL=C s="$1" out="" i c
+    json_escape() {
+      # Escape a value for embedding in a JSON double-quoted string. LC_ALL=C
+      # forces byte-wise iteration: under the image's UTF-8 locale ${#s}/${s:i:1}
+      # index by codepoint and would mishandle a non-ASCII key byte. Handles the
+      # characters JSON requires escaping -- backslash and double-quote -- plus C0
+      # control bytes via \u00XX.
+      local LC_ALL=C s="$1" out="" i c ord
       for (( i = 0; i < ${#s}; i++ )); do
         c="${s:i:1}"
         case "$c" in
-          [a-zA-Z0-9.~_-]) out+="$c" ;;
-          *) printf -v c '%%%02X' "'$c"; out+="$c" ;;
+          '"') out+='\"' ;;
+          '\') out+='\\' ;;
+          *)
+            printf -v ord '%d' "'$c"
+            if [ "$ord" -lt 32 ]; then printf -v c '\\u%04x' "$ord"; fi
+            out+="$c"
+            ;;
         esac
       done
       printf '%s' "$out"
     }
     echo "Configuring S3 alias..."
-    export MC_HOST_s3="${S3_ENDPOINT%%://*}://$(urlencode "$S3_ACCESS_KEY"):$(urlencode "$S3_SECRET_KEY")@${S3_ENDPOINT#*://}"
+    mkdir -p "$MC_CONFIG_DIR"
+    ALIAS_FILE="$MC_CONFIG_DIR/s3-alias.json"
+    ( umask 077
+      printf '{"url":"%s","accessKey":"%s","secretKey":"%s","api":"s3v4","path":"auto"}\n' \
+        "$(json_escape "$S3_ENDPOINT")" "$(json_escape "$S3_ACCESS_KEY")" "$(json_escape "$S3_SECRET_KEY")" \
+        > "$ALIAS_FILE" )
+    mc alias import s3 "$ALIAS_FILE"
+    rm -f "$ALIAS_FILE"
 
     # Stage to a .tmp object and publish (mc mv) to the canonical backup_<ts>.dump
     # name ONLY after integrity is verified (#159). A mid-stream pg_dump failure makes
@@ -168,19 +187,32 @@ data:
       *://*) ;;
       *) echo "ERROR: S3_ENDPOINT must include a scheme (http:// or https://)" >&2; exit 1 ;;
     esac
-    # Credentials via MC_HOST_<alias>, never argv (#167); percent-encode reserved chars.
-    urlencode() {
-      local LC_ALL=C s="$1" out="" i c
+    # Credentials imported from a 0600 JSON doc, never argv (#167) and never a
+    # percent-encoded MC_HOST URL (#221, which broke SigV4 for keys with / or +).
+    json_escape() {
+      local LC_ALL=C s="$1" out="" i c ord
       for (( i = 0; i < ${#s}; i++ )); do
         c="${s:i:1}"
         case "$c" in
-          [a-zA-Z0-9.~_-]) out+="$c" ;;
-          *) printf -v c '%%%02X' "'$c"; out+="$c" ;;
+          '"') out+='\"' ;;
+          '\') out+='\\' ;;
+          *)
+            printf -v ord '%d' "'$c"
+            if [ "$ord" -lt 32 ]; then printf -v c '\\u%04x' "$ord"; fi
+            out+="$c"
+            ;;
         esac
       done
       printf '%s' "$out"
     }
-    export MC_HOST_s3="${S3_ENDPOINT%%://*}://$(urlencode "$S3_ACCESS_KEY"):$(urlencode "$S3_SECRET_KEY")@${S3_ENDPOINT#*://}"
+    mkdir -p "$MC_CONFIG_DIR"
+    ALIAS_FILE="$MC_CONFIG_DIR/s3-alias.json"
+    ( umask 077
+      printf '{"url":"%s","accessKey":"%s","secretKey":"%s","api":"s3v4","path":"auto"}\n' \
+        "$(json_escape "$S3_ENDPOINT")" "$(json_escape "$S3_ACCESS_KEY")" "$(json_escape "$S3_SECRET_KEY")" \
+        > "$ALIAS_FILE" )
+    mc alias import s3 "$ALIAS_FILE"
+    rm -f "$ALIAS_FILE"
 
     echo "Finding the latest backup under s3/${S3_DIR}/ ..."
     # Separate the mc listing from the parse so a real S3/mc error fails the Job

--- a/pg/templates/backup-configmap.yaml
+++ b/pg/templates/backup-configmap.yaml
@@ -78,7 +78,14 @@ data:
       printf '{"url":"%s","accessKey":"%s","secretKey":"%s","api":"s3v4","path":"auto"}\n' \
         "$(json_escape "$S3_ENDPOINT")" "$(json_escape "$S3_ACCESS_KEY")" "$(json_escape "$S3_SECRET_KEY")" \
         > "$ALIAS_FILE" )
-    mc alias import s3 "$ALIAS_FILE"
+    # Remove the temp doc whether or not the import succeeds, so a failed import
+    # under `set -e` never leaves the credential file behind (the imported
+    # credentials still persist in $MC_CONFIG_DIR/config.json, 0600, for mc's use).
+    if ! mc alias import s3 "$ALIAS_FILE"; then
+      rm -f "$ALIAS_FILE"
+      echo "ERROR: failed to import S3 credentials into mc" >&2
+      exit 1
+    fi
     rm -f "$ALIAS_FILE"
 
     # Stage to a .tmp object and publish (mc mv) to the canonical backup_<ts>.dump
@@ -211,7 +218,12 @@ data:
       printf '{"url":"%s","accessKey":"%s","secretKey":"%s","api":"s3v4","path":"auto"}\n' \
         "$(json_escape "$S3_ENDPOINT")" "$(json_escape "$S3_ACCESS_KEY")" "$(json_escape "$S3_SECRET_KEY")" \
         > "$ALIAS_FILE" )
-    mc alias import s3 "$ALIAS_FILE"
+    # Remove the temp doc whether or not the import succeeds (see backup.sh).
+    if ! mc alias import s3 "$ALIAS_FILE"; then
+      rm -f "$ALIAS_FILE"
+      echo "ERROR: failed to import S3 credentials into mc" >&2
+      exit 1
+    fi
     rm -f "$ALIAS_FILE"
 
     echo "Finding the latest backup under s3/${S3_DIR}/ ..."

--- a/pg/tests/test-backup-restore.sh
+++ b/pg/tests/test-backup-restore.sh
@@ -12,17 +12,26 @@ MINIO_RELEASE="minio-test"
 
 begin_suite "Backup and Restore Integration"
 
+# #221 regression guard: the S3 secret key deliberately contains '/' and '+'.
+# A prior fix (#167) percent-encoded credentials into an MC_HOST URL, but mc then
+# signed SigV4 with the *encoded* secret, so any key with these chars failed every
+# upload with a signature mismatch in production. Running the whole backup ->
+# validation -> restore path against such a key makes a regression fail the backup
+# job here instead of silently in prod. mc alias set (raw argv) handles it fine, so
+# the test harness's own setup calls use the same key.
+S3_SECRET='9Ea4amnO1POkgnUvz8TC/O9hLv58Ka+n91UW5/ek'
+
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 
 echo "Deploying MinIO for S3-compatible storage..."
-kubectl apply -n "${NAMESPACE}" -f - <<'MINIO_MANIFEST'
+kubectl apply -n "${NAMESPACE}" -f - <<MINIO_MANIFEST
 apiVersion: v1
 kind: Secret
 metadata:
   name: minio-creds
 stringData:
   access-key-id: minioadmin
-  secret-access-key: minioadmin
+  secret-access-key: "${S3_SECRET}"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -46,7 +55,7 @@ spec:
             - name: MINIO_ROOT_USER
               value: minioadmin
             - name: MINIO_ROOT_PASSWORD
-              value: minioadmin
+              value: "${S3_SECRET}"
           ports:
             - containerPort: 9000
           readinessProbe:
@@ -73,7 +82,7 @@ wait_for_deployment_ready "${NAMESPACE}" "minio" 120
 echo "Creating S3 bucket..."
 kubectl run mc-setup -n "${NAMESPACE}" --restart=Never --image=minio/mc:RELEASE.2024-11-21T17-21-54Z \
   --command -- sh -c "
-    mc alias set s3 http://minio:9000 minioadmin minioadmin &&
+    mc alias set s3 http://minio:9000 minioadmin '${S3_SECRET}' &&
     mc mb s3/pg-backups || true
   "
 kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/mc-setup -n "${NAMESPACE}" --timeout=120s
@@ -128,7 +137,7 @@ echo "Verifying backup exists in S3..."
 # Dumps are namespaced per release under <prefix>/<fullname>/ (#143), so list that subpath.
 kubectl run mc-check -n "${NAMESPACE}" --restart=Never --image=minio/mc:RELEASE.2024-11-21T17-21-54Z \
   --command -- sh -c "
-    mc alias set s3 http://minio:9000 minioadmin minioadmin &&
+    mc alias set s3 http://minio:9000 minioadmin '${S3_SECRET}' &&
     mc ls s3/pg-backups/backups/${FULLNAME}/ --json | head -1
   "
 kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/mc-check -n "${NAMESPACE}" --timeout=120s
@@ -150,7 +159,7 @@ echo "Restoring from backup..."
 kubectl run mc-fetch -n "${NAMESPACE}" --restart=Never --image=minio/mc:RELEASE.2024-11-21T17-21-54Z \
   --command -- sh -c "sleep 300"
 kubectl wait --for=condition=Ready pod/mc-fetch -n "${NAMESPACE}" --timeout=120s
-kubectl exec -n "${NAMESPACE}" mc-fetch -- mc alias set s3 http://minio:9000 minioadmin minioadmin
+kubectl exec -n "${NAMESPACE}" mc-fetch -- mc alias set s3 http://minio:9000 minioadmin "${S3_SECRET}"
 # #159 adversarial decoy: plant a staging object with a FAR-FUTURE timestamp so it is
 # lexically newer than the real dump. A correct selection must still reject it (it is a
 # .tmp stage), so this proves the .tmp-rejection rather than restating the filter.

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -1369,6 +1369,21 @@ assert_not_contains "backup #167: no mc alias set with the endpoint in argv" "${
 assert_not_contains "backup #221: credentials NOT percent-encoded into an MC_HOST URL" "${backup_configmap}" "export MC_HOST_s3="
 assert_contains "backup #221: credentials imported from a JSON doc" "${backup_configmap}" 'mc alias import s3 "$ALIAS_FILE"'
 assert_contains "backup #221: alias doc carries url/accessKey/secretKey" "${backup_configmap}" '"url":"%s","accessKey":"%s","secretKey":"%s"'
+assert_contains "backup #221: alias doc written with a restrictive umask (0600 contract)" "${backup_configmap}" "umask 077"
+# The block above renders validation disabled, so it only exercises backup.sh.
+# validate.sh shares the credential path and must not silently regress to the
+# MC_HOST URL -- render it and assert the same contract over just that script.
+backup_val_configmap=$(helm template test-pg "${CHART_DIR}" \
+  --set backup.enabled=true \
+  --set backup.validation.enabled=true \
+  --set backup.s3.endpoint=https://s3.test \
+  --set backup.s3.bucket=test \
+  --set backup.existingSecret.name=test-secret \
+  --show-only templates/backup-configmap.yaml 2>&1)
+validate_sh=$(printf '%s\n' "${backup_val_configmap}" | sed -n '/validate.sh: |/,$p')
+assert_not_contains "validate #221: credentials NOT percent-encoded into an MC_HOST URL" "${validate_sh}" "export MC_HOST_s3="
+assert_contains "validate #221: credentials imported from a JSON doc" "${validate_sh}" 'mc alias import s3 "$ALIAS_FILE"'
+assert_contains "validate #221: alias doc written with a restrictive umask (0600 contract)" "${validate_sh}" "umask 077"
 # #221: json_escape is the load-bearing credential path -- it must leave the chars
 # urlencode mangled ('/', '+', ':', '@', '=') UNTOUCHED (so SigV4 sees the raw
 # secret) and escape only JSON metacharacters. Extract the function from the

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -1360,20 +1360,29 @@ assert_not_contains "#119: backup verify does not buffer the dump to /tmp" "${ba
 assert_contains "backup #143: dump path namespaced per release (fullname)" "${backup_configmap}" 'S3_DIR="${S3_BUCKET}/${S3_PREFIX%/}/test-pg"'
 assert_contains "backup #143: find calls scoped to the release subpath + name filter" "${backup_configmap}" 'mc find "s3/${S3_DIR}/" --name '"'"'backup_'
 assert_not_contains "backup #143: retention not run over the bare shared prefix" "${backup_configmap}" 'mc find "s3/${S3_BUCKET}/${S3_PREFIX}/" --older-than'
-# #167: S3 credentials must not be passed in mc argv (visible in /proc/<pid>/cmdline);
-# provide them via MC_HOST_s3 read from the environment instead.
-assert_contains "backup #167: credentials provided via MC_HOST_s3 env" "${backup_configmap}" "export MC_HOST_s3="
+# #167 + #221: S3 credentials must not appear in mc argv (/proc/<pid>/cmdline),
+# AND must not be percent-encoded into an MC_HOST URL -- mc signs SigV4 with the
+# encoded secret, so a key containing '/' or '+' (common in real AWS keys) fails
+# with a signature mismatch (#221). Credentials are imported from a 0600 JSON doc
+# instead, which feeds the RAW secret to the signer.
 assert_not_contains "backup #167: no mc alias set with the endpoint in argv" "${backup_configmap}" 'mc alias set s3 "$S3_ENDPOINT"'
-# #167: urlencode is the load-bearing credential path -- a regression would silently
-# break S3 auth for keys with reserved chars. Extract the function from the rendered
-# script and run it against an adversarial key to assert correct percent-encoding.
-urlencode_fn=$(printf '%s\n' "${backup_configmap}" | awk '/urlencode\(\) \{/{f=1} f{print} f&&/^    \}$/{exit}' | sed 's/^    //')
-if [ -n "${urlencode_fn}" ]; then
-  urlencode_out=$(bash -c "${urlencode_fn}
-urlencode 'a/b+c@d:e%f'")
-  assert_eq "backup #167: urlencode percent-encodes reserved chars (/ + @ : %)" "a%2Fb%2Bc%40d%3Ae%25f" "${urlencode_out}"
+assert_not_contains "backup #221: credentials NOT percent-encoded into an MC_HOST URL" "${backup_configmap}" "export MC_HOST_s3="
+assert_contains "backup #221: credentials imported from a JSON doc" "${backup_configmap}" 'mc alias import s3 "$ALIAS_FILE"'
+assert_contains "backup #221: alias doc carries url/accessKey/secretKey" "${backup_configmap}" '"url":"%s","accessKey":"%s","secretKey":"%s"'
+# #221: json_escape is the load-bearing credential path -- it must leave the chars
+# urlencode mangled ('/', '+', ':', '@', '=') UNTOUCHED (so SigV4 sees the raw
+# secret) and escape only JSON metacharacters. Extract the function from the
+# rendered script and run it against adversarial keys.
+json_escape_fn=$(printf '%s\n' "${backup_configmap}" | awk '/json_escape\(\) \{/{f=1} f{print} f&&/^    \}$/{exit}' | sed 's/^    //')
+if [ -n "${json_escape_fn}" ]; then
+  json_escape_out=$(bash -c "${json_escape_fn}
+json_escape 'a/b+c:d@e=f'")
+  assert_eq "backup #221: json_escape leaves /,+,:,@,= untouched (was percent-encoded, broke SigV4)" 'a/b+c:d@e=f' "${json_escape_out}"
+  json_escape_bs=$(bash -c "${json_escape_fn}"'
+json_escape "$(printf '"'"'a\\b'"'"')"')
+  assert_eq "backup #221: json_escape escapes a backslash for valid JSON" 'a\\b' "${json_escape_bs}"
 else
-  fail "backup #167: urlencode function extractable from the rendered script" "could not extract urlencode()"
+  fail "backup #221: json_escape function extractable from the rendered script" "could not extract json_escape()"
 fi
 # #159: stage the dump to a .tmp object and publish (mc mv) to the canonical name only
 # after integrity verification, so a truncated dump never sits at backup_<ts>.dump.

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,19 @@
 # pgvector chart changelog
 
+## 1.2.7 - 2026-06-26
+
+Chart-only fix inherited from pg's symlinked templates, for the legacy `backup.enabled`
+(pg_dump → S3) path. No image change (`trixie-5.5.0-27`). See the pg CHANGELOG for full
+detail.
+
+### Fixed
+
+- **Backup to AWS S3 failed when the secret access key contained `/` or `+` (#221).**
+  Credentials are now loaded via `mc alias import` from a `0600` JSON document (feeding the
+  raw secret to the SigV4 signer) instead of a percent-encoded `MC_HOST` URL, which `mc`
+  signed with the encoded secret and rejected. Credentials still never appear in the process
+  argv.
+
 ## 1.2.6 - 2026-06-26
 
 Image security refresh: repmgr image `trixie-5.5.0-26` → `trixie-5.5.0-27`. No chart

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with pgvector extension and optional PGPool-II
 type: application
-version: 1.2.6
+version: 1.2.7
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg


### PR DESCRIPTION
## Summary

Fixes #221 — the legacy `backup.enabled` (pg_dump → S3) CronJob failed against AWS S3 whenever the secret access key contained `/` or `+`, with `The request signature we calculated does not match the signature you provided`. This hit production (`service-medusa-pg-backup`, 2026-06-25).

## Root cause

#167 moved S3 credentials out of the `mc` argv (where they were visible in `/proc/<pid>/cmdline`) by percent-encoding them into an `MC_HOST_<alias>` URL. But `mc` signs SigV4 requests with the **encoded** secret, so any key containing URL-reserved characters — commonly `/` and `+` in real AWS keys — produced a signature mismatch and every upload failed.

## Fix

`backup.sh` and `validate.sh` now write a `0600` JSON credential document and load it with **`mc alias import`**, which feeds the **raw** secret to the signer — while still keeping credentials out of the process argv (the original #167 goal preserved). A pure-bash `json_escape` (replacing `urlencode`) leaves `/`, `+`, `:`, `@`, `=` untouched and escapes only JSON metacharacters.

## Verified empirically

Reproduced and fixed against the **exact pinned `minio/mc` image** (`RELEASE.2024-11-21T17-21-54Z`) with MinIO configured to use a secret key containing `/` and `+`:

- encoded `MC_HOST` URL → **reproduces** the production signature mismatch
- `mc alias import` from a JSON doc → **upload succeeds**

## Test coverage (the gap that let this ship)

- **`test-template.sh`** — replaced the `urlencode` assertions with `json_escape` ones that assert `/`, `+`, `:`, `@`, `=` pass through untouched (the chars that broke SigV4) and that JSON metacharacters are escaped; assert credentials are imported, not embedded in a `MC_HOST` URL or argv.
- **`test-backup-restore.sh`** — the full backup → validation → restore path now runs against a secret key containing `/` and `+`, so a regression fails in CI instead of silently in production.

## Scope & metadata

- pgBackRest path confirmed **unaffected** (it uses `secretKeyRef` env vars, never `mc`/`MC_HOST`).
- pg + pgvector bumped **1.2.6 → 1.2.7** (pgvector inherits via its symlinked template); CHANGELOGs updated. No image change (`trixie-5.5.0-27`).
- 792/792 `test-template.sh` assertions pass; `helm lint` clean for both charts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AWS S3 backup failures for legacy `backup.enabled` when secrets contain reserved characters like `/` and `+`.
  * Updated S3 credential handling to be imported via a temporary, restrictive JSON alias (avoids percent-encoding/signing mismatches and keeps secrets out of command arguments).
  * Added regression coverage for backup → validation → restore using special-character secrets.
* **Documentation**
  * Updated changelogs with the 1.2.7 fix details.
* **Chores**
  * Bumped Helm chart versions to **1.2.7** for both charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->