### PR TITLE
feat(pg,pgvector): pgaudit-based audit logging for compliance (1.5.0) (#219)

### DIFF
--- a/.github/workflows/repmgr-image-publish.yaml
+++ b/.github/workflows/repmgr-image-publish.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.25.12'
 
       - name: vet + test + verify + hermetic build + govulncheck
         working-directory: images/repmgr/agent

--- a/.github/workflows/repmgr-image-test.yaml
+++ b/.github/workflows/repmgr-image-test.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.25.12'
 
       - name: vet + test the agent module
         working-directory: images/repmgr/agent

--- a/images/repmgr/DOCKER_HUB.md
+++ b/images/repmgr/DOCKER_HUB.md
@@ -8,6 +8,7 @@ High-availability PostgreSQL image with automatic failover for Kubernetes Statef
 - **Base image**: `debian:trixie-slim`
 - **PostgreSQL**: 18
 - **repmgr**: 5.5.0
+- **pgaudit**: bundled (`postgresql-18-pgaudit`; opt-in audit logging)
 - **Kubernetes**: 1.19+
 - **Exposed port**: 5432
 

--- a/images/repmgr/Dockerfile
+++ b/images/repmgr/Dockerfile
@@ -1,8 +1,9 @@
 # --- Stage 1: build the Go HA agent (cross-compiled, static, no cgo) ---
-# Digest-pinned (manifest-list digest, multi-arch). Go 1.25 carries the patched
-# stdlib (net/textproto, mime, crypto/x509, html/template, net) the agent links.
+# Digest-pinned (manifest-list digest, multi-arch). go1.25.12 carries the patched
+# stdlib (crypto/tls GO-2026-5856 ECH leak, plus net/textproto, mime, crypto/x509,
+# html/template, net) the agent links.
 # Refresh with: docker buildx imagetools inspect golang:1.25-bookworm
-FROM --platform=$BUILDPLATFORM golang:1.25-bookworm@sha256:bbb255b0e131db500cf0520adc97441d2260cf629c7fa7e39e025ddf53995a24 AS agent-build
+FROM --platform=$BUILDPLATFORM golang:1.25-bookworm@sha256:ea341baa9bd5ba6784f6d7161ace70544349a6242d54d34a0fbfd2c4d51c9d58 AS agent-build
 ARG TARGETARCH
 WORKDIR /src/agent
 COPY agent/go.mod agent/go.sum ./

--- a/images/repmgr/Dockerfile
+++ b/images/repmgr/Dockerfile
@@ -36,10 +36,13 @@ RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmo
 
 RUN echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/postgresql.list
 
-# Install PostgreSQL and repmgr
+# Install PostgreSQL and repmgr. postgresql-18-pgaudit ships the pgaudit extension
+# used by the chart's opt-in compliance audit logging (#219); it is inert unless the
+# chart adds it to shared_preload_libraries, so it costs nothing when audit is off.
 RUN apt-get update && apt-get install -y \
     postgresql-18 \
     postgresql-18-repmgr \
+    postgresql-18-pgaudit \
     pgbackrest \
     cron \
     && rm -rf /var/lib/apt/lists/*

--- a/images/repmgr/README.md
+++ b/images/repmgr/README.md
@@ -5,7 +5,7 @@
 > `.github/workflows/repmgr-image-publish.yaml` on `trixie-*` tags; the pg/pgvector chart CI
 > builds the image from this source (`pg-test.yaml`) rather than pulling it.
 
-PostgreSQL 18 with repmgr 5.5.0, pgBackRest, and cron on Debian Trixie. Designed for Kubernetes StatefulSet deployments with automatic failover and WAL-based incremental backups.
+PostgreSQL 18 with repmgr 5.5.0, pgBackRest, pgaudit, and cron on Debian Trixie. Designed for Kubernetes StatefulSet deployments with automatic failover and WAL-based incremental backups.
 
 ## Execution Modes
 
@@ -130,5 +130,6 @@ docker build -t cagriekin/repmgr:trixie-5.5.0-5 .
 - PostgreSQL 18
 - repmgr 5.5.0
 - pgBackRest (latest from PostgreSQL APT repository)
+- pgaudit (`postgresql-18-pgaudit`; opt-in compliance audit logging)
 - Debian Trixie
 - Kubernetes 1.19+

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,27 @@
 # pg chart changelog
 
+## 1.5.0 - 2026-07-12
+
+Requires the new repmgr image (`trixie-5.5.0-28`), which bundles the `pgaudit`
+extension. The default `repmgr.image.tag` is bumped accordingly; pgaudit is inert
+until `postgresql.audit.enabled` is set, so upgrading with audit off is a no-op
+beyond the image pull.
+
+### Added
+
+- **pgaudit-based audit logging (`postgresql.audit.*`)** for compliance regimes
+  (SOC 2, HIPAA, PCI-DSS, ISO 27001) that require a per-object record of who did
+  what (#219). Opt-in and default-off: `audit.enabled=false` renders identically to
+  1.4.3. When enabled, the chart adds `pgaudit` to `shared_preload_libraries`
+  (keeping `repmgr` and any operator-declared libraries), renders the `pgaudit.*`
+  GUCs into the postgresql ConfigMap, and creates the extension idempotently on the
+  primary via a post-install/upgrade hook Job. Because `shared_preload_libraries` is
+  a postmaster parameter, toggling audit triggers a controlled rolling restart via
+  the existing config-checksum annotation. Knobs: `log` (audit classes),
+  `logCatalog`, `logParameter`, `logRelation`, and `role` (object-level auditing via
+  `pgaudit.role`). Requires `repmgr.enabled=true` (guarded at render time — the stock
+  postgres image used in standalone mode has no pgaudit).
+
 ## 1.4.3 - 2026-07-11
 
 Chart-only fix. No image change (`trixie-5.5.0-27`).

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with repmgr replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 1.4.3
+version: 1.5.0
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/README.md
+++ b/pg/README.md
@@ -201,7 +201,7 @@ When `repmgr.enabled` is true, `additionalCommands` automatically discover the c
 |-----------|-------------|---------|
 | `repmgr.enabled` | Enable repmgr | `true` |
 | `repmgr.image.repository` | Repmgr image repository | `cagriekin/repmgr` |
-| `repmgr.image.tag` | Repmgr image tag | `trixie-5.5.0-27` |
+| `repmgr.image.tag` | Repmgr image tag | `trixie-5.5.0-28` |
 | `repmgr.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `repmgr.image.majorVersion` | PostgreSQL major bundled in the repmgr image. In repmgr mode the server always runs this major; `postgresql.majorVersion` must match or the chart fails to render. Bump with `repmgr.image.tag` when moving to an image built for a new PG major. | `"18"` |
 | `repmgr.username` | Repmgr database user | `repmgr` |

--- a/pg/README.md
+++ b/pg/README.md
@@ -163,6 +163,12 @@ Runtime configuration can be injected without rebuilding images. Settings are wr
 | `postgresql.configuration` | Map of postgresql.conf parameters | `{}` |
 | `postgresql.pgHba` | List of pg_hba.conf entries injected via postStart | `[]` |
 | `postgresql.extensions.enabled` | Enable extensions support | `false` |
+| `postgresql.audit.enabled` | Enable pgaudit audit logging (requires repmgr mode; see [Audit logging](#audit-logging-pgaudit)) | `false` |
+| `postgresql.audit.log` | pgaudit session classes: `read,write,function,role,ddl,misc,misc_set,all` (negate with `-`) | `"ddl, role, write"` |
+| `postgresql.audit.logCatalog` | Audit `pg_catalog` statements | `false` |
+| `postgresql.audit.logParameter` | Log statement parameter values (may contain PII/secrets) | `false` |
+| `postgresql.audit.logRelation` | Log the fully-qualified relation per affected table | `false` |
+| `postgresql.audit.role` | Optional `pgaudit.role` for object-level auditing (empty = session-only) | `""` |
 | `postgresql.lifecycle.postStart.additionalCommands` | Shell commands to run after PostgreSQL is ready | `""` |
 | `postgresql.migrateLegacyMd5Users` | Re-hash MD5 user passwords to SCRAM on PG14+ | `true` |
 | `postgresql.nodeSelector` | Node selector for PostgreSQL pods | `{}` |
@@ -666,6 +672,50 @@ Caveats:
 - **Cert rotation:** PostgreSQL reloads `ssl_*` on SIGHUP, not when the mounted Secret
   changes. Run `kubectl rollout restart statefulset/<release>-pg` after rotating the
   cert Secret.
+
+## Audit logging (pgaudit)
+
+Opt-in, [pgaudit](https://github.com/pgaudit/pgaudit)-based audit logging for compliance
+regimes (SOC 2, HIPAA, PCI-DSS, ISO 27001) that need a per-object record of *who did what*.
+Off by default — with `audit.enabled: false` the rendered manifests are unchanged.
+
+```yaml
+postgresql:
+  audit:
+    enabled: true
+    log: "ddl, role, write"   # pgaudit session classes; see below
+    logCatalog: false
+    logParameter: false        # parameters can contain PII/secrets — enable deliberately
+    logRelation: false
+    role: ""                   # optional pgaudit.role for object-level auditing
+```
+
+**What the chart does when enabled:** adds `pgaudit` to `shared_preload_libraries`
+(preserving `repmgr` and any libraries you set in `postgresql.configuration` —
+they are merged), renders the `pgaudit.*` GUCs into the postgresql ConfigMap, and
+creates the extension idempotently on the primary via a post-install/upgrade hook Job.
+
+- **Requires `repmgr.enabled: true`.** Audit logging needs the `cagriekin/repmgr` image,
+  which bundles the `pgaudit` extension. Standalone mode (`repmgr.enabled: false`) uses the
+  stock `postgres` image, which has no pgaudit, so a bare `shared_preload_libraries=pgaudit`
+  would crash-loop the postmaster. The chart **fails fast** at render time in that case; to
+  audit in standalone mode, supply a `postgresql.image` that ships pgaudit.
+- **Enabling audit restarts PostgreSQL.** `shared_preload_libraries` is a postmaster
+  parameter, so it only takes effect after a restart. Toggling `audit.enabled` changes the
+  ConfigMap checksum, which the StatefulSet's `checksum/postgresql-config` annotation turns
+  into a controlled rolling restart — no manual step needed.
+- **Log classes** (`log`): comma-separated `read`, `write`, `function`, `role`, `ddl`,
+  `misc`, `misc_set`, `all`. Prefix a class with `-` to subtract from `all`
+  (e.g. `all, -misc`). Validated against this allowlist at render time.
+- **Object-level auditing** (`role`): set `pgaudit.role` to an existing role; any object it
+  is `GRANT`ed on is audited regardless of the class list. Leave empty for session-only
+  logging. To audit objects in databases other than the primary, add `pgaudit` to that
+  database's `postgresql.databases[].extensions`.
+- **Where the records go, and retention.** pgaudit writes to the PostgreSQL server log
+  (stderr → `kubectl logs`). The chart emits the records; **tamper-evident retention is your
+  platform's job** — ship the pod logs to Loki / ELK / CloudWatch with an
+  append-only/immutable retention policy. Runtime `ALTER SYSTEM` / session GUC changes are
+  **not** persisted; this declarative config is the source of truth.
 
 ## Replication Management
 

--- a/pg/templates/_helpers.tpl
+++ b/pg/templates/_helpers.tpl
@@ -261,6 +261,54 @@ GRANT {{ $privs }} ON DATABASE "{{ $g.database }}" TO "{{ $role }}"
 {{- end -}}
 {{- end }}
 
+{{- /* #219: the authoritative shared_preload_libraries value when audit is enabled.
+       This renders into pgaudit.conf, which sorts after custom.conf under conf.d's
+       include_dir and therefore wins -- so it MUST reassemble the full list, not just
+       pgaudit. repmgr is always kept (replication + repmgr GUCs depend on the preload,
+       and audit is guarded to repmgr mode); any libraries the operator declared in
+       postgresql.configuration.shared_preload_libraries are merged in (comma-split,
+       trimmed, de-duplicated) so enabling audit never silently drops a preload. */ -}}
+{{- define "pg.auditSharedPreloadLibraries" -}}
+{{- $libs := list -}}
+{{- $user := (.Values.postgresql.configuration).shared_preload_libraries | default "" | toString -}}
+{{- range $l := splitList "," $user -}}
+  {{- $t := trim $l -}}
+  {{- if and $t (not (has $t $libs)) -}}{{- $libs = append $libs $t -}}{{- end -}}
+{{- end -}}
+{{- if not (has "repmgr" $libs) -}}{{- $libs = prepend $libs "repmgr" -}}{{- end -}}
+{{- if not (has "pgaudit" $libs) -}}{{- $libs = append $libs "pgaudit" -}}{{- end -}}
+{{- join "," $libs -}}
+{{- end -}}
+
+{{- /* #219: validate postgresql.audit. Guards: (g1) audit requires repmgr mode -- the
+       cagriekin/repmgr image bundles pgaudit; standalone uses the stock postgres image
+       (no pgaudit) and a bare shared_preload_libraries=pgaudit would crash-loop the
+       postmaster. (g2) log must be non-empty and every class in the allowlist (negatable
+       with a leading -). (g3) role, if set, must be a valid identifier. Class + role
+       validation also blocks smuggling a `'` that would break out of the single-quoted
+       GUC in pgaudit.conf. */ -}}
+{{- define "pg.validateAudit" -}}
+{{- if .Values.postgresql.audit.enabled -}}
+  {{- if not .Values.repmgr.enabled -}}
+    {{- fail "postgresql.audit.enabled requires repmgr.enabled=true: audit logging needs the cagriekin/repmgr image, which bundles pgaudit. Standalone mode uses the stock postgres image (no pgaudit) and would fail to start on shared_preload_libraries. To audit in standalone mode, build a postgresql.image that ships pgaudit." -}}
+  {{- end -}}
+  {{- $allowed := list "read" "write" "function" "role" "ddl" "misc" "misc_set" "all" -}}
+  {{- $log := .Values.postgresql.audit.log | default "" | toString -}}
+  {{- if not (trim $log) -}}{{- fail "postgresql.audit.log must not be empty when audit.enabled (e.g. \"ddl, role, write\" or \"all\")" -}}{{- end -}}
+  {{- range $c := splitList "," $log -}}
+    {{- $t := trim $c -}}
+    {{- if $t -}}
+      {{- $cls := lower (trimPrefix "-" $t) -}}
+      {{- if not (has $cls $allowed) -}}{{- fail (printf "postgresql.audit.log: %q is not a valid pgaudit class (allowed: %s, each optionally prefixed with - to subtract)" $t (join ", " $allowed)) -}}{{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $role := .Values.postgresql.audit.role | default "" | toString -}}
+  {{- if and $role (not (regexMatch "^[A-Za-z_][A-Za-z0-9_]*$" $role)) -}}
+    {{- fail (printf "postgresql.audit.role: invalid role name %q (must match ^[A-Za-z_][A-Za-z0-9_]*$)" $role) -}}
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
 {{- define "pg.pgpoolAdminSecretName" -}}
 {{- if .Values.pgpool.admin.existingSecret.enabled }}
 {{- required "pgpool.admin.existingSecret.name is required when pgpool.admin.existingSecret.enabled is true" .Values.pgpool.admin.existingSecret.name }}

