### PR TITLE
fix(pg,pgvector): pgbackrest validation restores recovery GUCs from pg_control (1.4.2)

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,25 @@
 # pg chart changelog
 
+## 1.4.2 - 2026-07-05
+
+Chart-only fix. No image change (`trixie-5.5.0-27`).
+
+### Fixed
+
+- **pgBackRest PITR restore-validation no longer fails when the primary raises a
+  recovery-relevant GUC (e.g. `max_connections`).** PostgreSQL refuses to begin archive
+  recovery with `hot_standby=on` unless the recovery instance's `max_connections`,
+  `max_worker_processes`, `max_wal_senders`, `max_prepared_transactions` and
+  `max_locks_per_transaction` are each `>=` the value the primary had when the WAL was
+  written (recorded in `pg_control`). Those tunables live in the chart's `conf.d` overlay,
+  which `validate.sh` strips along with the `include_dir` line — so the throwaway instance
+  fell back to initdb defaults (`max_connections=100`, etc.) and
+  the postmaster died at startup with *"recovery aborted because of insufficient parameter
+  settings"*, failing the validation Job even though the backup itself was fully restorable. The script now reads the required minimums straight from
+  `pg_controldata` (which reports exactly the primary values recovery checks against) and
+  passes them as `pg_ctl` startup overrides, so validation stays green and self-adjusts if
+  the primary is ever retuned. Inherited by `pgvector` via its symlinked template.
+
 ## 1.4.1 - 2026-06-30
 
 Chart-only fix. No image change (`trixie-5.5.0-27`).

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with repmgr replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/templates/pgbackrest-configmap.yaml
+++ b/pg/templates/pgbackrest-configmap.yaml
@@ -101,6 +101,54 @@ data:
     # (listen_addresses='') and discarded when the pod ends.
     printf 'local all all trust\n%s\n' "$(cat "$PGDATA/pg_hba.conf")" > "$PGDATA/pg_hba.conf"
 
