### PR TITLE
feat(redis): load/stress test + sizing guide (1.3.1) (#89)

### DIFF
--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.3.1 - 2026-06-29
+
+Sizing guidance and a throughput baseline (docs + tests only; no chart template or values
+changes, so rendered output is unchanged).
+
+### Added
+- `tests/test-performance.sh` + `values-performance.yaml` — opt-in `make test-performance`
+  target that runs `redis-benchmark` against a small standalone instance and asserts a
+  conservative throughput floor (regression guard, not a precise number) (#89).
+- README "Sizing & performance" guide: memory headroom and `maxmemory` table, single-threaded
+  CPU guidance, connection/`maxclients` notes, throughput expectations, and replication/
+  persistence overhead (#89).
+
 ## 1.3.0 - 2026-06-24
 
 Exporter configuration options (non-breaking; all new values default to the exporter's

--- a/redis/Chart.yaml
+++ b/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: Redis standalone or Sentinel-managed HA replication, with ACLs, TLS, AOF persistence, and a Prometheus metrics exporter
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: "8"
 home: https://github.com/cagriekin/charts/tree/master/redis
 icon: https://www.vectorlogo.zone/logos/redis/redis-icon.svg

--- a/redis/Makefile
+++ b/redis/Makefile
@@ -18,7 +18,7 @@ help:
 	@echo "  test-failover   - Run Sentinel failover tests (needs an existing replication release)"
 	@echo "  test-tls        - Run replication-over-TLS smoke (opt-in; generates a self-signed cert)"
 	@echo "  test-acl        - Run ACL tests (standalone restricted user + replication locked default)"
-	@echo "  test-performance - Run redis-benchmark throughput baseline (opt-in; standalone)"
+	@echo "  test-performance - Run redis-benchmark throughput baseline (opt-in; needs a cluster)"
 	@echo "  cluster-create  - Create Kind cluster"
 	@echo "  cluster-delete  - Delete Kind cluster"
 	@echo "  clean           - Delete cluster and test namespaces"

--- a/redis/Makefile
+++ b/redis/Makefile
@@ -3,7 +3,7 @@ KIND_CONFIG := kind-config.yaml
 TESTS_DIR := tests
 MAKEFLAGS += --output-sync=target
 
-.PHONY: test test-template test-cluster test-minimal test-full test-persistence test-replication test-failover test-ha test-tls test-acl cluster-create cluster-delete cluster-exists clean help
+.PHONY: test test-template test-cluster test-minimal test-full test-persistence test-replication test-failover test-ha test-tls test-acl test-performance cluster-create cluster-delete cluster-exists clean help
 
 help:
 	@echo "Targets:"
@@ -18,6 +18,7 @@ help:
 	@echo "  test-failover   - Run Sentinel failover tests (needs an existing replication release)"
 	@echo "  test-tls        - Run replication-over-TLS smoke (opt-in; generates a self-signed cert)"
 	@echo "  test-acl        - Run ACL tests (standalone restricted user + replication locked default)"
+	@echo "  test-performance - Run redis-benchmark throughput baseline (opt-in; standalone)"
 	@echo "  cluster-create  - Create Kind cluster"
 	@echo "  cluster-delete  - Delete Kind cluster"
 	@echo "  clean           - Delete cluster and test namespaces"
@@ -72,6 +73,9 @@ test-failover: cluster-exists
 
 test-tls: cluster-exists
 	@bash $(TESTS_DIR)/test-tls.sh
+
+test-performance: cluster-exists
+	@bash $(TESTS_DIR)/test-performance.sh
 
 test-acl: cluster-exists
 	@bash $(TESTS_DIR)/test-acl.sh

--- a/redis/README.md
+++ b/redis/README.md
@@ -264,16 +264,73 @@ AOF is enabled by default; every write is appended and replayed on startup.
   (list of `{seconds, changes}`) for faster restarts.
 - **Data directory**: `/data`, backed by a PVC when `redis.persistence.enabled: true`.
 
-## Memory Tuning
+## Sizing & performance
 
-Set `redis.config.maxmemory` to ~80% of the container memory limit to leave room for AOF
-rewrite buffers and fragmentation.
+Redis is fast and lightweight; the usual constraint is **memory**, not CPU. Start small and
+scale the memory limit (and `maxmemory` with it) to your working set.
 
-| Container Limit | Recommended maxmemory |
+### Memory
+
+Set `redis.config.maxmemory` to ~80% of the container memory limit. The remaining headroom
+absorbs AOF rewrite buffers, replication backlog, client output buffers, and allocator
+fragmentation — without it the pod gets OOMKilled before `maxmemory-policy` can evict.
+
+| Container limit (`redis.resources.limits.memory`) | Recommended `maxmemory` |
 |----------------|-----------------------|
 | 256Mi | 200mb |
 | 512Mi | 400mb |
 | 1Gi | 800mb |
+| 4Gi | 3200mb |
+
+When the working set exceeds `maxmemory`, the `maxmemory-policy` decides behavior: the
+default `allkeys-lru` evicts least-recently-used keys (cache mode); `noeviction` rejects
+writes instead (datastore mode — use when every key must survive). Watch `evicted_keys` and
+`mem_fragmentation_ratio` (exposed by the exporter) in production.
+
+### CPU
+
+Command execution is **single-threaded**, so one core handles a very high request rate and
+extra cores do *not* raise single-instance throughput. The `1` vCPU default request/limit is
+ample for most workloads. Give more CPU only when you also run heavy background work (RDB
+`save`/AOF rewrite forks, TLS termination, the exporter sidecar) or enable Redis I/O threads.
+Scale **read** capacity horizontally with `architecture: replication` (replicas serve reads),
+not by adding cores.
+
+### Connections
+
+`maxclients` defaults to 10000. Each idle connection costs a few KB plus its output buffer;
+thousands of connections from an app without pooling can dominate memory. Prefer a client-side
+connection pool, and bound noisy clients with `redis.config.client-output-buffer-limit`.
+
+### Throughput baseline
+
+`make -C redis test-performance` runs `redis-benchmark` against a small standalone instance
+(1 vCPU / 512Mi, AOF fsync deferred) and asserts a conservative floor. It's a regression guard
+and a starting point — **measure on your own hardware with your own value sizes**, since rates
+swing widely with CPU, payload size, pipelining, TLS, and `appendfsync`. Rough expectations on
+a single modern core:
+
+| Scenario | Order of magnitude |
+|----------|--------------------|
+| `SET`/`GET`, no pipelining | tens of thousands of ops/s (latency-bound) |
+| `SET`/`GET`, pipelined (`-P 16`) | hundreds of thousands to millions of ops/s |
+| `appendfsync always` | substantially lower writes (one fsync per write) |
+| TLS enabled | lower, from per-connection handshake + encryption cost |
+
+Pipelining and a connection pool usually buy more than any server-side tuning. To benchmark a
+live release yourself:
+
+```bash
+kubectl exec -n <ns> <release>-redis-0 -c redis -- \
+  redis-benchmark -h 127.0.0.1 -q -n 100000 -c 50 -P 16 -t set,get
+```
+
+### Replication & persistence overhead
+
+Each replica holds a full copy of the dataset, so HA (`replication`, 3 pods by default) needs
+~3× the memory of a single instance. `appendfsync everysec` (default) costs little; `always`
+trades throughput for the smallest durability window. RDB `save` and AOF rewrite fork the
+process and briefly raise memory via copy-on-write — another reason for the 20% headroom above.
 
 ## Migrating to 1.0.0
 
@@ -320,6 +377,7 @@ make -C redis test            # full: create cluster, run all suites, delete clu
 make -C redis test-template   # helm lint + template assertions (no cluster)
 make -C redis test-ha         # replication + Sentinel failover (needs a cluster)
 make -C redis test-tls        # replication-over-TLS smoke (opt-in)
+make -C redis test-performance # redis-benchmark throughput baseline (opt-in)
 ```
 
 Declarative unit tests run with `helm unittest -f 'tests/unit/*_test.yaml' redis`.

--- a/redis/README.md
+++ b/redis/README.md
@@ -377,7 +377,7 @@ make -C redis test            # full: create cluster, run all suites, delete clu
 make -C redis test-template   # helm lint + template assertions (no cluster)
 make -C redis test-ha         # replication + Sentinel failover (needs a cluster)
 make -C redis test-tls        # replication-over-TLS smoke (opt-in)
-make -C redis test-performance # redis-benchmark throughput baseline (opt-in)
+make -C redis test-performance # redis-benchmark throughput baseline (opt-in; needs a cluster)
 ```
 
 Declarative unit tests run with `helm unittest -f 'tests/unit/*_test.yaml' redis`.

--- a/redis/tests/test-performance.sh
+++ b/redis/tests/test-performance.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+set -euo pipefail
+
+# Performance baseline: install a single standalone instance sized like a small
+# production cache and run redis-benchmark against it from inside the pod (localhost,
+# no network hop). This is a regression guard, not a precise number — it asserts a
+# conservative throughput floor so a broken/throttled config is caught, and prints the
+# measured rates for the sizing guide. Absolute numbers vary with the runner's CPU.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+source "${SCRIPT_DIR}/helpers.sh"
+
+NAMESPACE="${NAMESPACE:-redis-test-performance}"
+RELEASE="${RELEASE:-redis-perf}"
+# Conservative floor (requests/sec). Even a single throttled CI core clears this by an
+# order of magnitude; tripping it means the instance is fundamentally misconfigured.
+MIN_RPS="${MIN_RPS:-1000}"
+# Keep the run short and deterministic; we want a signal, not an exhaustive sweep.
+REQUESTS="${REQUESTS:-50000}"
+CLIENTS="${CLIENTS:-50}"
+
+FULLNAME=$(resolve_fullname "${RELEASE}" "${CHART_DIR}" "${SCRIPT_DIR}/values-performance.yaml")
+
+begin_suite "Performance Baseline (standalone redis-benchmark)"
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+helm upgrade --install "${RELEASE}" "${CHART_DIR}" \
+  -n "${NAMESPACE}" \
+  -f "${SCRIPT_DIR}/values-performance.yaml" \
+  --wait --timeout 5m
+
+wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=redis" 1 300
+
+POD="${FULLNAME}-0"
+
+ready=$(kubectl get pod -n "${NAMESPACE}" "${POD}" -o jsonpath='{.status.containerStatuses[?(@.name=="redis")].ready}')
+assert_eq "redis container is ready" "true" "${ready}"
+
+# Parse "<rps> requests per second" from redis-benchmark -q output. The -q progress line
+# is rewritten in place with carriage returns and only the final summary carries the
+# "requests per second" phrase, so strip \r and match that phrase directly. We invoke one
+# test per call (-t set OR -t get), so there is exactly one summary line to match.
+# Returns the integer rps (truncated) on stdout, or empty on failure.
+extract_rps() {
+  local output="$1"
+  tr '\r' '\n' <<< "${output}" \
+    | grep -oE '[0-9]+(\.[0-9]+)? requests per second' \
+    | grep -oE '^[0-9]+' \
+    | head -n1
+}
+
+assert_throughput() {
+  local label="$1"      # human description
+  local test_name="$2"  # redis-benchmark -t value (SET / GET)
+  local pipeline="$3"   # -P value
+  local output rps
+
+  echo "  Running redis-benchmark: -t ${test_name,,} -n ${REQUESTS} -c ${CLIENTS} -P ${pipeline}"
+  if ! output=$(kubectl exec -n "${NAMESPACE}" "${POD}" -c redis -- \
+      redis-benchmark -h 127.0.0.1 -p 6379 -q -n "${REQUESTS}" -c "${CLIENTS}" \
+      -P "${pipeline}" -t "${test_name,,}" 2>/dev/null); then
+    fail "${label}" "redis-benchmark exec failed"
+    return
+  fi
+  echo "${output}" | sed 's/^/      /'
+
+  rps=$(extract_rps "${output}")
+  if [[ -z "${rps}" ]]; then
+    fail "${label}" "could not parse throughput from benchmark output"
+    return
+  fi
+
+  if [[ "${rps}" -ge "${MIN_RPS}" ]]; then
+    pass "${label} (${rps} req/s >= ${MIN_RPS} floor)"
+  else
+    fail "${label}" "throughput ${rps} req/s below floor ${MIN_RPS}"
+  fi
+}
+
+# Non-pipelined: latency-bound, the worst case for raw request rate.
+assert_throughput "SET throughput (no pipeline)" "SET" 1
+assert_throughput "GET throughput (no pipeline)" "GET" 1
+# Pipelined: shows the headroom batching unlocks on the same instance.
+assert_throughput "SET throughput (pipeline 16)" "SET" 16
+assert_throughput "GET throughput (pipeline 16)" "GET" 16
+
+# Sanity: the instance is actually serving and observable post-benchmark.
+result=$(redis_exec "${NAMESPACE}" "${POD}" "PING")
+assert_eq "PING returns PONG after load" "PONG" "${result}"
+
+# Surface the realized memory footprint — useful context for the sizing guide.
+used_memory=$(redis_exec "${NAMESPACE}" "${POD}" "INFO memory" | grep "^used_memory_human:" | cut -d: -f2 | tr -d '\r')
+echo "  used_memory after run: ${used_memory:-unknown}"
+
+# Clean up the namespace so repeated runs start fresh.
+helm uninstall "${RELEASE}" -n "${NAMESPACE}" >/dev/null 2>&1 || true
+kubectl delete namespace "${NAMESPACE}" --wait=false >/dev/null 2>&1 || true
+
+end_suite
+print_summary

--- a/redis/tests/test-performance.sh
+++ b/redis/tests/test-performance.sh
@@ -66,7 +66,10 @@ assert_throughput() {
   fi
   echo "${output}" | sed 's/^/      /'
 
-  rps=$(extract_rps "${output}")
+  # `|| true`: extract_rps's grep pipeline exits non-zero on no-match, which under
+  # `set -euo pipefail` would abort the whole suite at this assignment — before the
+  # graceful guard below. Neutralize it so an unparseable result becomes a clean FAIL.
+  rps=$(extract_rps "${output}") || true
   if [[ -z "${rps}" ]]; then
     fail "${label}" "could not parse throughput from benchmark output"
     return
@@ -91,7 +94,9 @@ result=$(redis_exec "${NAMESPACE}" "${POD}" "PING")
 assert_eq "PING returns PONG after load" "PONG" "${result}"
 
 # Surface the realized memory footprint — useful context for the sizing guide.
-used_memory=$(redis_exec "${NAMESPACE}" "${POD}" "INFO memory" | grep "^used_memory_human:" | cut -d: -f2 | tr -d '\r')
+# `|| true`: this is informational only; a grep no-match must not abort the suite
+# (pipefail + set -e) after every assertion has already passed.
+used_memory=$(redis_exec "${NAMESPACE}" "${POD}" "INFO memory" | grep "^used_memory_human:" | cut -d: -f2 | tr -d '\r') || true
 echo "  used_memory after run: ${used_memory:-unknown}"
 
 # No teardown here: like the other suites, the release/namespace are left for the

--- a/redis/tests/test-performance.sh
+++ b/redis/tests/test-performance.sh
@@ -94,9 +94,9 @@ assert_eq "PING returns PONG after load" "PONG" "${result}"
 used_memory=$(redis_exec "${NAMESPACE}" "${POD}" "INFO memory" | grep "^used_memory_human:" | cut -d: -f2 | tr -d '\r')
 echo "  used_memory after run: ${used_memory:-unknown}"
 
-# Clean up the namespace so repeated runs start fresh.
-helm uninstall "${RELEASE}" -n "${NAMESPACE}" >/dev/null 2>&1 || true
-kubectl delete namespace "${NAMESPACE}" --wait=false >/dev/null 2>&1 || true
+# No teardown here: like the other suites, the release/namespace are left for the
+# ephemeral cluster teardown (make cluster-delete / clean). Reruns are idempotent
+# (create-namespace is apply-based and the install is `helm upgrade --install`).
 
 end_suite
 print_summary

--- a/redis/tests/values-performance.yaml
+++ b/redis/tests/values-performance.yaml
@@ -1,0 +1,40 @@
+# Performance baseline fixture: a single standalone instance sized like a small
+# production cache (1 vCPU / 512Mi, maxmemory at ~80% of the limit). Auth and
+# persistence are disabled to isolate raw in-memory throughput from network auth
+# round-trips and fsync cost — the guide documents those overheads separately.
+architecture: standalone
+
+redis:
+  auth:
+    enabled: false
+  podDisruptionBudget:
+    enabled: false
+  image:
+    repository: redis
+    tag: "8.6.2-trixie"
+    pullPolicy: IfNotPresent
+  persistence:
+    enabled: false
+  config:
+    maxmemory: "400mb"
+    maxmemory-policy: "allkeys-lru"
+    # AOF stays enabled (the chart hardcodes appendonly yes), but appendfsync=no defers
+    # flushing to the OS so the benchmark measures CPU-bound throughput, not fsync latency.
+    appendfsync: "no"
+  resources:
+    requests:
+      cpu: "1"
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 512Mi
+
+exporter:
+  enabled: false
+
+networkPolicy:
+  enabled: false
+
+service:
+  type: ClusterIP
+  port: 6379

--- a/redis/tests/values-performance.yaml
+++ b/redis/tests/values-performance.yaml
@@ -34,7 +34,3 @@ exporter:
 
 networkPolicy:
   enabled: false
-
-service:
-  type: ClusterIP
-  port: 6379


### PR DESCRIPTION
Closes #89.

Adds a performance baseline and sizing guidance for the Redis chart. Docs + tests only — **no chart template or values changes**, so rendered output for existing installs is unchanged.

## What's new

- **`make test-performance`** (opt-in, like `test-tls`) — `tests/test-performance.sh` + `tests/values-performance.yaml`. Installs a single standalone instance sized like a small production cache (1 vCPU / 512Mi, `maxmemory 400mb`, AOF fsync deferred), runs `redis-benchmark` from inside the pod, and asserts a conservative throughput floor (`MIN_RPS=1000`). It's a regression guard + starting point, not a precise number; it prints SET/GET rates (non-pipelined and `-P 16`) and the realized `used_memory`.
- **README "Sizing & performance" guide** — replaces the short "Memory Tuning" note with: `maxmemory` headroom table (incl. 4Gi), single-threaded CPU guidance (scale reads via replication, not cores), `maxclients`/connection-pool notes, an order-of-magnitude throughput table, a copy-paste `kubectl exec … redis-benchmark` snippet, and replication/persistence (`appendfsync`, fork CoW) overhead.

## Why opt-in, not in the default gate

`test-performance` is excluded from `test-cluster` for the same reason as `test-tls`: it's a benchmark/baseline, not a correctness assertion, and timing-dependent floors don't belong in the merge gate. The floor is set an order of magnitude below observed rates so it only trips on a fundamentally broken/throttled config.

## Verification

- `make test-performance` on kind: 6/6 pass — SET ~88k / GET ~96k req/s non-pipelined, 1.2M / 1.9M pipelined.
- `test-template.sh`: 88/88. `helm unittest`: 112/112. `helm lint`: clean.
- redis-benchmark `-q` output parsing validated against a real `redis:8.6.2-trixie` (handles the carriage-return progress line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `make test-performance` workflow to benchmark Redis throughput and sanity-check results.
  * Added a “Sizing & performance” README section with memory, CPU, connection, and overhead guidance.
* **Tests**
  * New performance benchmark suite runs pipelined and non-pipelined `SET/GET`, validates a configurable minimum RPS, and reports memory context.
* **Documentation**
  * Updated the Redis chart README and added Redis chart release notes for version **1.3.1**.
* **Chores**
  * Bumped the Redis Helm chart version to **1.3.1** and added a performance values preset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->