### PR TITLE
feat(redis): document PVC lifecycle + add persistence.retain knob (1.5.0) (#91)

### DIFF
--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.5.0 - 2026-07-01
+
+PVC lifecycle documentation and a retention knob (additive; `redis.persistence.retain`
+defaults `true`, which renders no new manifest fields — existing installs are unchanged).
+
+### Added
+- `redis.persistence.retain` (default `true`) — controls the StatefulSet
+  `persistentVolumeClaimRetentionPolicy`. `true` keeps data PVCs on uninstall and
+  scale-down (no policy emitted; relies on the Kubernetes default `Retain`, so rendered
+  output matches earlier versions). `false` emits
+  `persistentVolumeClaimRetentionPolicy: {whenDeleted: Delete, whenScaled: Delete}` so
+  PVCs are garbage-collected on uninstall and scale-down — for ephemeral/dev installs
+  (requires Kubernetes 1.27+). Applies to both replication and standalone (#91).
+- README "PVC lifecycle & reclaim behavior" section: PVC naming, why `helm uninstall`
+  leaves PVCs behind, the `retain` knob, manual cleanup commands, the interaction with
+  the PV/`storageClass` reclaim policy, and recovering data from orphaned PVCs (#91).
+
 ## 1.4.1 - 2026-07-01
 
 Bugfix: standalone mode now honors pod scheduling fields (additive; no change to

--- a/redis/Chart.yaml
+++ b/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: Redis standalone or Sentinel-managed HA replication, with ACLs, TLS, AOF persistence, and a Prometheus metrics exporter
 type: application
-version: 1.4.1
+version: 1.5.0
 appVersion: "8"
 home: https://github.com/cagriekin/charts/tree/master/redis
 icon: https://www.vectorlogo.zone/logos/redis/redis-icon.svg

--- a/redis/README.md
+++ b/redis/README.md
@@ -217,6 +217,7 @@ window.
 |-----------|-------------|---------|
 | `redis.image.repository` / `redis.image.tag` | Redis image | `redis` / `8.6.2-trixie` |
 | `redis.persistence.enabled` / `size` / `storageClass` | Persistence | `true` / `1Gi` / `""` |
+| `redis.persistence.retain` | Keep data PVCs on uninstall / scale-down (`false` = auto-delete) | `true` |
 | `redis.resources` | Requests/limits | see `values.yaml` |
 | `redis.config.maxmemory` / `maxmemory-policy` | Memory cap / eviction | `200mb` / `allkeys-lru` |
 | `redis.config.appendfsync` | AOF sync (`always`/`everysec`/`no`) | `everysec` |
@@ -318,6 +319,54 @@ AOF is enabled by default; every write is appended and replayed on startup.
 - **RDB snapshots**: off by default (`save ""`); enable via `redis.config.rdbSnapshots`
   (list of `{seconds, changes}`) for faster restarts.
 - **Data directory**: `/data`, backed by a PVC when `redis.persistence.enabled: true`.
+
+### PVC lifecycle & reclaim behavior
+
+Persistent volumes are provisioned from the StatefulSet's `volumeClaimTemplates`, one PVC
+per pod named `data-<release>-redis-<ordinal>` (e.g. `data-myredis-redis-0`). Because the
+PVCs are created by the StatefulSet controller — not rendered by Helm — **`helm uninstall`
+does not delete them**, and neither does deleting the StatefulSet directly. This is
+deliberate: your data (AOF/RDB) survives an accidental uninstall or a chart re-install.
+
+**Retention is controlled by `redis.persistence.retain` (default `true`):**
+
+- **`retain: true` (default)** — PVCs are kept when the release is uninstalled and when
+  replicas are scaled down. The chart emits no `persistentVolumeClaimRetentionPolicy`, so
+  it relies on Kubernetes' own default (`Retain` for both `whenDeleted` and `whenScaled`).
+  Rendered output is unchanged from earlier chart versions.
+- **`retain: false`** — the StatefulSet is rendered with
+  `persistentVolumeClaimRetentionPolicy: {whenDeleted: Delete, whenScaled: Delete}`, so
+  PVCs are garbage-collected on uninstall **and** when you scale `replicaCount` down. Use
+  this only for ephemeral or dev installs where losing the data is acceptable. Requires
+  Kubernetes 1.27+ (the feature is stable since 1.32; on older clusters the field is
+  ignored and PVCs are retained).
+
+> The retention policy governs only controller/uninstall-driven deletion. It does not
+> protect against manually deleting a PVC, and it does not affect the underlying
+> PersistentVolume's own reclaim policy (see below).
+
+**Manual cleanup.** With the default `retain: true`, reclaim the storage yourself after an
+uninstall:
+
+```sh
+# list the orphaned claims for a release
+kubectl get pvc -l app.kubernetes.io/instance=<release> -n <namespace>
+
+# delete them (irreversible — this frees the underlying PV per its reclaim policy)
+kubectl delete pvc -l app.kubernetes.io/instance=<release> -n <namespace>
+```
+
+Whether the backing PersistentVolume (and cloud disk) is then deleted or kept depends on
+the **PV reclaim policy** set by your `storageClass` — usually `Delete` for dynamically
+provisioned cloud volumes, `Retain` if you want the disk to outlive the PVC. Check with
+`kubectl get pv` / `kubectl get storageclass -o wide`.
+
+**Recovering data from an orphaned PVC.** A reinstall with the same release name and the
+same PVC naming (same ordinals, same `storageClass`/`size`) will bind to the existing
+`data-<release>-redis-<ordinal>` claims and start from their AOF/RDB — no extra steps. To
+recover into a *different* release, pre-create PVCs with the new release's expected names
+bound to the retained PVs (set the PV's `claimRef` accordingly), or copy the data out of a
+temporary pod that mounts the old PVC before deleting it.
 
 ## Sizing & performance
 

--- a/redis/templates/_helpers.tpl
+++ b/redis/templates/_helpers.tpl
@@ -202,6 +202,15 @@ exec redis-server /config-rw/redis.conf
 {{- add (int .Values.redis.replicaCount) 1 }}
 {{- end }}
 
+{{- /* PVC retention policy shared by the replication and standalone StatefulSets. Rendered
+       only when persistence.retain is false (guarded at each call site); retain: true keeps
+       PVCs by relying on the Kubernetes default, so nothing is emitted. */ -}}
+{{- define "redis.pvcRetentionPolicy" -}}
+persistentVolumeClaimRetentionPolicy:
+  whenDeleted: Delete
+  whenScaled: Delete
+{{- end -}}
+
 {{- /* Sentinel quorum: explicit override (incl. an out-of-range value, which the
        validate guard then rejects), else a strict majority of the pods. */ -}}
 {{- define "redis.quorum" -}}

--- a/redis/templates/statefulset.yaml
+++ b/redis/templates/statefulset.yaml
@@ -343,6 +343,11 @@ spec:
           emptyDir: {}
         {{- end }}
   {{- if .Values.redis.persistence.enabled }}
+  {{- if not .Values.redis.persistence.retain }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -524,6 +529,11 @@ spec:
           emptyDir: {}
         {{- end }}
   {{- if .Values.redis.persistence.enabled }}
+  {{- if not .Values.redis.persistence.retain }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/redis/templates/statefulset.yaml
+++ b/redis/templates/statefulset.yaml
@@ -344,9 +344,7 @@ spec:
         {{- end }}
   {{- if .Values.redis.persistence.enabled }}
   {{- if not .Values.redis.persistence.retain }}
-  persistentVolumeClaimRetentionPolicy:
-    whenDeleted: Delete
-    whenScaled: Delete
+  {{- include "redis.pvcRetentionPolicy" . | nindent 2 }}
   {{- end }}
   volumeClaimTemplates:
     - metadata:
@@ -530,9 +528,7 @@ spec:
         {{- end }}
   {{- if .Values.redis.persistence.enabled }}
   {{- if not .Values.redis.persistence.retain }}
-  persistentVolumeClaimRetentionPolicy:
-    whenDeleted: Delete
-    whenScaled: Delete
+  {{- include "redis.pvcRetentionPolicy" . | nindent 2 }}
   {{- end }}
   volumeClaimTemplates:
     - metadata:

--- a/redis/tests/unit/statefulset_test.yaml
+++ b/redis/tests/unit/statefulset_test.yaml
@@ -346,3 +346,49 @@ tests:
           content:
             name: REDIS_EXPORTER_SCRIPT
             value: /scripts/custom.lua
+
+  - it: default - persistence.retain true emits no PVC retention policy
+    template: templates/statefulset.yaml
+    set:
+      redis.persistence.enabled: true
+      redis.persistence.retain: true
+    asserts:
+      - notExists:
+          path: spec.persistentVolumeClaimRetentionPolicy
+
+  - it: replication - persistence.retain false sets PVC retention policy to Delete
+    template: templates/statefulset.yaml
+    set:
+      redis.persistence.enabled: true
+      redis.persistence.retain: false
+    asserts:
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Delete
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Delete
+
+  - it: standalone - persistence.retain false sets PVC retention policy to Delete
+    template: templates/statefulset.yaml
+    set:
+      architecture: standalone
+      redis.persistence.enabled: true
+      redis.persistence.retain: false
+    asserts:
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Delete
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Delete
+
+  - it: standalone - persistence.retain true emits no PVC retention policy
+    template: templates/statefulset.yaml
+    set:
+      architecture: standalone
+      redis.persistence.enabled: true
+      redis.persistence.retain: true
+    asserts:
+      - notExists:
+          path: spec.persistentVolumeClaimRetentionPolicy

--- a/redis/values.schema.json
+++ b/redis/values.schema.json
@@ -22,6 +22,15 @@
           "type": "integer",
           "minimum": 0
         },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "storageClass": { "type": "string" },
+            "size": { "type": "string" },
+            "retain": { "type": "boolean" }
+          }
+        },
         "auth": {
           "type": "object",
           "properties": {

--- a/redis/values.yaml
+++ b/redis/values.yaml
@@ -29,6 +29,11 @@ redis:
     enabled: true
     storageClass: ""
     size: 1Gi
+    # Keep PVCs when the release/StatefulSet is deleted or replicas are scaled down.
+    # true (default) leaves data PVCs behind for recovery (see README "Persistence").
+    # false sets the StatefulSet persistentVolumeClaimRetentionPolicy to Delete, so
+    # PVCs are garbage-collected on uninstall and on scale-down — use for ephemeral/dev.
+    retain: true
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
Closes #91.

PVCs provisioned from the StatefulSet `volumeClaimTemplates` are created by the controller, not rendered by Helm, so `helm uninstall` (and deleting the StatefulSet) leaves them behind. This was undocumented, and there was no way to opt into automatic cleanup.

## Changes

- **`redis.persistence.retain`** (default `true`) — controls the StatefulSet `persistentVolumeClaimRetentionPolicy`.
  - `true` (default): emits **no** policy and relies on Kubernetes' own default (`Retain` for `whenDeleted`/`whenScaled`). Rendered output is byte-identical to earlier versions — verified against `origin/master`.
  - `false`: emits `persistentVolumeClaimRetentionPolicy: {whenDeleted: Delete, whenScaled: Delete}` so PVCs are garbage-collected on uninstall and scale-down. For ephemeral/dev installs. Requires Kubernetes 1.27+ (ignored on older clusters, which retain).
  - Applies to both replication and standalone StatefulSets.
- **README** — new "PVC lifecycle & reclaim behavior" section: PVC naming, why uninstall keeps PVCs, the `retain` knob, manual cleanup commands, interaction with the PV/`storageClass` reclaim policy, and recovering data from orphaned PVCs. Config-table row added.
- **`values.schema.json`** — added the `redis.persistence` object (`enabled`/`storageClass`/`size`/`retain`).
- **Unit tests** — cover both `retain` modes across replication and standalone.

Version bump `1.4.1` → `1.5.0` (additive; default renders no new fields).

## Verification

- `helm lint redis` passes.
- `helm unittest redis` — 121 tests pass (4 new).
- Default (`retain: true`) render diffed against `origin/master`: only the chart-version label differs; no retention policy emitted.
- `retain: false` confirmed to emit the policy at spec level in both replication and standalone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `redis.persistence.retain` to control whether data PVCs are retained or deleted when uninstalling or scaling down.
  - Updated the StatefulSet rendering to apply PVC retention behavior when `retain` is set to delete.
- **Documentation**
  - Documented PVC lifecycle and reclaim behavior, including manual cleanup and recovery guidance for retained/orphaned PVCs.
- **Tests**
  - Added unit tests validating PVC retention policy behavior across replication and standalone modes.
- **Chores**
  - Bumped the Helm chart version to `1.5.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->