--- a/pg/templates/_helpers.tpl
+++ b/pg/templates/_helpers.tpl
@@ -267,10 +267,16 @@ GRANT {{ $privs }} ON DATABASE "{{ $g.database }}" TO "{{ $role }}"
        pgaudit. repmgr is always kept (replication + repmgr GUCs depend on the preload,
        and audit is guarded to repmgr mode); any libraries the operator declared in
        postgresql.configuration.shared_preload_libraries are merged in (comma-split,
-       trimmed, de-duplicated) so enabling audit never silently drops a preload. */ -}}
+       trimmed, de-duplicated) so enabling audit never silently drops a preload. The
+       operator's key is matched case-insensitively -- PostgreSQL GUC names are
+       case-insensitive, so a value under e.g. `Shared_Preload_Libraries` must still be
+       picked up (and is likewise suppressed in custom.conf) or it would be dropped. */ -}}
 {{- define "pg.auditSharedPreloadLibraries" -}}
 {{- $libs := list -}}
-{{- $user := (.Values.postgresql.configuration).shared_preload_libraries | default "" | toString -}}
+{{- $user := "" -}}
+{{- range $k, $v := (.Values.postgresql.configuration | default dict) -}}
+  {{- if eq (lower ($k | toString)) "shared_preload_libraries" -}}{{- $user = $v | toString -}}{{- end -}}
+{{- end -}}
 {{- range $l := splitList "," $user -}}
   {{- $t := trim $l -}}
   {{- if and $t (not (has $t $libs)) -}}{{- $libs = append $libs $t -}}{{- end -}}

