### PR TITLE
fix(pg,pgvector): pgpool reaps orphaned SysV shmem before start (1.4.3)

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,25 @@
 # pg chart changelog
 
+## 1.4.3 - 2026-07-11
+
+Chart-only fix. No image change (`trixie-5.5.0-27`).
+
+### Fixed
+
+- **pgpool no longer wedges in a permanent crash loop after repeated container
+  OOM kills.** pgpool allocates its connection-pool state as an `IPC_PRIVATE`
+  SysV shared-memory segment. When the pgpool container is OOM-killed the pod (and
+  its IPC namespace) survives, but SIGKILL can't run `shmctl(IPC_RMID)`, so each
+  restart strands another ~136Mi segment. After enough cycles the pod cgroup fills
+  and the kernel OOM-kills `runc init` before pgpool runs, leaving the pod
+  recoverable only by deletion (#234). The pgpool container now runs `ipcrm -a`
+  to reap orphaned segments before `exec`ing pgpool.
+
+### Added
+
+- **`pgpool.command`** — override the pgpool container startup command. Empty
+  (default) keeps the chart's `ipcrm -a` reap + `exec pgpool` sequence (#234).
+
 ## 1.4.2 - 2026-07-05
 
 Chart-only fix. No image change (`trixie-5.5.0-27`).

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with repmgr replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 1.4.2
+version: 1.4.3
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/README.md
+++ b/pg/README.md
@@ -337,6 +337,7 @@ Two ways to provide etcd:
 | `pgpool.image.tag` | PGPool-II image tag | `4.7.1` |
 | `pgpool.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `pgpool.replicaCount` | Number of PGPool-II instances | `1` |
+| `pgpool.command` | Override the pgpool container startup command. Empty uses the chart default, which runs `ipcrm -a` to reap SysV shmem orphaned by a prior OOM-killed pgpool before `exec`ing pgpool (prevents a cross-restart shmem-accumulation crash loop). Keep the `ipcrm` reap and `exec` if you override. | `[]` |
 | `pgpool.numInitChildren` | Number of worker processes | `32` |
 | `pgpool.maxPool` | Max cached connections per process | `4` |
 | `pgpool.childLifeTime` | Worker process lifetime in seconds | `300` |

--- a/pg/templates/pgpool-deployment.yaml
+++ b/pg/templates/pgpool-deployment.yaml
@@ -212,7 +212,10 @@ spec:
               # wedging the pod in a crash loop recoverable only by pod deletion
               # (#234). The namespace holds nothing but pgpool's own orphans (the
               # exporter sidecar uses no SysV IPC), so `ipcrm -a` is safe here.
-              ipcrm -a 2>/dev/null || true
+              # stderr is left visible (a missing ipcrm or a permission error is a
+              # signal worth logging); `|| true` keeps a no-op reap non-fatal so a
+              # healthy first boot with nothing to remove still starts pgpool.
+              ipcrm -a || true
               exec pgpool -D -n -f /usr/local/etc/pgpool.conf -F /usr/local/etc/pcp.conf -a /usr/local/etc/pool_hba.conf
           {{- end }}
           ports:

--- a/pg/templates/pgpool-deployment.yaml
+++ b/pg/templates/pgpool-deployment.yaml
@@ -197,15 +197,24 @@ spec:
           securityContext:
             {{- toYaml .Values.pgpool.containerSecurityContext | nindent 12 }}
           command:
-            - pgpool
-            - -D
-            - -n
-            - -f
-            - /usr/local/etc/pgpool.conf
-            - -F
-            - /usr/local/etc/pcp.conf
-            - -a
-            - /usr/local/etc/pool_hba.conf
+          {{- with .Values.pgpool.command }}
+            {{- toYaml . | nindent 12 }}
+          {{- else }}
+            - /bin/sh
+            - -c
+            - |
+              # Reap SysV shmem/semaphores orphaned by a prior OOM-killed pgpool in
+              # this pod's IPC namespace before allocating new ones. A container OOM
+              # kill (pod cgroup memory.oom.group=0) leaves the pod -- and its IPC
+              # namespace -- alive, but SIGKILL can't run shmctl(IPC_RMID), so each
+              # restart strands another ~136Mi segment. After enough cycles the pod
+              # cgroup fills and the kernel OOM-kills runc init before pgpool runs,
+              # wedging the pod in a crash loop recoverable only by pod deletion
+              # (#234). The namespace holds nothing but pgpool's own orphans (the
+              # exporter sidecar uses no SysV IPC), so `ipcrm -a` is safe here.
+              ipcrm -a 2>/dev/null || true
+              exec pgpool -D -n -f /usr/local/etc/pgpool.conf -F /usr/local/etc/pcp.conf -a /usr/local/etc/pool_hba.conf
+          {{- end }}
           ports:
             - name: pgpool
               containerPort: 9999

--- a/pg/tests/unit/pgpool_deployment_test.yaml
+++ b/pg/tests/unit/pgpool_deployment_test.yaml
@@ -20,13 +20,12 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].command[1]
           value: -c
+      # Single ordered match: the reap MUST precede exec, or pgpool replaces the
+      # shell before the shmem is cleared and the reap never runs. exec also keeps
+      # pgpool as the container's main process so it still receives SIGTERM.
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ipcrm -a 2>/dev/null \|\| true'
-      # exec keeps pgpool as the container's main process so it still gets SIGTERM
-      - matchRegex:
-          path: spec.template.spec.containers[0].command[2]
-          pattern: 'exec pgpool -D -n -f /usr/local/etc/pgpool.conf -F /usr/local/etc/pcp.conf -a /usr/local/etc/pool_hba.conf'
+          pattern: 'ipcrm -a \|\| true[\s\S]*exec pgpool -D -n -f /usr/local/etc/pgpool.conf -F /usr/local/etc/pcp.conf -a /usr/local/etc/pool_hba.conf'
 
   # --- override: pgpool.command replaces the default verbatim ---
   - it: pgpool.command overrides the default startup command

--- a/pg/tests/unit/pgpool_deployment_test.yaml
+++ b/pg/tests/unit/pgpool_deployment_test.yaml
@@ -1,0 +1,44 @@
+suite: pgpool Deployment startup command
+release:
+  name: test-pg
+# pgpool-deployment computes checksum/* annotations by include-ing the configmap
+# and secret templates, so both must be loaded for the deployment to render.
+templates:
+  - templates/pgpool-deployment.yaml
+  - templates/pgpool-configmap.yaml
+  - templates/pgpool-secret.yaml
+tests:
+  # --- default: ipcrm -a reap wrapper, exec pgpool with the original flags (#234) ---
+  - it: default command reaps orphaned SysV shmem then execs pgpool
+    template: templates/pgpool-deployment.yaml
+    set:
+      pgpool.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command[0]
+          value: /bin/sh
+      - equal:
+          path: spec.template.spec.containers[0].command[1]
+          value: -c
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ipcrm -a 2>/dev/null \|\| true'
+      # exec keeps pgpool as the container's main process so it still gets SIGTERM
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'exec pgpool -D -n -f /usr/local/etc/pgpool.conf -F /usr/local/etc/pcp.conf -a /usr/local/etc/pool_hba.conf'
+
+  # --- override: pgpool.command replaces the default verbatim ---
+  - it: pgpool.command overrides the default startup command
+    template: templates/pgpool-deployment.yaml
+    set:
+      pgpool.enabled: true
+      pgpool.command:
+        - /custom/entrypoint.sh
+        - --flag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/entrypoint.sh
+            - --flag

--- a/pg/values.schema.json
+++ b/pg/values.schema.json
@@ -84,6 +84,11 @@
     "pgpool": {
       "type": "object",
       "properties": {
+        "command": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Override the pgpool container startup command. Empty uses the chart default (ipcrm -a reap + exec pgpool)."
+        },
         "tls": {
           "type": "object",
           "properties": {

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -358,6 +358,14 @@ pgpool:
 
   replicaCount: 1
 
+  # Startup command override for the pgpool container. Empty uses the chart default,
+  # which reaps SysV shmem/semaphores orphaned by a prior OOM-killed pgpool
+  # (`ipcrm -a`) before exec'ing pgpool -- without this, orphaned segments pile up
+  # in the pod's IPC namespace across container restarts until the pod cgroup fills
+  # and wedges in a crash loop (#234). Override only if you need a custom startup
+  # sequence; keep the ipcrm reap and `exec` so pgpool still receives SIGTERM.
+  command: []
+
   numInitChildren: 32
   maxPool: 4
   childLifeTime: 300

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # pgvector chart changelog
 
+## 1.4.3 - 2026-07-11
+
+Chart-only fix inherited from pg's symlinked templates. No image change
+(`trixie-5.5.0-27`). pgpool now reaps orphaned SysV shmem (`ipcrm -a`) before
+starting, preventing a crash loop after repeated container OOM kills, and adds a
+`pgpool.command` override. See the pg CHANGELOG for full detail (#234).
+
 ## 1.4.2 - 2026-07-05
 
 Chart-only fix inherited from pg's symlinked templates. No image change

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus repmgr replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 1.4.2
+version: 1.4.3
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -261,6 +261,7 @@ Must satisfy `leaseDuration > renewDeadline > retryPeriod`; widen for managed cl
 | `pgpool.image.tag` | PGPool-II image tag | `4.7.1` |
 | `pgpool.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `pgpool.replicaCount` | Number of PGPool-II instances | `1` |
+| `pgpool.command` | Override the pgpool container startup command. Empty uses the chart default, which runs `ipcrm -a` to reap SysV shmem orphaned by a prior OOM-killed pgpool before `exec`ing pgpool (prevents a cross-restart shmem-accumulation crash loop). Keep the `ipcrm` reap and `exec` if you override. | `[]` |
 | `pgpool.numInitChildren` | Number of worker processes | `32` |
 | `pgpool.maxPool` | Max cached connections per process | `4` |
 | `pgpool.childLifeTime` | Worker process lifetime in seconds | `300` |

--- a/pgvector/tests/unit/pgpool_deployment_test.yaml
+++ b/pgvector/tests/unit/pgpool_deployment_test.yaml
@@ -1,0 +1,1 @@
+../../../pg/tests/unit/pgpool_deployment_test.yaml

--- a/pgvector/values.schema.json
+++ b/pgvector/values.schema.json
@@ -84,6 +84,11 @@
     "pgpool": {
       "type": "object",
       "properties": {
+        "command": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Override the pgpool container startup command. Empty uses the chart default (ipcrm -a reap + exec pgpool)."
+        },
         "tls": {
           "type": "object",
           "properties": {

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -321,6 +321,14 @@ pgpool:
 
   replicaCount: 1
 
+  # Startup command override for the pgpool container. Empty uses the chart default,
+  # which reaps SysV shmem/semaphores orphaned by a prior OOM-killed pgpool
+  # (`ipcrm -a`) before exec'ing pgpool -- without this, orphaned segments pile up
+  # in the pod's IPC namespace across container restarts until the pod cgroup fills
+  # and wedges in a crash loop (#234). Override only if you need a custom startup
+  # sequence; keep the ipcrm reap and `exec` so pgpool still receives SIGTERM.
+  command: []
+
   numInitChildren: 32
   maxPool: 4
   childLifeTime: 300


### PR DESCRIPTION
## Problem

pgpool pre-allocates its connection-pool state as an **`IPC_PRIVATE` SysV shared-memory segment**. In Kubernetes all containers in a pod share one IPC namespace, held open by the pause/sandbox container. When the pgpool container is OOM-killed:

1. `memory.oom.group = 0` at the pod cgroup → only the pgpool container dies; the pod and its IPC namespace survive.
2. The ~136Mi segment stays in the namespace — SIGKILL can't run `shmctl(IPC_RMID)`, and `IPC_PRIVATE` means a new pgpool can't locate a prior instance's segment to clean it up.
3. On restart pgpool allocates **another** ~136Mi segment into the same namespace.
4. After ~8 crash cycles the pod cgroup limit is exhausted and the kernel OOM-kills `runc init` before pgpool runs — a permanent, unrecoverable restart loop whose only symptom is `container init was OOM-killed` with no application logs. Deleting the pod is the only recovery.

Closes #234.

## Fix

Wrap the pgpool startup command:

```
sh -c 'ipcrm -a 2>/dev/null || true; exec pgpool -D -n -f … -F … -a …'
```

`ipcrm -a` reaps orphaned SysV segments/semaphores from prior instances before pgpool allocates new ones. The pod's IPC namespace holds nothing but pgpool's own orphans (the exporter sidecar uses no SysV IPC), so `-a` is safe. `exec` keeps pgpool as the container's main process, so it still receives SIGTERM for graceful shutdown.

Also exposes **`pgpool.command`** as a values override so operators can customise the startup sequence without forking; empty (default) keeps the chart's `ipcrm` reap + `exec pgpool`.

## Notes

- Chart-only. No image change (`trixie-5.5.0-27`).
- Verified `ipcrm` is present (`/usr/bin/ipcrm`, util-linux) in `cagriekin/pgpool:4.7.1`, runs as uid 999 (owns the orphaned segments), and exits 0 on an empty namespace.
- `pgvector` inherits `pgpool-deployment.yaml` via symlink, so both charts bump to **1.4.3**.
- Verified with `helm lint`, `helm template` (default wrapper + override render), and `helm unittest` (39/39, incl. 2 new pgpool-deployment tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `pgpool.command` setting to customize the PGPool-II container startup command.
  * PGPool-II now clears orphaned shared-memory resources before startup by default, helping prevent crash loops after repeated out-of-memory restarts.
  * Updated PostgreSQL and pgvector chart versions to 1.4.3.

* **Documentation**
  * Documented the new startup-command override and customization guidance in chart values and README files.

* **Tests**
  * Added coverage for the default cleanup sequence and custom command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->