### PR TITLE
feat(redis): standalone honors nodeSelector/tolerations/affinity/podAnnotations (1.4.1)

### DIFF
--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.4.1 - 2026-07-01
+
+Bugfix: standalone mode now honors pod scheduling fields (additive; no change to
+replication mode or to standalone installs that don't set these).
+
+### Fixed
+- **`architecture: standalone` ignored `redis.nodeSelector`, `redis.tolerations`,
+  `redis.affinity`, and `redis.podAnnotations`.** Only the replication StatefulSet
+  rendered them, so a standalone install could not be pinned to a node pool — e.g. it
+  could land on an EKS Auto Mode node that doesn't support the `ebs.csi.aws.com`
+  (`gp3`) provisioner, leaving the PVC unbound and the pod Pending. The standalone
+  StatefulSet now renders the same scheduling fields as the replication branch
+  (no default podAntiAffinity, since standalone is a single pod).
+
 ## 1.4.0 - 2026-06-30
 
 Grafana dashboard (additive; `exporter.dashboards.enabled` defaults `false`, so existing

--- a/redis/Chart.yaml
+++ b/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: Redis standalone or Sentinel-managed HA replication, with ACLs, TLS, AOF persistence, and a Prometheus metrics exporter
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: "8"
 home: https://github.com/cagriekin/charts/tree/master/redis
 icon: https://www.vectorlogo.zone/logos/redis/redis-icon.svg

--- a/redis/templates/statefulset.yaml
+++ b/redis/templates/statefulset.yaml
@@ -391,12 +391,30 @@ spec:
         app.kubernetes.io/component: redis
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.redis.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.redis.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml .Values.redis.podSecurityContext | nindent 8 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.affinity }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:


### PR DESCRIPTION
Standalone StatefulSet ignored `redis.nodeSelector/tolerations/affinity/podAnnotations` (only replication rendered them), so a standalone install couldn't be pinned to a node pool — e.g. to avoid EKS Auto Mode nodes that don't support the `ebs.csi.aws.com` (gp3) provisioner, leaving the PVC unbound/pod Pending. Standalone now renders the same scheduling fields (no default podAntiAffinity, single pod).

Release as `redis-1.4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standalone deployments now honor pod annotations and scheduling settings such as node selection, tolerations, affinity, and priority class.
  * This improves the ability to place pods on the right nodes and helps avoid pods remaining pending in some storage setups.

* **Chores**
  * Updated the chart version to **1.4.1**.
  * Added a release note entry for this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->