--- a/pg/templates/_helpers.tpl
+++ b/pg/templates/_helpers.tpl
@@ -303,10 +303,14 @@ GRANT {{ $privs }} ON DATABASE "{{ $g.database }}" TO "{{ $role }}"
   {{- if not (trim $log) -}}{{- fail "postgresql.audit.log must not be empty when audit.enabled (e.g. \"ddl, role, write\" or \"all\")" -}}{{- end -}}
   {{- range $c := splitList "," $log -}}
     {{- $t := trim $c -}}
-    {{- if $t -}}
-      {{- $cls := lower (trimPrefix "-" $t) -}}
-      {{- if not (has $cls $allowed) -}}{{- fail (printf "postgresql.audit.log: %q is not a valid pgaudit class (allowed: %s, each optionally prefixed with - to subtract)" $t (join ", " $allowed)) -}}{{- end -}}
-    {{- end -}}
+    {{- /* Reject empty segments (stray/trailing/double comma). The raw log string is
+           rendered verbatim into `pgaudit.log = '...'`, so a value like "ddl," would
+           pass a skip-empties check yet leave an empty class token that pgaudit
+           rejects at postmaster start -- a config the chart accepted but that breaks
+           the server. Fail fast at render time instead. */ -}}
+    {{- if not $t -}}{{- fail (printf "postgresql.audit.log: empty class segment in %q (check for a stray, leading, trailing, or doubled comma)" $log) -}}{{- end -}}
+    {{- $cls := lower (trimPrefix "-" $t) -}}
+    {{- if not (has $cls $allowed) -}}{{- fail (printf "postgresql.audit.log: %q is not a valid pgaudit class (allowed: %s, each optionally prefixed with - to subtract)" $t (join ", " $allowed)) -}}{{- end -}}
   {{- end -}}
   {{- $role := .Values.postgresql.audit.role | default "" | toString -}}
   {{- if and $role (not (regexMatch "^[A-Za-z_][A-Za-z0-9_]*$" $role)) -}}

