### PR TITLE
feat(redis): Grafana dashboard (1.4.0) (#95)

### DIFF
--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -12,8 +12,10 @@ installs render no new objects).
   keys, AOF/RDB persistence status, and replication health (#95).
 - Configurable sidecar `label`/`labelValue`, ConfigMap `namespace`, `additionalLabels`, and
   `annotations` (e.g. `grafana_folder`). The dashboard's `datasource`/`namespace`/`service`/
-  `instance` template variables make one dashboard serve both standalone and replication and
-  any number of releases (#95).
+  `pod` template variables make one dashboard serve both standalone and replication and
+  any number of releases. The dashboard assumes the chart's ServiceMonitor (Prometheus
+  Operator) scrape path for its `namespace`/`service`/`pod` target labels — the same labels
+  the bundled alerts use (#95).
 
 ## 1.3.1 - 2026-06-29
 

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.4.0 - 2026-06-30
+
+Grafana dashboard (additive; `exporter.dashboards.enabled` defaults `false`, so existing
+installs render no new objects).
+
+### Added
+- `exporter.dashboards.*` — ship `dashboards/redis-dashboard.json` as a ConfigMap labeled for
+  Grafana sidecar auto-discovery. Covers memory/fragmentation, hit/miss ratio, connected and
+  blocked clients, command throughput and per-command latency, keyspace and evicted/expired
+  keys, AOF/RDB persistence status, and replication health (#95).
+- Configurable sidecar `label`/`labelValue`, ConfigMap `namespace`, `additionalLabels`, and
+  `annotations` (e.g. `grafana_folder`). The dashboard's `datasource`/`namespace`/`service`/
+  `instance` template variables make one dashboard serve both standalone and replication and
+  any number of releases (#95).
+
 ## 1.3.1 - 2026-06-29
 
 Sizing guidance and a throughput baseline (docs + tests only; no chart template or values

--- a/redis/Chart.yaml
+++ b/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: Redis standalone or Sentinel-managed HA replication, with ACLs, TLS, AOF persistence, and a Prometheus metrics exporter
 type: application
-version: 1.3.1
+version: 1.4.0
 appVersion: "8"
 home: https://github.com/cagriekin/charts/tree/master/redis
 icon: https://www.vectorlogo.zone/logos/redis/redis-icon.svg

--- a/redis/README.md
+++ b/redis/README.md
@@ -281,11 +281,19 @@ exporter:
     # namespace: monitoring
 ```
 
-The dashboard has `datasource`, `namespace`, `service`, and `instance` template variables, so
-one dashboard covers both standalone and replication and any number of releases — pick the
-release via `service` and drill into individual pods via `instance`. It is gated on
-`exporter.enabled`; with the exporter off, nothing is rendered. No Grafana sidecar? Import the
-JSON file directly through the Grafana UI.
+The dashboard has `datasource`, `namespace`, `service`, and `pod` template variables, so one
+dashboard covers both standalone and replication and any number of releases — pick the release
+via `service` and drill into individual members via `pod`. It is gated on `exporter.enabled`;
+with the exporter off, nothing is rendered. No Grafana sidecar? Import the JSON file directly
+through the Grafana UI.
+
+> **Scrape labels.** Panels and variables filter on the `namespace`, `service`, and `pod`
+> labels — the target labels the Prometheus Operator adds when scraping through the chart's
+> ServiceMonitor (`exporter.serviceMonitor.enabled`, default `true`). This is the same scrape
+> path the bundled alerts assume. If you scrape with a plain `scrape_config` or Prometheus
+> Agent instead, relabel those three labels onto the series or the panels read empty. When
+> `exporter.dashboards.namespace` points the ConfigMap at a namespace outside the release,
+> `helm uninstall` will not reap it — remove it yourself.
 
 ## Persistence
 

--- a/redis/README.md
+++ b/redis/README.md
@@ -284,8 +284,23 @@ exporter:
 The dashboard has `datasource`, `namespace`, `service`, and `pod` template variables, so one
 dashboard covers both standalone and replication and any number of releases — pick the release
 via `service` and drill into individual members via `pod`. It is gated on `exporter.enabled`;
-with the exporter off, nothing is rendered. No Grafana sidecar? Import the JSON file directly
-through the Grafana UI.
+with the exporter off, nothing is rendered.
+
+For the sidecar to import it automatically, three things must line up — otherwise the
+ConfigMap is created but silently ignored:
+
+1. **The dashboard sidecar is enabled.** In kube-prometheus-stack that is
+   `grafana.sidecar.dashboards.enabled: true` (default on); a plain Grafana with no sidecar
+   never sees the ConfigMap — import the JSON through the Grafana UI instead.
+2. **The label matches.** `exporter.dashboards.label`/`labelValue` must equal what the sidecar
+   watches for (`grafana.sidecar.dashboards.label`/`labelValue`). The defaults here
+   (`grafana_dashboard: "1"`) match the kube-prometheus-stack default.
+3. **The namespace is watched.** By default the sidecar only watches its own namespace. If
+   Grafana and this release live in different namespaces, either run the sidecar with
+   `searchNamespace: ALL` (or a list including this one), or set `exporter.dashboards.namespace`
+   to a namespace the sidecar watches. The `grafana_folder` annotation likewise only takes
+   effect when the sidecar has folder-annotation support enabled (on by default in
+   kube-prometheus-stack).
 
 > **Scrape labels.** Panels and variables filter on the `namespace`, `service`, and `pod`
 > labels — the target labels the Prometheus Operator adds when scraping through the chart's

--- a/redis/README.md
+++ b/redis/README.md
@@ -230,6 +230,10 @@ window.
 | `exporter.exportClientList` | Export per-client metrics via `CLIENT LIST` (expensive) | `false` |
 | `exporter.disableExporterMetrics` | Disable go-runtime metrics from the exporter itself | `false` |
 | `exporter.extraEnvVars` | Additional env vars for the exporter container (supports `value` and `valueFrom`) | `[]` |
+| `exporter.dashboards.enabled` | Ship the Grafana dashboard as a sidecar-discoverable ConfigMap | `false` |
+| `exporter.dashboards.label` / `labelValue` | Label the Grafana sidecar watches for | `grafana_dashboard` / `"1"` |
+| `exporter.dashboards.namespace` | ConfigMap namespace (empty = release namespace) | `""` |
+| `exporter.dashboards.additionalLabels` / `annotations` | Extra labels / annotations (e.g. `grafana_folder`) | `{}` / `{}` |
 
 ## Monitoring
 
@@ -254,6 +258,34 @@ All new options apply to both architectures (replication sidecar and standalone 
   exporter process itself; useful when you want only Redis metrics in the scraped output.
 - **`extraEnvVars`** — pass any other `REDIS_EXPORTER_*` flag (e.g. a Lua script path via
   `REDIS_EXPORTER_SCRIPT`, or `REDIS_EXPORTER_MAX_DISTINCT_KEY_GROUPS`).
+
+### Grafana dashboard
+
+A ready-made dashboard ships with the chart (`dashboards/redis-dashboard.json`): memory and
+fragmentation, hit/miss ratio, connected/blocked clients, command throughput and per-command
+latency, keyspace and evicted/expired keys, AOF/RDB persistence status, and replication
+health. Set `exporter.dashboards.enabled: true` to render it as a ConfigMap that the Grafana
+sidecar ([kiwigrid/k8s-sidecar](https://github.com/kiwigrid/k8s-sidecar), bundled with the
+Grafana and kube-prometheus-stack charts) auto-imports:
+
+```yaml
+exporter:
+  dashboards:
+    enabled: true
+    # Match whatever your Grafana install watches for; "1" is the common default.
+    label: grafana_dashboard
+    labelValue: "1"
+    # Optional: drop it in a Grafana folder and/or a namespace the sidecar watches.
+    annotations:
+      grafana_folder: Redis
+    # namespace: monitoring
+```
+
+The dashboard has `datasource`, `namespace`, `service`, and `instance` template variables, so
+one dashboard covers both standalone and replication and any number of releases — pick the
+release via `service` and drill into individual pods via `instance`. It is gated on
+`exporter.enabled`; with the exporter off, nothing is rendered. No Grafana sidecar? Import the
+JSON file directly through the Grafana UI.
 
 ## Persistence
 

--- a/redis/dashboards/redis-dashboard.json
+++ b/redis/dashboards/redis-dashboard.json
@@ -54,7 +54,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "min(redis_up{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "expr": "min(redis_up{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"})",
           "legendFormat": "up",
           "refId": "A"
         }
@@ -87,7 +87,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "max(redis_uptime_in_seconds{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "expr": "max(redis_uptime_in_seconds{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"})",
           "legendFormat": "uptime",
           "refId": "A"
         }
@@ -120,7 +120,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(redis_connected_clients{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "expr": "sum(redis_connected_clients{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"})",
           "legendFormat": "clients",
           "refId": "A"
         }
@@ -153,7 +153,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "max(redis_memory_used_bytes{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"} / (redis_memory_max_bytes{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"} > 0)) * 100",
+          "expr": "max(redis_memory_used_bytes{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"} / (redis_memory_max_bytes{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"} > 0)) * 100",
           "legendFormat": "mem %",
           "refId": "A"
         }
@@ -188,7 +188,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(rate(redis_keyspace_hits_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m])) / (sum(rate(redis_keyspace_hits_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m])) + sum(rate(redis_keyspace_misses_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m])))",
+          "expr": "sum(rate(redis_keyspace_hits_total{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}[5m])) / (sum(rate(redis_keyspace_hits_total{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}[5m])) + sum(rate(redis_keyspace_misses_total{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}[5m])))",
           "legendFormat": "hit ratio",
           "refId": "A"
         }
@@ -221,7 +221,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "max(redis_connected_slaves{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "expr": "max(redis_connected_slaves{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"})",
           "legendFormat": "replicas",
           "refId": "A"
         }
@@ -278,20 +278,20 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "redis_memory_used_bytes{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
-          "legendFormat": "used - {{instance}}",
+          "expr": "redis_memory_used_bytes{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}",
+          "legendFormat": "used - {{pod}}",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "redis_memory_used_rss_bytes{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
-          "legendFormat": "rss - {{instance}}",
+          "expr": "redis_memory_used_rss_bytes{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}",
+          "legendFormat": "rss - {{pod}}",
           "refId": "B"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "redis_memory_max_bytes{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"} > 0",
-          "legendFormat": "maxmemory - {{instance}}",
+          "expr": "redis_memory_max_bytes{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"} > 0",
+          "legendFormat": "maxmemory - {{pod}}",
           "refId": "C"
         }
       ],
@@ -337,8 +337,8 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "redis_mem_fragmentation_ratio{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
-          "legendFormat": "{{instance}}",
+          "expr": "redis_mem_fragmentation_ratio{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}",
+          "legendFormat": "{{pod}}",
           "refId": "A"
         }
       ],
@@ -392,8 +392,8 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "rate(redis_commands_processed_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m])",
-          "legendFormat": "{{instance}}",
+          "expr": "rate(redis_commands_processed_total{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "{{pod}}",
           "refId": "A"
         }
       ],
@@ -439,14 +439,14 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "redis_connected_clients{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
-          "legendFormat": "connected - {{instance}}",
+          "expr": "redis_connected_clients{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}",
+          "legendFormat": "connected - {{pod}}",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "redis_blocked_clients{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
-          "legendFormat": "blocked - {{instance}}",
+          "expr": "redis_blocked_clients{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}",
+          "legendFormat": "blocked - {{pod}}",
           "refId": "B"
         }
       ],
@@ -503,13 +503,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(rate(redis_keyspace_hits_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(redis_keyspace_hits_total{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}[5m]))",
           "legendFormat": "hits",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(rate(redis_keyspace_misses_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(redis_keyspace_misses_total{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}[5m]))",
           "legendFormat": "misses",
           "refId": "B"
         }
@@ -556,13 +556,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (db) (redis_db_keys{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "expr": "sum by (db) (redis_db_keys{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"})",
           "legendFormat": "keys - {{db}}",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (db) (redis_db_keys_expiring{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "expr": "sum by (db) (redis_db_keys_expiring{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"})",
           "legendFormat": "expiring - {{db}}",
           "refId": "B"
         }
@@ -617,7 +617,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "topk(10, sum by (cmd) (rate(redis_commands_duration_seconds_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m])) / sum by (cmd) (rate(redis_commands_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m])))",
+          "expr": "topk(10, sum by (cmd) (rate(redis_commands_duration_seconds_total{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}[5m])) / sum by (cmd) (rate(redis_commands_total{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}[5m])))",
           "legendFormat": "{{cmd}}",
           "refId": "A"
         }
@@ -666,13 +666,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(rate(redis_evicted_keys_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(redis_evicted_keys_total{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}[5m]))",
           "legendFormat": "evicted",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(rate(redis_expired_keys_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(redis_expired_keys_total{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}[5m]))",
           "legendFormat": "expired",
           "refId": "B"
         }
@@ -715,20 +715,20 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "redis_aof_last_write_status{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
-          "legendFormat": "AOF write - {{instance}}",
+          "expr": "redis_aof_last_write_status{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}",
+          "legendFormat": "AOF write - {{pod}}",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "redis_aof_last_bgrewrite_status{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
-          "legendFormat": "AOF rewrite - {{instance}}",
+          "expr": "redis_aof_last_bgrewrite_status{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}",
+          "legendFormat": "AOF rewrite - {{pod}}",
           "refId": "B"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "redis_rdb_last_bgsave_status{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
-          "legendFormat": "RDB bgsave - {{instance}}",
+          "expr": "redis_rdb_last_bgsave_status{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}",
+          "legendFormat": "RDB bgsave - {{pod}}",
           "refId": "C"
         }
       ],
@@ -776,13 +776,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "max(redis_rdb_changes_since_last_save{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "expr": "max(redis_rdb_changes_since_last_save{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"})",
           "legendFormat": "changes since last save",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "time() - max(redis_rdb_last_save_timestamp_seconds{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "expr": "time() - min(redis_rdb_last_save_timestamp_seconds{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"})",
           "legendFormat": "time since last save",
           "refId": "B"
         }
@@ -837,14 +837,14 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "redis_connected_slaves{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
-          "legendFormat": "connected replicas - {{instance}}",
+          "expr": "redis_connected_slaves{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}",
+          "legendFormat": "connected replicas - {{pod}}",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "redis_master_link_up{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
-          "legendFormat": "master link up - {{instance}}",
+          "expr": "redis_master_link_up{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}",
+          "legendFormat": "master link up - {{pod}}",
           "refId": "B"
         }
       ],
@@ -890,13 +890,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(rate(redis_net_input_bytes_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(redis_net_input_bytes_total{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}[5m]))",
           "legendFormat": "in",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(rate(redis_net_output_bytes_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(redis_net_output_bytes_total{namespace=\"$namespace\", service=\"$service\", pod=~\"$pod\"}[5m]))",
           "legendFormat": "out",
           "refId": "B"
         }
@@ -958,14 +958,14 @@
       {
         "current": {},
         "datasource": { "type": "prometheus", "uid": "${datasource}" },
-        "definition": "label_values(redis_up{namespace=\"$namespace\", service=\"$service\"}, instance)",
+        "definition": "label_values(redis_up{namespace=\"$namespace\", service=\"$service\"}, pod)",
         "hide": 0,
         "includeAll": true,
-        "label": "Instance",
+        "label": "Pod",
         "multi": true,
-        "name": "instance",
+        "name": "pod",
         "options": [],
-        "query": { "query": "label_values(redis_up{namespace=\"$namespace\", service=\"$service\"}, instance)", "refId": "instance" },
+        "query": { "query": "label_values(redis_up{namespace=\"$namespace\", service=\"$service\"}, pod)", "refId": "pod" },
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/redis/dashboards/redis-dashboard.json
+++ b/redis/dashboards/redis-dashboard.json
@@ -1,0 +1,983 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Redis metrics from oliver006/redis_exporter: memory, hit/miss ratio, clients, command latency, keyspace, AOF/RDB persistence, and replication.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Whether each scraped Redis instance is up.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "red", "text": "DOWN" }, "1": { "color": "green", "text": "UP" } }, "type": "value" }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "min(redis_up{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "legendFormat": "up",
+          "refId": "A"
+        }
+      ],
+      "title": "Status",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Longest current uptime across the selected instances.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max(redis_uptime_in_seconds{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "legendFormat": "uptime",
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Total client connections across the selected instances.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(redis_connected_clients{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "legendFormat": "clients",
+          "refId": "A"
+        }
+      ],
+      "title": "Connected clients",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Used memory as a percentage of maxmemory. Shows N/A when maxmemory is 0 (unbounded).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "max": 100,
+          "min": 0,
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 75 }, { "color": "red", "value": 90 } ] },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "id": 4,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max(redis_memory_used_bytes{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"} / (redis_memory_max_bytes{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"} > 0)) * 100",
+          "legendFormat": "mem %",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory used %",
+      "type": "gauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Keyspace hit ratio over the last 5 minutes: hits / (hits + misses).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "max": 1,
+          "min": 0,
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "yellow", "value": 0.5 }, { "color": "green", "value": 0.9 } ] },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(redis_keyspace_hits_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m])) / (sum(rate(redis_keyspace_hits_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m])) + sum(rate(redis_keyspace_misses_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m])))",
+          "legendFormat": "hit ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Hit ratio (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Replicas connected to the master.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "id": 6,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max(redis_connected_slaves{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "legendFormat": "replicas",
+          "refId": "A"
+        }
+      ],
+      "title": "Connected replicas",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 101,
+      "panels": [],
+      "title": "Memory",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Used memory, resident set size (RSS), and the maxmemory limit per instance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "bytes"
+        },
+        "overrides": [
+          { "matcher": { "id": "byRegexp", "options": ".*max.*" }, "properties": [ { "id": "custom.lineStyle", "value": { "dash": [ 10, 10 ], "fill": "dash" } }, { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } } ] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 7,
+      "options": {
+        "legend": { "calcs": [ "lastNotNull", "max" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "redis_memory_used_bytes{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
+          "legendFormat": "used - {{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "redis_memory_used_rss_bytes{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
+          "legendFormat": "rss - {{instance}}",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "redis_memory_max_bytes{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"} > 0",
+          "legendFormat": "maxmemory - {{instance}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Memory usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Ratio of RSS to used memory. Sustained values well above 1.5 indicate fragmentation; below 1 indicates swapping.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 8,
+      "options": {
+        "legend": { "calcs": [ "lastNotNull" ], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "redis_mem_fragmentation_ratio{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory fragmentation ratio",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 102,
+      "panels": [],
+      "title": "Throughput & clients",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Commands processed per second (operations/sec).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "id": 9,
+      "options": {
+        "legend": { "calcs": [ "lastNotNull", "max" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(redis_commands_processed_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m])",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Commands processed / sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Connected and blocked clients per instance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "id": 10,
+      "options": {
+        "legend": { "calcs": [ "lastNotNull", "max" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "redis_connected_clients{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
+          "legendFormat": "connected - {{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "redis_blocked_clients{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
+          "legendFormat": "blocked - {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Clients",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "id": 103,
+      "panels": [],
+      "title": "Keyspace & cache efficiency",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Keyspace hits and misses per second.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ops"
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "misses" }, "properties": [ { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } } ] },
+          { "matcher": { "id": "byName", "options": "hits" }, "properties": [ { "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } } ] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": [ "lastNotNull" ], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(redis_keyspace_hits_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m]))",
+          "legendFormat": "hits",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(redis_keyspace_misses_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m]))",
+          "legendFormat": "misses",
+          "refId": "B"
+        }
+      ],
+      "title": "Keyspace hits / misses",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Total keys and keys with a TTL, summed per database.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "id": 12,
+      "options": {
+        "legend": { "calcs": [ "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (db) (redis_db_keys{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "legendFormat": "keys - {{db}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (db) (redis_db_keys_expiring{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "legendFormat": "expiring - {{db}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Keys per database",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "id": 104,
+      "panels": [],
+      "title": "Command latency & evictions",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Average per-call duration by command over the last 5 minutes (total call time / calls). Top movers only.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "id": 13,
+      "options": {
+        "legend": { "calcs": [ "lastNotNull", "max" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "topk(10, sum by (cmd) (rate(redis_commands_duration_seconds_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m])) / sum by (cmd) (rate(redis_commands_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m])))",
+          "legendFormat": "{{cmd}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Avg command latency (top 10)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Keys evicted (maxmemory pressure) and expired (TTL) per second.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ops"
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "evicted" }, "properties": [ { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } } ] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "id": 14,
+      "options": {
+        "legend": { "calcs": [ "lastNotNull" ], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(redis_evicted_keys_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m]))",
+          "legendFormat": "evicted",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(redis_expired_keys_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m]))",
+          "legendFormat": "expired",
+          "refId": "B"
+        }
+      ],
+      "title": "Evicted / expired keys",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 41 },
+      "id": 105,
+      "panels": [],
+      "title": "Persistence (AOF / RDB)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Last AOF and RDB background-save status per instance. OK = last operation succeeded.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "red", "text": "FAIL" }, "1": { "color": "green", "text": "OK" } }, "type": "value" }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 42 },
+      "id": 15,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "redis_aof_last_write_status{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
+          "legendFormat": "AOF write - {{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "redis_aof_last_bgrewrite_status{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
+          "legendFormat": "AOF rewrite - {{instance}}",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "redis_rdb_last_bgsave_status{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
+          "legendFormat": "RDB bgsave - {{instance}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Persistence status",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Writes not yet persisted to RDB, and time since the last successful RDB save.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "short"
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "time since last save" }, "properties": [ { "id": "unit", "value": "s" }, { "id": "custom.axisPlacement", "value": "right" } ] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 42 },
+      "id": 16,
+      "options": {
+        "legend": { "calcs": [ "lastNotNull", "max" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max(redis_rdb_changes_since_last_save{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "legendFormat": "changes since last save",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "time() - max(redis_rdb_last_save_timestamp_seconds{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"})",
+          "legendFormat": "time since last save",
+          "refId": "B"
+        }
+      ],
+      "title": "RDB save backlog",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 50 },
+      "id": 106,
+      "panels": [],
+      "title": "Replication & network",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Replica link health (1 = up) and the number of replicas connected to the master.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 51 },
+      "id": 17,
+      "options": {
+        "legend": { "calcs": [ "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "redis_connected_slaves{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
+          "legendFormat": "connected replicas - {{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "redis_master_link_up{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}",
+          "legendFormat": "master link up - {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Replication health",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Network bytes in and out per second.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 51 },
+      "id": 18,
+      "options": {
+        "legend": { "calcs": [ "lastNotNull", "max" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(redis_net_input_bytes_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m]))",
+          "legendFormat": "in",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(redis_net_output_bytes_total{namespace=\"$namespace\", service=\"$service\", instance=~\"$instance\"}[5m]))",
+          "legendFormat": "out",
+          "refId": "B"
+        }
+      ],
+      "title": "Network I/O",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [ "redis" ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "definition": "label_values(redis_up, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": { "query": "label_values(redis_up, namespace)", "refId": "namespace" },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "definition": "label_values(redis_up{namespace=\"$namespace\"}, service)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Service",
+        "multi": false,
+        "name": "service",
+        "options": [],
+        "query": { "query": "label_values(redis_up{namespace=\"$namespace\"}, service)", "refId": "service" },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "definition": "label_values(redis_up{namespace=\"$namespace\", service=\"$service\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": { "query": "label_values(redis_up{namespace=\"$namespace\", service=\"$service\"}, instance)", "refId": "instance" },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Redis",
+  "uid": "redis-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/redis/templates/dashboard-configmap.yaml
+++ b/redis/templates/dashboard-configmap.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.exporter.enabled .Values.exporter.dashboards.enabled }}
+{{- /* Grafana dashboard for the Redis metrics exporter. The sidecar in the
+       Grafana chart (kiwigrid/k8s-sidecar) discovers ConfigMaps carrying the
+       configured label and imports every *.json entry. */}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "redis.fullname" . }}-dashboard
+  {{- with .Values.exporter.dashboards.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+    {{ .Values.exporter.dashboards.label }}: {{ .Values.exporter.dashboards.labelValue | quote }}
+    {{- with .Values.exporter.dashboards.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.exporter.dashboards.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  redis-dashboard.json: |-
+{{ .Files.Get "dashboards/redis-dashboard.json" | indent 4 }}
+{{- end }}

--- a/redis/templates/dashboard-configmap.yaml
+++ b/redis/templates/dashboard-configmap.yaml
@@ -11,8 +11,8 @@ metadata:
   {{- end }}
   labels:
     {{- include "redis.labels" . | nindent 4 }}
-    app.kubernetes.io/component: redis
-    {{ .Values.exporter.dashboards.label }}: {{ .Values.exporter.dashboards.labelValue | quote }}
+    app.kubernetes.io/component: metrics
+    {{ .Values.exporter.dashboards.label | quote }}: {{ .Values.exporter.dashboards.labelValue | quote }}
     {{- with .Values.exporter.dashboards.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/redis/tests/unit/dashboard_test.yaml
+++ b/redis/tests/unit/dashboard_test.yaml
@@ -1,0 +1,90 @@
+suite: dashboard
+templates:
+  - templates/dashboard-configmap.yaml
+tests:
+  - it: disabled by default - no dashboard ConfigMap
+    release:
+      name: r
+    values:
+      - ../values-minimal.yaml
+    set:
+      exporter.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: enabled - renders a labeled ConfigMap carrying the dashboard JSON
+    release:
+      name: r
+    values:
+      - ../values-minimal.yaml
+    set:
+      exporter.enabled: true
+      exporter.dashboards.enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: r-redis-dashboard
+      - equal:
+          path: metadata.labels["grafana_dashboard"]
+          value: "1"
+      - isNotEmpty:
+          path: data["redis-dashboard.json"]
+      - matchRegex:
+          path: data["redis-dashboard.json"]
+          pattern: '"uid": "redis-overview"'
+
+  - it: requires the exporter - dashboards.enabled alone renders nothing
+    release:
+      name: r
+    values:
+      - ../values-minimal.yaml
+    set:
+      exporter.enabled: false
+      exporter.dashboards.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: honors a custom sidecar label and value
+    release:
+      name: r
+    values:
+      - ../values-minimal.yaml
+    set:
+      exporter.enabled: true
+      exporter.dashboards.enabled: true
+      exporter.dashboards.label: my_dashboards
+      exporter.dashboards.labelValue: redis
+    asserts:
+      - equal:
+          path: metadata.labels["my_dashboards"]
+          value: redis
+      - notExists:
+          path: metadata.labels["grafana_dashboard"]
+
+  - it: honors namespace override, extra labels, and annotations
+    release:
+      name: r
+    values:
+      - ../values-minimal.yaml
+    set:
+      exporter.enabled: true
+      exporter.dashboards.enabled: true
+      exporter.dashboards.namespace: monitoring
+      exporter.dashboards.additionalLabels:
+        team: platform
+      exporter.dashboards.annotations:
+        grafana_folder: Redis
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: monitoring
+      - equal:
+          path: metadata.labels["team"]
+          value: platform
+      - equal:
+          path: metadata.annotations["grafana_folder"]
+          value: Redis

--- a/redis/values.schema.json
+++ b/redis/values.schema.json
@@ -165,8 +165,14 @@
             "label": { "type": "string", "minLength": 1 },
             "labelValue": { "type": "string" },
             "namespace": { "type": "string" },
-            "additionalLabels": { "type": "object" },
-            "annotations": { "type": "object" }
+            "additionalLabels": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
           }
         }
       }

--- a/redis/values.schema.json
+++ b/redis/values.schema.json
@@ -157,7 +157,18 @@
         "includeSystemMetrics":   { "type": "boolean" },
         "exportClientList":       { "type": "boolean" },
         "disableExporterMetrics": { "type": "boolean" },
-        "extraEnvVars": { "type": "array" }
+        "extraEnvVars": { "type": "array" },
+        "dashboards": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "label": { "type": "string", "minLength": 1 },
+            "labelValue": { "type": "string" },
+            "namespace": { "type": "string" },
+            "additionalLabels": { "type": "object" },
+            "annotations": { "type": "object" }
+          }
+        }
       }
     },
     "service": {

--- a/redis/values.yaml
+++ b/redis/values.yaml
@@ -266,6 +266,20 @@ exporter:
     enabled: false
     additionalLabels: {}
     rules: []
+  # Grafana dashboard, shipped as a ConfigMap for the Grafana sidecar to import.
+  dashboards:
+    enabled: false
+    # Label the Grafana sidecar watches for (kiwigrid/k8s-sidecar). The value is
+    # whatever your Grafana install was configured with (commonly "1").
+    label: grafana_dashboard
+    labelValue: "1"
+    # Namespace for the dashboard ConfigMap. Empty defaults to the release
+    # namespace; set it if your Grafana sidecar watches a specific namespace.
+    namespace: ""
+    # Extra labels on the ConfigMap (e.g. to target a specific Grafana instance).
+    additionalLabels: {}
+    # Annotations on the ConfigMap (e.g. grafana_folder for the sidecar).
+    annotations: {}
 
   # Connection timeout for the exporter when connecting to Redis.
   # Uses Go duration syntax (e.g. "5s", "15s"). Empty leaves the exporter default (15s).


### PR DESCRIPTION
Closes #95.

Ships a ready-made Grafana dashboard for the Redis metrics exporter, gated behind `exporter.dashboards.enabled` (default `false`) so existing installs render no new objects.

## What

- **`dashboards/redis-dashboard.json`** — 18 panels across overview, memory, throughput/clients, keyspace/cache efficiency, command latency/evictions, persistence (AOF/RDB), and replication/network. Covers everything the issue asked for: memory usage, hit/miss ratio, connected clients, command latency, keyspace stats, AOF status.
- **`templates/dashboard-configmap.yaml`** — renders the JSON into a ConfigMap labeled `grafana_dashboard: "1"` for the Grafana sidecar ([kiwigrid/k8s-sidecar](https://github.com/kiwigrid/k8s-sidecar)) to auto-import. Gated on `exporter.enabled`.
- **`exporter.dashboards.*` values** — configurable sidecar `label`/`labelValue`, ConfigMap `namespace`, `additionalLabels`, and `annotations` (e.g. `grafana_folder`).

The dashboard has `datasource`, `namespace`, `service`, and `instance` template variables, so one dashboard serves both standalone and replication and any number of releases. Built around the `oliver006/redis_exporter` metric names already used by the chart's PrometheusRule.

## Verification

- `helm lint` clean
- helm-unittest: **117 tests** pass (new `dashboard_test.yaml`: enabled/disabled, exporter gate, custom label, namespace/labels/annotations overrides)
- bash template suite: **88** pass
- Embedded JSON round-trips out of the rendered ConfigMap and re-parses (title/uid/panels intact)

Docs + CHANGELOG (1.4.0) updated. No template or values changes to the data path — additive and default-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in Redis Grafana dashboard shipped as a Kubernetes ConfigMap for sidecar auto-import (guarded by `exporter.dashboards.enabled`, default `false`).
  * Configured via `exporter.dashboards.*` (sidecar label/labelValue, ConfigMap namespace, and optional additional labels/annotations).
  * Dashboard covers key Redis health/performance, persistence, and replication panels.
* **Documentation**
  * Updated README with dashboard behavior, templating variables, and a values example; updated changelog.
* **Configuration**
  * Extended values and values schema with `exporter.dashboards` options.
* **Tests**
  * Added unit tests validating ConfigMap rendering and override scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->