+    # PostgreSQL refuses to begin archive recovery with hot_standby=on unless the
+    # recovery instance's max_connections / max_worker_processes / max_wal_senders /
+    # max_prepared_transactions / max_locks_per_transaction are >= the values the
+    # PRIMARY had when the WAL was generated (checked against pg_control). Those
+    # primary values come from the chart's conf.d overlay (any of these tunables raised
+    # above its default), which we stripped above with the include_dir line -- so the
+    # throwaway would fall back to initdb defaults and FATAL with "recovery aborted
+    # because of insufficient parameter settings". pg_controldata reports exactly the
+    # primary values recorded in pg_control, so echo them back as startup overrides
+    # (self-adjusting if the primary is ever retuned). Guarded with `|| CTL=""`: under
+    # `set -e` a non-zero pg_controldata (e.g. a version-mismatched PGDATA vs the newest
+    # installed PG binary picked for PG_BIN above) would otherwise abort the Job HERE,
+    # before recovery is even attempted -- instead we fall through to the recovery
+    # diagnostics below. A single awk pass maps each pg_controldata field to its GUC and
+    # WARNs (rather than silently dropping) if an expected label is absent, so a future
+    # label rename surfaces as a warning instead of a mystifying "recovery did not
+    # promote" failure that silently reintroduces the very bug this guards against.
+    CTL=$(pg_controldata "$PGDATA" 2>/dev/null) || CTL=""
+    REC_OVERRIDES=""
+    if [ -n "$CTL" ]; then
+      REC_OVERRIDES=$(printf '%s\n' "$CTL" | awk '
+        BEGIN {
+          g["max_connections setting"]      = "max_connections"
+          g["max_worker_processes setting"] = "max_worker_processes"
+          g["max_wal_senders setting"]      = "max_wal_senders"
+          g["max_prepared_xacts setting"]   = "max_prepared_transactions"
+          g["max_locks_per_xact setting"]   = "max_locks_per_transaction"
+        }
+        {
+          c = index($0, ":")
+          if (c > 0) {
+            label = substr($0, 1, c - 1); val = substr($0, c + 1)
+            gsub(/^[ \t]+|[ \t]+$/, "", label); gsub(/[ \t]/, "", val)
+            if ((label in g) && val != "") found[label] = val
+          }
+        }
+        END {
+          ov = ""
+          for (label in g) {
+            if (label in found) ov = ov " -c " g[label] "=" found[label]
+            else print "WARN: pg_controldata reported no \"" label "\"; recovery may abort if the source raised " g[label] > "/dev/stderr"
+          }
+          print ov
+        }')
+    else
+      echo "WARN: pg_controldata produced no output; starting recovery without derived GUC overrides (may abort if the source raised a recovery-relevant setting)" >&2
+    fi
+
     echo "Starting the throwaway PostgreSQL to replay WAL (archive recovery)..."
     # recovery.signal (written by restore) makes postgres replay WAL via the
     # restore_command (pgbackrest archive-get, inheriting this container's env for S3
@@ -122,8 +170,9 @@ data:
     #   logging_collector=off + log_destination=stderr : send any startup error to the
     #     -l file so a failure is visible (with logging_collector on it goes to PGDATA/log).
     #   archive_mode=off, hot_standby=on, socket-only : see above.
+    #   $REC_OVERRIDES : per-parameter minimums recovered from pg_control (see above).
     pg_ctl -D "$PGDATA" -w -t 60 -l "$PGDATA/startup.log" \
-      -o "-c listen_addresses='' -c unix_socket_directories=$WORK/run -c port=5432 -c archive_mode=off -c hot_standby=on -c shared_preload_libraries='' -c logging_collector=off -c log_destination=stderr" start \
+      -o "-c listen_addresses='' -c unix_socket_directories=$WORK/run -c port=5432 -c archive_mode=off -c hot_standby=on -c shared_preload_libraries='' -c logging_collector=off -c log_destination=stderr${REC_OVERRIDES}" start \
       || echo "WARN: server not connectable within 60s; polling for recovery/promotion below" >&2
     trap 'pg_ctl -D "$PGDATA" -m immediate -w stop >/dev/null 2>&1 || true' EXIT
 

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,20 @@
 # pgvector chart changelog
 
+## 1.4.2 - 2026-07-05
+
+Chart-only fix inherited from pg's symlinked templates. No image change
+(`trixie-5.5.0-27`). See the pg CHANGELOG for full detail.
+
+### Fixed
+
+- **pgBackRest PITR restore-validation no longer fails when the primary raises a
+  recovery-relevant GUC (e.g. `max_connections`).** The throwaway recovery instance started
+  with initdb defaults (`max_connections=100`) after `validate.sh` strips the `conf.d`
+  overlay, so archive recovery aborted with *"recovery aborted because of insufficient
+  parameter settings"* whenever the primary's value was higher — failing the validation Job
+  despite a fully restorable backup. The script now reads the required minimums from
+  `pg_controldata` and passes them as `pg_ctl` startup overrides.
+
 ## 1.4.1 - 2026-06-30
 
 Chart-only fix inherited from pg's symlinked templates. No image change. See the pg

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus repmgr replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg


### PR DESCRIPTION
## Problem

The pgBackRest PITR restore-validation Job fails at the WAL-replay step whenever the source cluster runs a recovery-relevant GUC above its built-in default. Restore itself succeeds; the throwaway instance then dies at startup with:

```
FATAL: recovery aborted because of insufficient parameter settings
DETAIL: max_connections = 100 is a lower setting than on the primary server, where its value was <higher>.
```

PostgreSQL refuses to begin archive recovery with `hot_standby=on` unless the recovery instance's `max_connections`, `max_worker_processes`, `max_wal_senders`, `max_prepared_transactions` and `max_locks_per_transaction` are each `>=` the value the source had when the WAL was written (recorded in `pg_control`). These tunables are applied through the chart's `conf.d` overlay, which `validate.sh` strips along with the `include_dir` line — so the throwaway instance falls back to initdb defaults (`max_connections=100`) and startup fails, even though the backup is fully restorable.

## Fix

After restore, read the required minimums straight from `pg_controldata` — which reports exactly the source values recovery checks against — and pass them as `pg_ctl` startup overrides. Self-adjusting: if the source cluster's tunables change, validation follows automatically.

## Notes

- Chart-only fix. No image change (`trixie-5.5.0-27`).
- `pgvector` inherits the same `pgbackrest-configmap.yaml` via symlink, so both charts are bumped to `1.4.2`.
- Verified with `bash -n`, `helm lint`, `helm template`, and a server-side dry-run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chart-only PITR restore-validation failing when the primary has recovery-relevant settings above initdb defaults (e.g., `max_connections`).
  * Restore validation now derives required minimums from the restored cluster’s control data and applies them as startup overrides, keeping checks passing after primary tuning.

* **Chores**
  * Bumped Helm chart versions to **1.4.2** (both charts).
  * Added release note entries for the new version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->