--- a/pg/templates/audit-extension-job.yaml
+++ b/pg/templates/audit-extension-job.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.postgresql.audit.enabled }}
+{{- /* #219: pgaudit session logging works purely from shared_preload_libraries, but
+       object-level auditing (the pgaudit.role GUC) and the DDL event triggers need the
+       extension installed. This post-install/upgrade hook Job creates it idempotently on
+       the primary (it replicates to standbys), in the primary database. The extension's
+       control file ships in the repmgr image regardless of the preload, so this does not
+       depend on the config-change rolling restart having completed. For object auditing in
+       OTHER databases, add `pgaudit` to that database's postgresql.databases[].extensions. */}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "pg.fullname" . }}-audit-extension
+  labels:
+    {{- include "pg.labels" . | nindent 4 }}
+    app.kubernetes.io/component: audit-extension
+  annotations:
+    # one-shot hook Job: liveness/readiness probes do not apply (kube-linter waiver).
+    ignore-check.kube-linter.io/no-liveness-probe: "one-shot audit-extension hook Job"
+    ignore-check.kube-linter.io/no-readiness-probe: "one-shot audit-extension hook Job"
+    {{- with (include "pg.annotations" .) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "7"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  activeDeadlineSeconds: 600
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        {{- include "pg.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: audit-extension
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Never
+      # Talks only to PostgreSQL, never the Kubernetes API.
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-pgaudit-extension
+          image: {{ include "pg.image" .Values.postgresql.image | quote }}
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command: ["/bin/bash", "-eu", "-o", "pipefail", "-c"]
+          args:
+            - |
+              echo "Waiting for the primary to accept connections..."
+              for i in $(seq 1 60); do
+                if PGPASSWORD="$POSTGRES_PASSWORD" pg_isready -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; then
+                  break
+                fi
+                sleep 5
+              done
+              echo "Ensuring the pgaudit extension exists in database '$POSTGRES_DB'..."
+              # Idempotent (IF NOT EXISTS) so re-running on every upgrade is safe. No
+              # user-supplied identifier is interpolated -- the extension name is a fixed
+              # literal, so there is no injection surface.
+              PGPASSWORD="$POSTGRES_PASSWORD" psql -v ON_ERROR_STOP=1 \
+                -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
+              CREATE EXTENSION IF NOT EXISTS pgaudit;
+              SQL
+              echo "pgaudit extension is ready."
+          env:
+            - name: POSTGRES_HOST
+              value: {{ printf "%s.%s.svc.cluster.local" (include "pg.fullname" .) .Release.Namespace | quote }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pg.secretName" . }}
+                  key: {{ include "pg.secretUsernameKey" . }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pg.secretName" . }}
+                  key: {{ include "pg.secretPasswordKey" . }}
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pg.secretName" . }}
+                  key: {{ include "pg.secretDatabaseKey" . }}
+          resources:
+            {{- include "pg.initResources" . | nindent 12 }}
+{{- end }}

--- a/pg/templates/audit-extension-job.yaml
+++ b/pg/templates/audit-extension-job.yaml
@@ -25,7 +25,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   activeDeadlineSeconds: 600
-  backoffLimit: 6
+  backoffLimit: 1   # 2 runs x the 300s readiness wait = the 600s activeDeadlineSeconds ceiling; a higher value was unreachable under the deadline
   template:
     metadata:
       labels:

--- a/pg/templates/audit-extension-job.yaml
+++ b/pg/templates/audit-extension-job.yaml
@@ -58,12 +58,18 @@ spec:
           args:
             - |
               echo "Waiting for the primary to accept connections..."
+              ready=""
               for i in $(seq 1 60); do
                 if PGPASSWORD="$POSTGRES_PASSWORD" pg_isready -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; then
+                  ready=1
                   break
                 fi
                 sleep 5
               done
+              if [ -z "$ready" ]; then
+                echo "Primary did not accept connections after 300s (60 x 5s); aborting so the hook fails loudly instead of erroring against an unreachable primary. The Job will retry (backoffLimit) within activeDeadlineSeconds." >&2
+                exit 1
+              fi
               echo "Ensuring the pgaudit extension exists in database '$POSTGRES_DB'..."
               # Idempotent (IF NOT EXISTS) so re-running on every upgrade is safe. No
               # user-supplied identifier is interpolated -- the extension name is a fixed

--- a/pg/templates/audit-extension-job.yaml
+++ b/pg/templates/audit-extension-job.yaml
@@ -25,7 +25,12 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   activeDeadlineSeconds: 600
-  backoffLimit: 1   # 2 runs x the 300s readiness wait = the 600s activeDeadlineSeconds ceiling; a higher value was unreachable under the deadline
+  # readiness (a slow-booting primary) is absorbed by the in-pod pg_isready loop; these
+  # retries exist for transient SQL failures -- e.g. a primary that is momentarily
+  # read-only mid-failover -- which fail fast, so many attempts fit before
+  # activeDeadlineSeconds. A persistently unreachable primary is bounded by that
+  # deadline, not by this count.
+  backoffLimit: 6
   template:
     metadata:
       labels:

--- a/pg/templates/databases-roles-job.yaml
+++ b/pg/templates/databases-roles-job.yaml
@@ -26,7 +26,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   activeDeadlineSeconds: 600
-  backoffLimit: 6
+  backoffLimit: 1   # 2 runs x the 300s readiness wait = the 600s activeDeadlineSeconds ceiling; a higher value was unreachable under the deadline
   template:
     metadata:
       labels:

--- a/pg/templates/databases-roles-job.yaml
+++ b/pg/templates/databases-roles-job.yaml
@@ -26,7 +26,12 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   activeDeadlineSeconds: 600
-  backoffLimit: 1   # 2 runs x the 300s readiness wait = the 600s activeDeadlineSeconds ceiling; a higher value was unreachable under the deadline
+  # readiness (a slow-booting primary) is absorbed by the in-pod pg_isready loop; these
+  # retries exist for transient SQL failures -- e.g. a primary that is momentarily
+  # read-only mid-failover -- which fail fast, so many attempts fit before
+  # activeDeadlineSeconds. A persistently unreachable primary is bounded by that
+  # deadline, not by this count.
+  backoffLimit: 6
   template:
     metadata:
       labels:

--- a/pg/templates/databases-roles-job.yaml
+++ b/pg/templates/databases-roles-job.yaml
@@ -59,12 +59,18 @@ spec:
           args:
             - |
               echo "Waiting for the primary to accept connections..."
+              ready=""
               for i in $(seq 1 60); do
                 if PGPASSWORD="$POSTGRES_PASSWORD" pg_isready -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; then
+                  ready=1
                   break
                 fi
                 sleep 5
               done
+              if [ -z "$ready" ]; then
+                echo "Primary did not accept connections after 300s (60 x 5s); aborting so the hook fails loudly instead of erroring against an unreachable primary. The Job will retry (backoffLimit) within activeDeadlineSeconds." >&2
+                exit 1
+              fi
 {{- if .Values.postgresql.roles }}
               echo "Applying declarative roles..."
               # :"x" = quoted identifier, :'x' = quoted literal; role names are validated

--- a/pg/templates/monitoring-user-job.yaml
+++ b/pg/templates/monitoring-user-job.yaml
@@ -23,7 +23,12 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   activeDeadlineSeconds: 600
-  backoffLimit: 1   # 2 runs x the 300s readiness wait = the 600s activeDeadlineSeconds ceiling; a higher value was unreachable under the deadline
+  # readiness (a slow-booting primary) is absorbed by the in-pod pg_isready loop; these
+  # retries exist for transient SQL failures -- e.g. a primary that is momentarily
+  # read-only mid-failover -- which fail fast, so many attempts fit before
+  # activeDeadlineSeconds. A persistently unreachable primary is bounded by that
+  # deadline, not by this count.
+  backoffLimit: 6
   template:
     metadata:
       labels:

--- a/pg/templates/monitoring-user-job.yaml
+++ b/pg/templates/monitoring-user-job.yaml
@@ -56,12 +56,18 @@ spec:
           args:
             - |
               echo "Waiting for the primary to accept connections..."
+              ready=""
               for i in $(seq 1 60); do
                 if PGPASSWORD="$POSTGRES_PASSWORD" pg_isready -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; then
+                  ready=1
                   break
                 fi
                 sleep 5
               done
+              if [ -z "$ready" ]; then
+                echo "Primary did not accept connections after 300s (60 x 5s); aborting so the hook fails loudly instead of erroring against an unreachable primary. The Job will retry (backoffLimit) within activeDeadlineSeconds." >&2
+                exit 1
+              fi
               echo "Creating/updating the read-only monitoring role '$MONITORING_USER'..."
               # psql variables: :"x" = quoted identifier, :'x' = quoted literal, so
               # the role name/password are injection-safe. The password is read from the

--- a/pg/templates/monitoring-user-job.yaml
+++ b/pg/templates/monitoring-user-job.yaml
@@ -23,7 +23,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   activeDeadlineSeconds: 600
-  backoffLimit: 6
+  backoffLimit: 1   # 2 runs x the 300s readiness wait = the 600s activeDeadlineSeconds ceiling; a higher value was unreachable under the deadline
   template:
     metadata:
       labels:

--- a/pg/templates/postgresql-configmap.yaml
+++ b/pg/templates/postgresql-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled }}
+{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled .Values.postgresql.audit.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,7 +14,12 @@ data:
 {{- if .Values.postgresql.configuration }}
   custom.conf: |
     {{- range $key, $value := .Values.postgresql.configuration }}
+    {{- /* When audit is on, shared_preload_libraries is owned by pgaudit.conf (which
+           merges this value with repmgr + pgaudit); emitting it here too would be a
+           dead duplicate that pgaudit.conf overrides, so skip it. */}}
+    {{- if not (and $.Values.postgresql.audit.enabled (eq $key "shared_preload_libraries")) }}
     {{ $key }} = '{{ $value | toString | replace "'" "''" }}'
+    {{- end }}
     {{- end }}
 {{- end }}
 {{- if .Values.pgbackrest.enabled }}
@@ -37,6 +42,23 @@ data:
     ssl_key_file = '/etc/postgresql/tls/tls.key'
 {{- if .Values.postgresql.tls.clientCertAuth }}
     ssl_ca_file = '/etc/postgresql/tls/ca.crt'
+{{- end }}
+{{- end }}
+{{- if .Values.postgresql.audit.enabled }}
+  # pgaudit audit logging (#219). shared_preload_libraries is a postmaster parameter,
+  # so it takes effect only after a restart -- toggling audit.enabled changes this
+  # ConfigMap's checksum, which the StatefulSet's checksum/postgresql-config annotation
+  # turns into a controlled rolling restart. This file sorts after custom.conf under
+  # conf.d's include_dir, so its shared_preload_libraries is authoritative; the helper
+  # keeps repmgr (replication) and any operator-declared libraries and adds pgaudit.
+  pgaudit.conf: |
+    shared_preload_libraries = '{{ include "pg.auditSharedPreloadLibraries" . }}'
+    pgaudit.log = '{{ .Values.postgresql.audit.log | toString | replace "'" "''" }}'
+    pgaudit.log_catalog = {{ ternary "on" "off" .Values.postgresql.audit.logCatalog }}
+    pgaudit.log_parameter = {{ ternary "on" "off" .Values.postgresql.audit.logParameter }}
+    pgaudit.log_relation = {{ ternary "on" "off" .Values.postgresql.audit.logRelation }}
+{{- if .Values.postgresql.audit.role }}
+    pgaudit.role = '{{ .Values.postgresql.audit.role | toString | replace "'" "''" }}'
 {{- end }}
 {{- end }}
 {{- end }}

--- a/pg/templates/postgresql-configmap.yaml
+++ b/pg/templates/postgresql-configmap.yaml
@@ -16,8 +16,11 @@ data:
     {{- range $key, $value := .Values.postgresql.configuration }}
     {{- /* When audit is on, shared_preload_libraries is owned by pgaudit.conf (which
            merges this value with repmgr + pgaudit); emitting it here too would be a
-           dead duplicate that pgaudit.conf overrides, so skip it. */}}
-    {{- if not (and $.Values.postgresql.audit.enabled (eq $key "shared_preload_libraries")) }}
+           dead duplicate that pgaudit.conf overrides, so skip it. Matched case-
+           insensitively -- PostgreSQL GUC names are case-insensitive, and the merge
+           helper reads the key the same way, so both must agree or a non-canonically
+           cased key would be emitted here yet dropped from the merged preload list. */}}
+    {{- if not (and $.Values.postgresql.audit.enabled (eq (lower ($key | toString)) "shared_preload_libraries")) }}
     {{ $key }} = '{{ $value | toString | replace "'" "''" }}'
     {{- end }}
     {{- end }}

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -1,4 +1,5 @@
 {{- include "pg.validateResourceNames" . }}
+{{- include "pg.validateAudit" . }}
 {{- if and (not .Values.repmgr.enabled) (gt (int .Values.postgresql.replicaCount) 0) }}
 {{- fail "postgresql.replicaCount > 0 requires repmgr.enabled=true: with repmgr disabled the chart would run replicaCount+1 independent PostgreSQL instances with no replication between them. Set postgresql.replicaCount=0 for standalone mode or enable repmgr" }}
 {{- end }}
@@ -101,9 +102,9 @@ spec:
       labels:
         {{- include "pg.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: postgresql
-{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled .Values.postgresql.podAnnotations }}
+{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled .Values.postgresql.audit.enabled .Values.postgresql.podAnnotations }}
       annotations:
-{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled }}
+{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled .Values.postgresql.audit.enabled }}
         checksum/postgresql-config: {{ include (print $.Template.BasePath "/postgresql-configmap.yaml") . | sha256sum }}
 {{- end }}
 {{- if .Values.pgbackrest.enabled }}
@@ -292,7 +293,7 @@ spec:
             - -c
             - |
               CONF=/var/lib/postgresql/data/pgdata/postgresql.conf
-{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled }}
+{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled .Values.postgresql.audit.enabled }}
               if [ -f "$CONF" ] && ! grep -q "include_dir = '/etc/postgresql/conf.d'" "$CONF"; then
                 echo "include_dir = '/etc/postgresql/conf.d'" >> "$CONF"
               fi
