### PR TITLE
fix(pg,pgvector): backup integrity check survives SIGPIPE on dumps > pipe buffer (1.4.1) (#230)

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,24 @@
 # pg chart changelog
 
+## 1.4.1 - 2026-06-30
+
+Chart-only fix. No image change (`trixie-5.5.0-27`).
+
+### Fixed
+
+- **Backup integrity check no longer aborts on dumps larger than the pipe buffer (#230).**
+  The `backup.enabled` (pg_dump → S3) integrity step (`mc cat … | pg_restore --list`) ran
+  under `set -o pipefail`. `pg_restore --list` reads only the header + TOC at the front of a
+  `-Fc` dump, so on any dump exceeding the OS pipe buffer (~64 KB — i.e. any real database)
+  it exits 0 while `mc cat` is still streaming; `mc cat` was then SIGPIPE-killed (exit 141)
+  and `pipefail` propagated that, aborting the Job *before* the staged `.tmp` object was
+  promoted to its canonical `backup_<ts>.dump` name — so no usable backup was ever published
+  and the CronJob never recorded a success. The check now reads `pg_restore`'s own exit
+  status via `PIPESTATUS[1]` and tolerates `mc cat`'s expected SIGPIPE, while a genuine
+  `pg_restore` parse failure stays fatal. The integration test now seeds a table whose
+  `-Fc` dump exceeds the pipe buffer so the SIGPIPE path is covered in CI. Inherited by
+  `pgvector` via its symlinked template.
+
 ## 1.4.0 - 2026-06-26
 
 Chart-only feature. No image change (`trixie-5.5.0-27`).

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -13,9 +13,11 @@ Chart-only fix. No image change (`trixie-5.5.0-27`).
   it exits 0 while `mc cat` is still streaming; `mc cat` was then SIGPIPE-killed (exit 141)
   and `pipefail` propagated that, aborting the Job *before* the staged `.tmp` object was
   promoted to its canonical `backup_<ts>.dump` name — so no usable backup was ever published
-  and the CronJob never recorded a success. The check now reads `pg_restore`'s own exit
-  status via `PIPESTATUS[1]` and tolerates `mc cat`'s expected SIGPIPE, while a genuine
-  `pg_restore` parse failure stays fatal. The integration test now seeds a table whose
+  and the CronJob never recorded a success. The check now disables `errexit`/`pipefail`
+  around the pipe and inspects both ends via `PIPESTATUS`: `pg_restore` must succeed and
+  `mc cat` may only exit `141` (SIGPIPE) — a genuine `pg_restore` parse failure **or** a
+  real `mc cat` S3-read error both stay fatal, so a damaged dump is never published as
+  verified. The integration test now seeds a table whose
   `-Fc` dump exceeds the pipe buffer so the SIGPIPE path is covered in CI. Inherited by
   `pgvector` via its symlinked template.
 

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with repmgr replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/templates/backup-configmap.yaml
+++ b/pg/templates/backup-configmap.yaml
@@ -114,10 +114,22 @@ data:
 
     # Stream the integrity check instead of buffering the whole dump to /tmp on the
     # container's (unbounded, unsized) writable layer -- a large DB could otherwise hit
-    # node-disk eviction (#119). pg_restore --list reads the TOC from stdin; under
-    # pipefail a failure in mc cat or pg_restore aborts the job.
+    # node-disk eviction (#119). pg_restore --list reads only the header + TOC at the
+    # front of a -Fc dump; it does NOT consume the data blocks. On any dump larger than
+    # the OS pipe buffer (~64 KB) pg_restore exits 0 while `mc cat` is still streaming,
+    # `mc cat` is then SIGPIPE-killed (exit 141), and pipefail would propagate that and
+    # abort the Job *before* the publish step -- so no backup is ever produced (#230).
+    # Check the CONSUMER's (pg_restore) status via PIPESTATUS and tolerate mc's SIGPIPE:
+    # a genuine pg_restore parse failure is still fatal.
     echo "Verifying backup integrity via pg_restore --list..."
+    set +o pipefail
     mc cat "s3/${S3_TMP}" | pg_restore --list > /dev/null
+    rc=${PIPESTATUS[1]}
+    set -o pipefail
+    if [ "$rc" -ne 0 ]; then
+      echo "ERROR: backup integrity check failed (pg_restore --list exit $rc)" >&2
+      exit 1
+    fi
     echo "Backup integrity verified"
 
     # Integrity confirmed -> publish the staged object to the canonical name. mc mv is

--- a/pg/templates/backup-configmap.yaml
+++ b/pg/templates/backup-configmap.yaml
@@ -119,15 +119,29 @@ data:
     # the OS pipe buffer (~64 KB) pg_restore exits 0 while `mc cat` is still streaming,
     # `mc cat` is then SIGPIPE-killed (exit 141), and pipefail would propagate that and
     # abort the Job *before* the publish step -- so no backup is ever produced (#230).
-    # Check the CONSUMER's (pg_restore) status via PIPESTATUS and tolerate mc's SIGPIPE:
-    # a genuine pg_restore parse failure is still fatal.
+    # Disable BOTH pipefail and errexit around the pipe so we can inspect each end via
+    # PIPESTATUS rather than aborting on the first non-zero (and so the diagnostics below
+    # actually run on a failure instead of being skipped by `set -e` at the pipe). The
+    # consumer (pg_restore) must succeed; the producer (mc cat) may exit 141 (128+SIGPIPE)
+    # because pg_restore closed the read end early -- that is expected -- but any OTHER
+    # mc cat failure (a real S3 read error / mid-stream truncation) is still fatal, so a
+    # damaged read can never be published as "verified".
     echo "Verifying backup integrity via pg_restore --list..."
-    set +o pipefail
+    set +o pipefail +e
     mc cat "s3/${S3_TMP}" | pg_restore --list > /dev/null
-    rc=${PIPESTATUS[1]}
-    set -o pipefail
-    if [ "$rc" -ne 0 ]; then
-      echo "ERROR: backup integrity check failed (pg_restore --list exit $rc)" >&2
+    # Copy the WHOLE array in one statement: any later command (even a bare assignment)
+    # resets PIPESTATUS, so reading [0] then [1] on separate lines would leave [1] unset
+    # (fatal under set -u). Index the snapshot instead.
+    rc=( "${PIPESTATUS[@]}" )
+    set -e -o pipefail
+    rc_cat=${rc[0]}
+    rc_restore=${rc[1]}
+    if [ "$rc_restore" -ne 0 ]; then
+      echo "ERROR: backup integrity check failed (pg_restore --list exit $rc_restore)" >&2
+      exit 1
+    fi
+    if [ "$rc_cat" -ne 0 ] && [ "$rc_cat" -ne 141 ]; then
+      echo "ERROR: reading the staged dump for verification failed (mc cat exit $rc_cat)" >&2
       exit 1
     fi
     echo "Backup integrity verified"

--- a/pg/tests/test-backup-restore.sh
+++ b/pg/tests/test-backup-restore.sh
@@ -147,10 +147,13 @@ assert_eq "backup-validation job completed successfully (#31)" "0" "${val_status
 
 echo "Verifying backup exists in S3..."
 # Dumps are namespaced per release under <prefix>/<fullname>/ (#143), so list that subpath.
+# Filter to the canonical backup_<ts>.dump JSON line (rejecting any *.tmp stage) so both
+# the existence and the #230 size assertion below measure the PUBLISHED dump, never a
+# leftover stage or an unrelated object that happened to sort first.
 kubectl run mc-check -n "${NAMESPACE}" --restart=Never --image=minio/mc:RELEASE.2024-11-21T17-21-54Z \
   --command -- sh -c "
     mc alias set s3 http://minio:9000 minioadmin '${S3_SECRET}' &&
-    mc ls s3/pg-backups/backups/${FULLNAME}/ --json | head -1
+    mc ls s3/pg-backups/backups/${FULLNAME}/ --json | grep -E '\"key\":\"backup_[^\"]*\\.dump\"' | head -1
   "
 kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/mc-check -n "${NAMESPACE}" --timeout=120s
 backup_file=$(kubectl logs -n "${NAMESPACE}" mc-check | tail -1)

--- a/pg/tests/test-backup-restore.sh
+++ b/pg/tests/test-backup-restore.sh
@@ -153,10 +153,12 @@ echo "Verifying backup exists in S3..."
 kubectl run mc-check -n "${NAMESPACE}" --restart=Never --image=minio/mc:RELEASE.2024-11-21T17-21-54Z \
   --command -- sh -c "
     mc alias set s3 http://minio:9000 minioadmin '${S3_SECRET}' &&
-    mc ls s3/pg-backups/backups/${FULLNAME}/ --json | grep -E '\"key\":\"backup_[^\"]*\\.dump\"' | head -1
+    mc ls s3/pg-backups/backups/${FULLNAME}/ --json
   "
 kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/mc-check -n "${NAMESPACE}" --timeout=120s
-backup_file=$(kubectl logs -n "${NAMESPACE}" mc-check | tail -1)
+# Filter host-side (the mc image ships no grep): the canonical backup_<ts>.dump JSON
+# line, rejecting any *.tmp stage, so the size assertion below measures the published dump.
+backup_file=$(kubectl logs -n "${NAMESPACE}" mc-check | grep -E '"key":"backup_[^"]*\.dump"' | head -1)
 kubectl delete pod mc-check -n "${NAMESPACE}" --wait=false
 
 if echo "${backup_file}" | grep -q '"size"'; then

--- a/pg/tests/test-backup-restore.sh
+++ b/pg/tests/test-backup-restore.sh
@@ -105,6 +105,18 @@ pg_exec "${NAMESPACE}" "${POD}" "INSERT INTO backup_test (value) VALUES ('before
 row_count_before=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT count(*) FROM backup_test" "testuser" "testdb")
 assert_eq "inserted 3 rows before backup" "3" "${row_count_before}"
 
+# #230 regression guard: pg_restore --list only reads the header + TOC at the front
+# of a -Fc dump, so on any dump LARGER than the OS pipe buffer (~64 KB) it exits 0
+# while `mc cat` is still streaming -- mc is then SIGPIPE-killed and (pre-fix) pipefail
+# aborted the whole Job before publishing, so no backup was ever produced. Seed a table
+# whose dump far exceeds the pipe buffer (high-entropy md5 text resists -Fc compression)
+# so the backup job below exercises the SIGPIPE path; the fix must let it complete.
+echo "Seeding a large table so the -Fc dump exceeds the 64 KB pipe buffer (#230)..."
+pg_exec "${NAMESPACE}" "${POD}" "CREATE TABLE backup_big (id int PRIMARY KEY, payload text)" "testuser" "testdb"
+pg_exec "${NAMESPACE}" "${POD}" "INSERT INTO backup_big SELECT g, md5(random()::text) FROM generate_series(1, 50000) g" "testuser" "testdb"
+big_count=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT count(*) FROM backup_big" "testuser" "testdb")
+assert_eq "seeded 50000 rows for the >64 KB dump (#230)" "50000" "${big_count}"
+
 # NOTE (#143/#159 coverage): the retention DELETE (mc find --name 'backup_*.dump'
 # --older-than ${RETENTION_DAYS}d) and the stale-stage sweep (--older-than 1d) are
 # day-granular and mc cannot back-date an S3 object, so they cannot be exercised in a
@@ -148,6 +160,16 @@ if echo "${backup_file}" | grep -q '"size"'; then
   pass "backup file exists in S3"
 else
   fail "backup file exists in S3" "no file found"
+fi
+
+# #230: prove the published dump actually exceeds the 64 KB pipe buffer, so the backup
+# job above genuinely traversed the SIGPIPE integrity-check path (not a sub-buffer dump
+# that would pass even with the bug present).
+backup_size=$(echo "${backup_file}" | grep -o '"size":[0-9]*' | grep -o '[0-9]*' | head -1)
+if [ -n "${backup_size}" ] && [ "${backup_size}" -gt 65536 ]; then
+  pass "#230: published dump exceeds the 64 KB pipe buffer (${backup_size} bytes)"
+else
+  fail "#230: published dump exceeds the 64 KB pipe buffer" "size=${backup_size:-unknown}"
 fi
 
 echo "Dropping test data..."

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -1360,6 +1360,9 @@ assert_not_contains "#119: backup verify does not buffer the dump to /tmp" "${ba
 # the Job before publishing. The fix wraps the pipe in set +o pipefail / PIPESTATUS[1].
 assert_contains "#230: integrity check reads pg_restore's status via PIPESTATUS" "${backup_configmap}" 'rc=${PIPESTATUS\[1\]}'
 assert_contains "#230: integrity check tolerates mc cat SIGPIPE (pipefail disabled around the pipe)" "${backup_configmap}" "set +o pipefail"
+# ...and pipefail is restored afterward, so the rest of backup.sh keeps its
+# fail-on-pipe-error behavior (the disable is scoped to the integrity pipe only).
+assert_contains "#230: pipefail restored after the integrity pipe" "${backup_configmap}" "set -o pipefail"
 # #143: dumps are namespaced per release and retention is scoped to this release's
 # own dump objects, so a shared bucket/prefix can never delete another release's backups.
 # needles are regex-safe (assert_contains greps as a regex): avoid the *. in backup_*.dump

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -1354,6 +1354,12 @@ assert_contains "backup: pg_restore verification present" "${backup_configmap}" 
 # fill the node on a large DB).
 assert_contains "#119: backup verify is streamed to pg_restore" "${backup_configmap}" "| pg_restore --list"
 assert_not_contains "#119: backup verify does not buffer the dump to /tmp" "${backup_configmap}" "verify_backup.dump"
+# #230: the integrity check must check pg_restore's own exit status via PIPESTATUS and
+# tolerate mc cat's SIGPIPE -- pg_restore --list closes the stream after the TOC, so on
+# any dump > the ~64 KB pipe buffer mc is SIGPIPE-killed and bare pipefail would abort
+# the Job before publishing. The fix wraps the pipe in set +o pipefail / PIPESTATUS[1].
+assert_contains "#230: integrity check reads pg_restore's status via PIPESTATUS" "${backup_configmap}" 'rc=${PIPESTATUS\[1\]}'
+assert_contains "#230: integrity check tolerates mc cat SIGPIPE (pipefail disabled around the pipe)" "${backup_configmap}" "set +o pipefail"
 # #143: dumps are namespaced per release and retention is scoped to this release's
 # own dump objects, so a shared bucket/prefix can never delete another release's backups.
 # needles are regex-safe (assert_contains greps as a regex): avoid the *. in backup_*.dump

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -1354,15 +1354,22 @@ assert_contains "backup: pg_restore verification present" "${backup_configmap}" 
 # fill the node on a large DB).
 assert_contains "#119: backup verify is streamed to pg_restore" "${backup_configmap}" "| pg_restore --list"
 assert_not_contains "#119: backup verify does not buffer the dump to /tmp" "${backup_configmap}" "verify_backup.dump"
-# #230: the integrity check must check pg_restore's own exit status via PIPESTATUS and
-# tolerate mc cat's SIGPIPE -- pg_restore --list closes the stream after the TOC, so on
-# any dump > the ~64 KB pipe buffer mc is SIGPIPE-killed and bare pipefail would abort
-# the Job before publishing. The fix wraps the pipe in set +o pipefail / PIPESTATUS[1].
-assert_contains "#230: integrity check reads pg_restore's status via PIPESTATUS" "${backup_configmap}" 'rc=${PIPESTATUS\[1\]}'
-assert_contains "#230: integrity check tolerates mc cat SIGPIPE (pipefail disabled around the pipe)" "${backup_configmap}" "set +o pipefail"
-# ...and pipefail is restored afterward, so the rest of backup.sh keeps its
-# fail-on-pipe-error behavior (the disable is scoped to the integrity pipe only).
-assert_contains "#230: pipefail restored after the integrity pipe" "${backup_configmap}" "set -o pipefail"
+# #230: the integrity check must inspect BOTH ends of the pipe via PIPESTATUS, not rely
+# on pipefail. pg_restore --list closes the stream after the TOC, so on any dump > the
+# ~64 KB pipe buffer mc cat is SIGPIPE-killed (141) and bare pipefail would abort the Job
+# before publishing. The fix disables errexit+pipefail around the pipe so it can require
+# pg_restore success while tolerating ONLY mc cat's SIGPIPE -- a real mc cat read error
+# stays fatal -- and so the diagnostics run instead of being skipped by set -e at the pipe.
+# Needles are regex-safe (assert_contains greps as BRE): escaped brackets, no ${ }.
+assert_contains "#230: integrity check snapshots both pipe statuses via PIPESTATUS" "${backup_configmap}" 'PIPESTATUS\[@\]'
+assert_contains "#230: errexit+pipefail disabled around the integrity pipe" "${backup_configmap}" "set +o pipefail +e"
+# ...and both are restored afterward, so the rest of backup.sh keeps its fail-fast
+# behavior (the disable is scoped to the integrity pipe only).
+assert_contains "#230: errexit+pipefail restored after the integrity pipe" "${backup_configmap}" "set -e -o pipefail"
+# The consumer (pg_restore) must succeed...
+assert_contains "#230: pg_restore (consumer) failure is fatal" "${backup_configmap}" "rc_restore"
+# ...and a non-SIGPIPE mc cat (producer) failure stays fatal -- only 141 is tolerated.
+assert_contains "#230: only mc cat SIGPIPE (141) is tolerated, other producer failures fatal" "${backup_configmap}" "ne 141"
 # #143: dumps are namespaced per release and retention is scoped to this release's
 # own dump objects, so a shared bucket/prefix can never delete another release's backups.
 # needles are regex-safe (assert_contains greps as a regex): avoid the *. in backup_*.dump

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -11,8 +11,8 @@ CHANGELOG for full detail.
   The `backup.enabled` (pg_dump → S3) integrity step (`mc cat … | pg_restore --list`) was
   SIGPIPE-killed and aborted by `pipefail` on any dump exceeding the ~64 KB pipe buffer
   (any real database), before the staged `.tmp` object was promoted — so no backup was ever
-  published. The check now reads `pg_restore`'s exit status via `PIPESTATUS[1]` and tolerates
-  `mc cat`'s SIGPIPE.
+  published. The check now inspects both ends of the pipe via `PIPESTATUS`: `pg_restore`
+  must succeed and `mc cat` may only exit `141` (SIGPIPE), so a real read error stays fatal.
 
 ## 1.4.0 - 2026-06-26
 

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,19 @@
 # pgvector chart changelog
 
+## 1.4.1 - 2026-06-30
+
+Chart-only fix inherited from pg's symlinked templates. No image change. See the pg
+CHANGELOG for full detail.
+
+### Fixed
+
+- **Backup integrity check no longer aborts on dumps larger than the pipe buffer (#230).**
+  The `backup.enabled` (pg_dump → S3) integrity step (`mc cat … | pg_restore --list`) was
+  SIGPIPE-killed and aborted by `pipefail` on any dump exceeding the ~64 KB pipe buffer
+  (any real database), before the staged `.tmp` object was promoted — so no backup was ever
+  published. The check now reads `pg_restore`'s exit status via `PIPESTATUS[1]` and tolerates
+  `mc cat`'s SIGPIPE.
+
 ## 1.4.0 - 2026-06-26
 
 Chart-only feature inherited from pg's symlinked templates. No image change

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus repmgr replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg


### PR DESCRIPTION
Fixes #230.

## Problem

The `backup.enabled` (pg_dump → S3) integrity check ran the staged dump through `mc cat … | pg_restore --list` under `set -o pipefail`. `pg_restore --list` reads only the header + TOC at the front of a `-Fc` dump — it does **not** consume the data blocks — so on any dump larger than the OS pipe buffer (~64 KB, i.e. any real database) it exits 0 while `mc cat` is still streaming. `mc cat` is then SIGPIPE-killed (exit 141), `pipefail` propagates that non-zero status, and `set -e` aborts the Job **before** the staged `.tmp` object is promoted to its canonical `backup_<ts>.dump` name. Result: no usable backup is ever published, the CronJob never records a success, and `PostgresBackupStale`/`PostgresBackupFailed` eventually fire.

CI didn't catch it because the backup test seeded only 3 tiny rows, whose entire `-Fc` dump fits inside the pipe buffer (so `mc cat` finishes before `pg_restore` closes the read end and SIGPIPE never occurs).

## Fix

`pg/templates/backup-configmap.yaml` — wrap the integrity pipe so it checks the **consumer's** (`pg_restore`) exit status via `PIPESTATUS[1]` and tolerates `mc cat`'s expected SIGPIPE. A genuine `pg_restore` parse failure stays fatal.

```bash
set +o pipefail
mc cat "s3/${S3_TMP}" | pg_restore --list > /dev/null
rc=${PIPESTATUS[1]}
set -o pipefail
if [ "$rc" -ne 0 ]; then
  echo "ERROR: backup integrity check failed (pg_restore --list exit $rc)" >&2
  exit 1
fi
```

`pgvector` inherits the fix via its symlinked `backup-configmap.yaml`.

## Regression coverage

- `tests/test-backup-restore.sh` now seeds a 50k-row table of high-entropy `md5()` text so the `-Fc` dump far exceeds the 64 KB pipe buffer, and asserts the published dump is `> 65536` bytes — so the backup job genuinely traverses the SIGPIPE path. Pre-fix this job would fail with `BackoffLimitExceeded`.
- `tests/test-template.sh` asserts the rendered script uses `PIPESTATUS[1]` and disables `pipefail` around the pipe.

## Verification

- `helm lint pg` / `helm lint pgvector` — clean.
- `test-template.sh` — 857 passed, 0 failed.
- `helm unittest` — pg 37/37, pgvector 10/10.

Patch bump: pg & pgvector `1.4.0` → `1.4.1` (chart-only fix, no image change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backup integrity verification to handle large dumps without aborting during restore/listing checks.
  * Improved streaming integrity verification to tolerate expected producer SIGPIPE behavior while still failing on genuine pg restore/list errors.
* **Tests**
  * Added regression coverage for backup restores involving data that exceeds the typical pipe buffer and tightened verification of the published dump artifact.
* **Chores**
  * Bumped the chart version to **1.4.1** (including the pgvector chart).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->