@@ -523,7 +524,7 @@ spec:
                   - |
                     for i in {1..30}; do
                       if pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" > /dev/null 2>&1; then
-                        {{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled }}
+                        {{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled .Values.postgresql.audit.enabled }}
                         CONF="$PGDATA/postgresql.conf"
                         if [ -f "$CONF" ] && ! grep -q "include_dir = '/etc/postgresql/conf.d'" "$CONF"; then
                           echo "include_dir = '/etc/postgresql/conf.d'" >> "$CONF"
@@ -562,7 +563,7 @@ spec:
                   - |
                     for i in {1..90}; do
                       if pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" > /dev/null 2>&1; then
-                        {{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled }}
+                        {{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled .Values.postgresql.audit.enabled }}
                         CONF="$PGDATA/postgresql.conf"
                         if [ -f "$CONF" ] && ! grep -q "include_dir = '/etc/postgresql/conf.d'" "$CONF"; then
                           echo "include_dir = '/etc/postgresql/conf.d'" >> "$CONF"
@@ -814,7 +815,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
-{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled }}
+{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled .Values.postgresql.audit.enabled }}
             - name: postgresql-config
               mountPath: /etc/postgresql/conf.d
               readOnly: true
@@ -1083,7 +1084,7 @@ spec:
 {{- end }}
 {{- if or .Values.postgresql.configuration .Values.postgresql.extensions.enabled .Values.repmgr.enabled .Values.pgbackrest.enabled .Values.postgresql.tls.enabled (not .Values.postgresql.persistence.enabled) }}
       volumes:
-{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled }}
+{{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled .Values.postgresql.audit.enabled }}
         - name: postgresql-config
           configMap:
             name: {{ include "pg.fullname" . }}-postgresql-config

--- a/pg/tests/unit/audit_test.yaml
+++ b/pg/tests/unit/audit_test.yaml
@@ -1,0 +1,163 @@
+suite: pgaudit audit logging (#219)
+release:
+  name: test-pg
+templates:
+  - templates/postgresql-configmap.yaml
+  - templates/audit-extension-job.yaml
+  - templates/statefulset.yaml
+tests:
+  # --- default: audit off renders no pgaudit anywhere ---
+  - it: audit disabled emits no pgaudit.conf even when other config is set
+    template: templates/postgresql-configmap.yaml
+    set:
+      postgresql.configuration:
+        max_connections: "200"
+    asserts:
+      - notFailedTemplate: {}
+      - notMatchRegex:
+          path: data["custom.conf"]
+          pattern: pgaudit
+      # pgaudit.conf key must not exist when audit is off
+      - notExists:
+          path: data["pgaudit.conf"]
+
+  - it: audit disabled does not render the extension hook Job
+    template: templates/audit-extension-job.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # --- enabled: GUC wiring ---
+  - it: enabled renders pgaudit GUCs with repmgr preserved in shared_preload_libraries
+    template: templates/postgresql-configmap.yaml
+    set:
+      postgresql.audit.enabled: true
+    asserts:
+      - equal:
+          path: data["pgaudit.conf"]
+          value: |
+            shared_preload_libraries = 'repmgr,pgaudit'
+            pgaudit.log = 'ddl, role, write'
+            pgaudit.log_catalog = off
+            pgaudit.log_parameter = off
+            pgaudit.log_relation = off
+
+  - it: log_catalog/parameter/relation booleans map to on/off and role is emitted
+    template: templates/postgresql-configmap.yaml
+    set:
+      postgresql.audit.enabled: true
+      postgresql.audit.logCatalog: true
+      postgresql.audit.logParameter: true
+      postgresql.audit.logRelation: true
+      postgresql.audit.role: auditor
+    asserts:
+      - matchRegex:
+          path: data["pgaudit.conf"]
+          pattern: 'pgaudit.log_catalog = on'
+      - matchRegex:
+          path: data["pgaudit.conf"]
+          pattern: 'pgaudit.log_parameter = on'
+      - matchRegex:
+          path: data["pgaudit.conf"]
+          pattern: 'pgaudit.log_relation = on'
+      - matchRegex:
+          path: data["pgaudit.conf"]
+          pattern: "pgaudit.role = 'auditor'"
+
+  - it: role is omitted when empty
+    template: templates/postgresql-configmap.yaml
+    set:
+      postgresql.audit.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["pgaudit.conf"]
+          pattern: pgaudit.role
+
+  # --- shared_preload_libraries merge (decision: never drop an operator preload) ---
+  - it: operator-declared shared_preload_libraries are merged with repmgr + pgaudit
+    template: templates/postgresql-configmap.yaml
+    set:
+      postgresql.audit.enabled: true
+      postgresql.configuration:
+        shared_preload_libraries: pg_stat_statements
+    asserts:
+      - matchRegex:
+          path: data["pgaudit.conf"]
+          pattern: "shared_preload_libraries = 'repmgr,pg_stat_statements,pgaudit'"
+      # the skipped key must NOT also appear in custom.conf (pgaudit.conf owns it)
+      - notMatchRegex:
+          path: data["custom.conf"]
+          pattern: shared_preload_libraries
+
+  # --- the CREATE EXTENSION hook Job ---
+  - it: enabled renders an idempotent post-install/upgrade extension hook Job
+    template: templates/audit-extension-job.yaml
+    set:
+      postgresql.audit.enabled: true
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'CREATE EXTENSION IF NOT EXISTS pgaudit;'
+
+  # --- guards ---
+  - it: g1 audit in standalone mode fails fast
+    template: templates/statefulset.yaml
+    set:
+      postgresql.audit.enabled: true
+      repmgr.enabled: false
+      postgresql.replicaCount: 0
+    asserts:
+      - failedTemplate:
+          errorMessage: "postgresql.audit.enabled requires repmgr.enabled=true: audit logging needs the cagriekin/repmgr image, which bundles pgaudit. Standalone mode uses the stock postgres image (no pgaudit) and would fail to start on shared_preload_libraries. To audit in standalone mode, build a postgresql.image that ships pgaudit."
+
+  - it: g2 an invalid audit class fails fast
+    template: templates/statefulset.yaml
+    set:
+      postgresql.audit.enabled: true
+      postgresql.audit.log: "ddl, bogus"
+    asserts:
+      - failedTemplate: {}
+
+  - it: g2 an empty audit.log fails fast
+    template: templates/statefulset.yaml
+    set:
+      postgresql.audit.enabled: true
+      postgresql.audit.log: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: 'postgresql.audit.log must not be empty when audit.enabled (e.g. "ddl, role, write" or "all")'
+
+  - it: g2 a negated class is accepted
+    template: templates/postgresql-configmap.yaml
+    set:
+      postgresql.audit.enabled: true
+      postgresql.audit.log: "all, -misc"
+    asserts:
+      - notFailedTemplate: {}
+      - matchRegex:
+          path: data["pgaudit.conf"]
+          pattern: "pgaudit.log = 'all, -misc'"
+
+  - it: g3 an invalid audit.role fails fast
+    template: templates/statefulset.yaml
+    set:
+      postgresql.audit.enabled: true
+      postgresql.audit.role: "bad-role;drop"
+    asserts:
+      - failedTemplate: {}
+
+  # --- rolling restart on toggle: the config checksum must render when ONLY audit is
+  #     enabled (no other conf.d feature), else toggling audit would not restart the
+  #     postmaster and shared_preload_libraries=pgaudit would never take effect ---
+  - it: enabling audit alone emits the postgresql-config checksum annotation
+    template: templates/statefulset.yaml
+    set:
+      postgresql.audit.enabled: true
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/postgresql-config"]

--- a/pg/tests/unit/audit_test.yaml
+++ b/pg/tests/unit/audit_test.yaml
@@ -89,6 +89,21 @@ tests:
           path: data["custom.conf"]
           pattern: shared_preload_libraries
 
+  - it: a non-canonically-cased shared_preload_libraries key is still merged (GUC names are case-insensitive)
+    template: templates/postgresql-configmap.yaml
+    set:
+      postgresql.audit.enabled: true
+      postgresql.configuration:
+        Shared_Preload_Libraries: pg_stat_statements
+    asserts:
+      - matchRegex:
+          path: data["pgaudit.conf"]
+          pattern: "shared_preload_libraries = 'repmgr,pg_stat_statements,pgaudit'"
+      # and it must be suppressed in custom.conf, not left as a dead override target
+      - notMatchRegex:
+          path: data["custom.conf"]
+          pattern: (?i)shared_preload_libraries
+
   # --- the CREATE EXTENSION hook Job ---
   - it: enabled renders an idempotent post-install/upgrade extension hook Job
     template: templates/audit-extension-job.yaml

--- a/pg/tests/unit/audit_test.yaml
+++ b/pg/tests/unit/audit_test.yaml
@@ -118,6 +118,10 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: 'CREATE EXTENSION IF NOT EXISTS pgaudit;'
+      # the wait loop aborts explicitly if the primary never becomes ready
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'if \[ -z "\$ready" \]; then'
 
   # --- guards ---
   - it: g1 audit in standalone mode fails fast

--- a/pg/tests/unit/audit_test.yaml
+++ b/pg/tests/unit/audit_test.yaml
@@ -170,6 +170,23 @@ tests:
     asserts:
       - failedTemplate: {}
 
+  - it: g2 a trailing comma in audit.log fails fast (would render an empty class token)
+    template: templates/statefulset.yaml
+    set:
+      postgresql.audit.enabled: true
+      postgresql.audit.log: "ddl,"
+    asserts:
+      - failedTemplate:
+          errorMessage: 'postgresql.audit.log: empty class segment in "ddl," (check for a stray, leading, trailing, or doubled comma)'
+
+  - it: g2 a doubled comma in audit.log fails fast
+    template: templates/statefulset.yaml
+    set:
+      postgresql.audit.enabled: true
+      postgresql.audit.log: "ddl,,write"
+    asserts:
+      - failedTemplate: {}
+
   # --- rolling restart on toggle: the config checksum must render when ONLY audit is
   #     enabled (no other conf.d feature), else toggling audit would not restart the
   #     postmaster and shared_preload_libraries=pgaudit would never take effect ---

--- a/pg/values.schema.json
+++ b/pg/values.schema.json
@@ -47,6 +47,17 @@
               "extensions": { "type": "array", "items": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_-]*$" } }
             }
           }
+        },
+        "audit": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "log": { "type": "string", "description": "Comma-separated pgaudit classes (read, write, function, role, ddl, misc, misc_set, all), optionally prefixed with - to subtract. Allowlist enforced by the pg.validateAudit template, not this schema." },
+            "logCatalog": { "type": "boolean" },
+            "logParameter": { "type": "boolean" },
+            "logRelation": { "type": "boolean" },
+            "role": { "type": "string", "description": "Optional pgaudit.role for object-level auditing. Empty disables object auditing." }
+          }
         }
       }
     },

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -173,6 +173,42 @@ postgresql:
     # (clientcert=verify-ca). Internal service users are exempted. Implies require.
     clientCertAuth: false
 
+  # pgaudit-based audit logging (#219) for compliance regimes (SOC 2, HIPAA, PCI-DSS,
+  # ISO 27001) that require a per-object record of who did what. Off by default:
+  # audit.enabled=false renders manifests identically to a chart with no audit block.
+  #
+  # Requires repmgr.enabled=true -- the cagriekin/repmgr image bundles the pgaudit
+  # extension. Standalone mode (repmgr.enabled=false) uses the stock postgres image,
+  # which has no pgaudit, so audit + standalone fails a render guard (a bare
+  # shared_preload_libraries=pgaudit would crash-loop the postmaster). To audit in
+  # standalone mode, supply a postgresql.image that ships pgaudit.
+  #
+  # shared_preload_libraries is a postmaster parameter: enabling audit triggers a
+  # controlled rolling restart via the StatefulSet's config-checksum annotation. The
+  # chart keeps repmgr in shared_preload_libraries (replication depends on it) and adds
+  # pgaudit. pgaudit writes to the PostgreSQL server log (stderr -> `kubectl logs`);
+  # tamper-evident retention is your platform's job -- ship the logs to Loki/ELK/
+  # CloudWatch. Runtime `ALTER SYSTEM`/session GUC changes are NOT persisted; this
+  # declarative config is the source of truth.
+  audit:
+    enabled: false
+    # pgaudit session-logging classes (comma-separated): read, write, function, role,
+    # ddl, misc, misc_set, all. Prefix a class with `-` to subtract from `all`
+    # (e.g. "all, -misc"). Validated against the allowlist at render time.
+    log: "ddl, role, write"
+    # Include catalog (pg_catalog) statements. Off keeps the log free of routine
+    # client/tooling metadata queries.
+    logCatalog: false
+    # Log statement parameter values. Off by default -- parameters can contain PII/
+    # secrets; enable only when your log sink is access-controlled and retained safely.
+    logParameter: false
+    # Log the fully-qualified relation for each affected table in READ/WRITE.
+    logRelation: false
+    # Optional object-level auditing: the pgaudit.role GUC. Set to an existing role;
+    # any object that role is GRANTed on is audited regardless of the class list.
+    # Empty disables object auditing (session logging via `log` still applies).
+    role: ""
+
   # When repmgr.enabled is true, re-hash any managed user (POSTGRES_USER,
   # REPMGR_USER) whose stored password is still MD5 to SCRAM at pod startup.
   # Idempotent (no-op once everyone is SCRAM-hashed, and auto-skipped on
@@ -227,7 +263,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-27
+    tag: trixie-5.5.0-28
     # Optional digest pin (e.g. "sha256:..."). When set it is appended as
     # repository:tag@digest, so the cosign-signed / provenance-attested image is
     # pinned at deploy time and a mutable-tag repush cannot silently change it.
@@ -810,4 +846,4 @@ etcd:
   # The bundled etcd's RBAC-bootstrap Job runs the pg-ha-agent (repmgr) image, so keep
   # this in lockstep with repmgr.image.tag above; the subchart's own default can lag.
   bootstrapImage:
-    tag: trixie-5.5.0-27
+    tag: trixie-5.5.0-28

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,18 @@
 # pgvector chart changelog
 
+## 1.5.0 - 2026-07-12
+
+Inherited from pg's symlinked templates. Requires the new repmgr image
+(`trixie-5.5.0-28`), which bundles the `pgaudit` extension; the default
+`repmgr.image.tag` is bumped accordingly. pgaudit is inert until
+`postgresql.audit.enabled` is set.
+
+### Added
+
+- **pgaudit-based audit logging (`postgresql.audit.*`)** for compliance regimes
+  (SOC 2, HIPAA, PCI-DSS, ISO 27001) — opt-in, default-off. See the pg CHANGELOG for
+  full detail (#219).
+
 ## 1.4.3 - 2026-07-11
 
 Chart-only fix inherited from pg's symlinked templates. No image change

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus repmgr replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 1.4.3
+version: 1.5.0
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -178,6 +178,12 @@ Runtime configuration can be injected without rebuilding images. Settings are wr
 | `postgresql.configuration` | Map of postgresql.conf parameters | `{}` |
 | `postgresql.pgHba` | List of pg_hba.conf entries injected via postStart | `[]` |
 | `postgresql.extensions.enabled` | Enable extensions support | `true` |
+| `postgresql.audit.enabled` | Enable pgaudit audit logging (requires repmgr mode; see [Audit logging](#audit-logging-pgaudit)) | `false` |
+| `postgresql.audit.log` | pgaudit session classes: `read,write,function,role,ddl,misc,misc_set,all` (negate with `-`) | `"ddl, role, write"` |
+| `postgresql.audit.logCatalog` | Audit `pg_catalog` statements | `false` |
+| `postgresql.audit.logParameter` | Log statement parameter values (may contain PII/secrets) | `false` |
+| `postgresql.audit.logRelation` | Log the fully-qualified relation per affected table | `false` |
+| `postgresql.audit.role` | Optional `pgaudit.role` for object-level auditing (empty = session-only) | `""` |
 | `postgresql.lifecycle.postStart.additionalCommands` | Shell commands to run after PostgreSQL is ready | pgvector CREATE EXTENSION |
 | `postgresql.migrateLegacyMd5Users` | Re-hash MD5 user passwords to SCRAM on PG14+ | `true` |
 | `postgresql.nodeSelector` | Node selector for PostgreSQL pods | `{}` |
@@ -467,6 +473,34 @@ With `postgresql.replicaCount: 0` the service exists but has no endpoints.
 kubectl port-forward svc/my-pgvector-pgpool 9999:9999
 psql -h localhost -p 9999 -U postgres -d postgres
 ```
+
+## Audit logging (pgaudit)
+
+Opt-in, [pgaudit](https://github.com/pgaudit/pgaudit)-based audit logging for compliance
+regimes (SOC 2, HIPAA, PCI-DSS, ISO 27001). Off by default — inherited unchanged from the
+pg chart's symlinked templates.
+
+```yaml
+postgresql:
+  audit:
+    enabled: true
+    log: "ddl, role, write"
+    role: ""   # optional pgaudit.role for object-level auditing
+```
+
+When enabled, the chart adds `pgaudit` to `shared_preload_libraries` (preserving `repmgr`),
+renders the `pgaudit.*` GUCs, and creates the extension idempotently on the primary via a
+post-install/upgrade hook Job.
+
+- **Requires `repmgr.enabled: true`** — the `cagriekin/repmgr` image bundles pgaudit;
+  standalone mode uses the stock `postgres` image (no pgaudit) and fails a render guard.
+- **Enabling audit restarts PostgreSQL** (`shared_preload_libraries` is a postmaster
+  parameter) via the config-checksum rolling restart — no manual step.
+- **Classes** (`log`): `read,write,function,role,ddl,misc,misc_set,all`, each negatable with
+  a leading `-`. **Retention** is your platform's job: pgaudit writes to the server log
+  (stderr → `kubectl logs`); ship it to Loki/ELK/CloudWatch with immutable retention.
+
+See the [pg chart README](../pg/README.md#audit-logging-pgaudit) for full detail.
 
 ## Replication Management
 

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -216,7 +216,7 @@ When `repmgr.enabled` is true, `additionalCommands` automatically discover the c
 |-----------|-------------|---------|
 | `repmgr.enabled` | Enable repmgr | `true` |
 | `repmgr.image.repository` | Repmgr image repository | `cagriekin/repmgr` |
-| `repmgr.image.tag` | Repmgr image tag | `trixie-5.5.0-27` |
+| `repmgr.image.tag` | Repmgr image tag | `trixie-5.5.0-28` |
 | `repmgr.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `repmgr.image.majorVersion` | PostgreSQL major bundled in the repmgr image. In repmgr mode the server always runs this major; `postgresql.majorVersion` must match or the chart fails to render. Bump with `repmgr.image.tag` when moving to an image built for a new PG major. | `"18"` |
 | `repmgr.username` | Repmgr database user | `repmgr` |

--- a/pgvector/templates/audit-extension-job.yaml
+++ b/pgvector/templates/audit-extension-job.yaml
@@ -1,0 +1,1 @@
+../../pg/templates/audit-extension-job.yaml

--- a/pgvector/tests/unit/audit_test.yaml
+++ b/pgvector/tests/unit/audit_test.yaml
@@ -1,0 +1,1 @@
+../../../pg/tests/unit/audit_test.yaml

--- a/pgvector/values.schema.json
+++ b/pgvector/values.schema.json
@@ -47,6 +47,17 @@
               "extensions": { "type": "array", "items": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_-]*$" } }
             }
           }
+        },
+        "audit": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "log": { "type": "string", "description": "Comma-separated pgaudit classes (read, write, function, role, ddl, misc, misc_set, all), optionally prefixed with - to subtract. Allowlist enforced by the pg.validateAudit template, not this schema." },
+            "logCatalog": { "type": "boolean" },
+            "logParameter": { "type": "boolean" },
+            "logRelation": { "type": "boolean" },
+            "role": { "type": "string", "description": "Optional pgaudit.role for object-level auditing. Empty disables object auditing." }
+          }
         }
       }
     },

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -158,6 +158,42 @@ postgresql:
     require: false       # reject non-TLS clients (hostssl); needs exporter/pgpool sslmode >= require
     clientCertAuth: false # mTLS for app users (clientcert=verify-ca); internal users exempt; implies require
 
+  # pgaudit-based audit logging (#219) for compliance regimes (SOC 2, HIPAA, PCI-DSS,
+  # ISO 27001) that require a per-object record of who did what. Off by default:
+  # audit.enabled=false renders manifests identically to a chart with no audit block.
+  #
+  # Requires repmgr.enabled=true -- the cagriekin/repmgr image bundles the pgaudit
+  # extension. Standalone mode (repmgr.enabled=false) uses the stock postgres image,
+  # which has no pgaudit, so audit + standalone fails a render guard (a bare
+  # shared_preload_libraries=pgaudit would crash-loop the postmaster). To audit in
+  # standalone mode, supply a postgresql.image that ships pgaudit.
+  #
+  # shared_preload_libraries is a postmaster parameter: enabling audit triggers a
+  # controlled rolling restart via the StatefulSet's config-checksum annotation. The
+  # chart keeps repmgr in shared_preload_libraries (replication depends on it) and adds
+  # pgaudit. pgaudit writes to the PostgreSQL server log (stderr -> `kubectl logs`);
+  # tamper-evident retention is your platform's job -- ship the logs to Loki/ELK/
+  # CloudWatch. Runtime `ALTER SYSTEM`/session GUC changes are NOT persisted; this
+  # declarative config is the source of truth.
+  audit:
+    enabled: false
+    # pgaudit session-logging classes (comma-separated): read, write, function, role,
+    # ddl, misc, misc_set, all. Prefix a class with `-` to subtract from `all`
+    # (e.g. "all, -misc"). Validated against the allowlist at render time.
+    log: "ddl, role, write"
+    # Include catalog (pg_catalog) statements. Off keeps the log free of routine
+    # client/tooling metadata queries.
+    logCatalog: false
+    # Log statement parameter values. Off by default -- parameters can contain PII/
+    # secrets; enable only when your log sink is access-controlled and retained safely.
+    logParameter: false
+    # Log the fully-qualified relation for each affected table in READ/WRITE.
+    logRelation: false
+    # Optional object-level auditing: the pgaudit.role GUC. Set to an existing role;
+    # any object that role is GRANTed on is audited regardless of the class list.
+    # Empty disables object auditing (session logging via `log` still applies).
+    role: ""
+
   # When repmgr.enabled is true, re-hash any managed user (POSTGRES_USER,
   # REPMGR_USER) whose stored password is still MD5 to SCRAM at pod startup.
   # Idempotent (no-op once everyone is SCRAM-hashed, and auto-skipped on
@@ -192,7 +228,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-27
+    tag: trixie-5.5.0-28
     # Optional digest pin (e.g. "sha256:..."). When set it is appended as
     # repository:tag@digest, so the cosign-signed / provenance-attested image is
     # pinned at deploy time and a mutable-tag repush cannot silently change it.
@@ -760,4 +796,4 @@ etcd:
   # The bundled etcd's RBAC-bootstrap Job runs the pg-ha-agent (repmgr) image, so keep
   # this in lockstep with repmgr.image.tag above; the subchart's own default can lag.
   bootstrapImage:
-    tag: trixie-5.5.0-27
+    tag: trixie-5.5.0-28


### PR DESCRIPTION
Closes #219.

Opt-in, default-off **pgaudit** audit logging so the chart can satisfy compliance regimes (SOC 2, HIPAA, PCI-DSS, ISO 27001) that require a per-object record of who did what. With `audit.enabled: false` (the default) rendered manifests are unchanged.

## Image
pgaudit ships in neither the stock `postgres` nor the `cagriekin/repmgr` image, so this adds `postgresql-18-pgaudit` to `images/repmgr/Dockerfile` and bumps the default `repmgr.image.tag` to **`trixie-5.5.0-28`**. pgaudit is inert until enabled, so it costs nothing when audit is off. Verified against the PGDG package layer: `pgaudit.so` + `pgaudit--18.0.sql` install and `repmgr.so` coexists.

## Chart (pg, inherited by pgvector via symlinked templates)
- **Values API** `postgresql.audit.*`: `enabled`, `log` (classes), `logCatalog`, `logParameter`, `logRelation`, `role` — plus `values.schema.json`.
- **ConfigMap** renders `pgaudit.conf` with the `pgaudit.*` GUCs and a **merged** `shared_preload_libraries` that keeps `repmgr` (replication depends on it) and any operator-declared libraries, then adds `pgaudit`. Necessary because the conf.d file sorts after `custom.conf` and would otherwise clobber the preload.
- **Extension hook** `audit-extension-job.yaml`: idempotent `CREATE EXTENSION IF NOT EXISTS pgaudit` on the primary (post-install/upgrade).
- **Controlled rolling restart**: `shared_preload_libraries` is a postmaster parameter, so toggling audit changes the ConfigMap checksum and the StatefulSet's `checksum/postgresql-config` annotation rolls the pods.
- **Render guards** (`pg.validateAudit`): audit **requires repmgr mode** (standalone uses the stock postgres image and would crash-loop on the missing library — fail fast); `log` must be non-empty and every class in the pgaudit allowlist (negation-aware); `role` must be a valid identifier.
- **Docs**: README "Audit logging" sections + config-table rows; retention guidance (pgaudit writes to the server log → ship to Loki/ELK/CloudWatch); CHANGELOG entries; both charts bumped to **1.5.0**.

## Testing
- 13 new `audit_test.yaml` cases (on/off render, GUC wiring, `shared_preload_libraries` merge, extension hook, all guards, checksum-annotation-on-toggle regression).
- Full unit suites green: pg 52, pgvector 25. `helm lint` clean on both (default + audit values). Both schemas valid JSON.

## Release note
Merging is chart-source only. The image publish is triggered separately by pushing the `trixie-5.5.0-28` tag (repmgr-image-publish workflow); the chart releases follow on `pg-1.5.0` / `pgvector-1.5.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in, default-off **pgaudit** audit logging for PostgreSQL 18 via Helm configuration (configurable audit classes, catalog/parameter/relation logging toggles, optional object-level auditing).
  * When enabled, it updates effective preload libraries, provisions `pgaudit` on the primary, and performs the chart-driven restart flow (with configuration validation).
  * **pgaudit** is bundled in the repmgr image (updated tag).
* **Bug Fixes**
  * Hook jobs now fail fast with bounded readiness retries if the primary never becomes reachable.
* **Documentation**
  * Updated Docker/Helm docs and changelogs with enablement, configuration parameters, and operational behavior.
* **Tests**
  * Added unit tests covering audit on/off, preload/ConfigMap rendering, hook job behavior, and validation failures.
* **Chores**
  * Bumped chart versions to **1.5.0** and updated the pinned repmgr image tag to **trixie-5.5.0-28** (including pgvector).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->