### PR TITLE
feat(kafka): pod-scope NetworkPolicy intra-cluster traffic (#51)

### DIFF
--- a/kafka/Chart.yaml
+++ b/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka
 description: Apache Kafka in KRaft mode (no ZooKeeper) with SASL authentication, TLS, declarative topic management, and a metrics exporter
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: 4.1.0
 dependencies:
   - name: common

--- a/kafka/artifacthub-pkg.yml
+++ b/kafka/artifacthub-pkg.yml
@@ -1,7 +1,7 @@
-version: 0.2.1
+version: 0.3.0
 name: kafka
 displayName: Kafka
-createdAt: "2026-07-23T00:00:00Z"
+createdAt: "2026-07-26T00:00:00Z"
 description: Apache Kafka in KRaft mode (no ZooKeeper) with SASL authentication, TLS, declarative topic management, and a metrics exporter
 homeURL: "https://cagriekin.github.io/charts"
 logoPath: ""
@@ -17,11 +17,5 @@ links:
     url: https://github.com/cagriekin/charts
 screenshots: []
 changes:
-  - kind: fixed
-    description: "Correct shell variable escaping in broker/controller/topic-init start scripts so pods no longer crash on startup"
-  - kind: fixed
-    description: "Stop corrupting user-supplied SASL passwords (upgrade note: an install that set a base64-looking kafka.auth.password on <=0.2.0 will now store the literal value; re-verify client credentials after upgrading)"
-  - kind: fixed
-    description: "Handle special characters in SASL credentials safely when building JAAS config: escape sed metacharacters (| & \\), and reject double-quote/backslash/newline that the JAAS format cannot represent"
-  - kind: fixed
-    description: "Render a valid exporter PodDisruptionBudget by default (maxUnavailable: 1)"
+  - kind: security
+    description: "Pod-scope NetworkPolicy intra-cluster traffic: the controller quorum port (9093) is now reachable only from broker/controller pods instead of the whole namespace, and all egress is restricted to specific component pods. Client (9092) and metrics (9308) ingress remain namespace-scoped with override hooks."

--- a/kafka/templates/_helpers.tpl
+++ b/kafka/templates/_helpers.tpl
@@ -225,6 +225,46 @@ Format: 1@controller-0.svc:9093,2@controller-1.svc:9093,3@controller-2.svc:9093
 {{- end }}
 
 {{/*
+NetworkPolicy peer that selects in-cluster Kafka pods of the given component(s),
+in the release namespace. Used to pod-scope intra-cluster traffic instead of
+allowing the whole namespace.
+Usage: include "kafka.netpol.podPeer" (dict "ctx" . "components" (list "kafka-broker" "kafka-controller"))
+*/}}
+{{- define "kafka.netpol.podPeer" -}}
+- podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kafka.name" .ctx }}
+      app.kubernetes.io/instance: {{ .ctx.Release.Name }}
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+        {{- range .components }}
+          - {{ . }}
+        {{- end }}
+{{- end }}
+
+{{/*
+NetworkPolicy egress rule allowing DNS resolution (to the release namespace and
+kube-system, where CoreDNS typically runs).
+Usage: include "kafka.netpol.dnsEgress" (dict "ctx" .)
+*/}}
+{{- define "kafka.netpol.dnsEgress" -}}
+- to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ .ctx.Release.Namespace }}
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+  ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+{{- end }}
+
+{{/*
 Generate Kafka cluster ID.
 */}}
 {{- define "kafka.kafka.clusterId" -}}

--- a/kafka/templates/kafka-networkpolicies.yaml
+++ b/kafka/templates/kafka-networkpolicies.yaml
@@ -24,10 +24,9 @@ spec:
     {{- if .Values.networkPolicy.controller.ingress }}
     {{- toYaml .Values.networkPolicy.controller.ingress | nindent 4 }}
     {{- else }}
+    # KRaft quorum port: reachable only from broker and controller pods.
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
+        {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-broker" "kafka-controller")) | nindent 8 }}
       ports:
         - protocol: TCP
           port: 9093
@@ -37,32 +36,13 @@ spec:
     {{- toYaml .Values.networkPolicy.controller.egress | nindent 4 }}
     {{- else }}
     - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
+        {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-broker" "kafka-controller")) | nindent 8 }}
       ports:
         - protocol: TCP
           port: 9092
         - protocol: TCP
           port: 9093
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
-      ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
-      ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
+    {{- include "kafka.netpol.dnsEgress" (dict "ctx" $) | nindent 4 }}
     {{- end }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -89,6 +69,9 @@ spec:
     {{- if .Values.networkPolicy.broker.ingress }}
     {{- toYaml .Values.networkPolicy.broker.ingress | nindent 4 }}
     {{- else }}
+    # Client-facing listener: brokers serve arbitrary client pods (and each
+    # other), so 9092 ingress is namespace-scoped by default. Override
+    # networkPolicy.broker.ingress to restrict to specific client pods.
     - from:
         - namespaceSelector:
             matchLabels:
@@ -101,33 +84,18 @@ spec:
     {{- if .Values.networkPolicy.broker.egress }}
     {{- toYaml .Values.networkPolicy.broker.egress | nindent 4 }}
     {{- else }}
+    # To controllers (quorum) and other brokers (replication) only.
     - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
+        {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-controller")) | nindent 8 }}
       ports:
-        - protocol: TCP
-          port: 9092
         - protocol: TCP
           port: 9093
     - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
+        {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-broker")) | nindent 8 }}
       ports:
-        - protocol: UDP
-          port: 53
         - protocol: TCP
-          port: 53
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
-      ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
+          port: 9092
+    {{- include "kafka.netpol.dnsEgress" (dict "ctx" $) | nindent 4 }}
     {{- end }}
 {{- if .Values.exporters.kafka.enabled }}
 ---
@@ -155,6 +123,9 @@ spec:
     {{- if .Values.networkPolicy.exporter.ingress }}
     {{- toYaml .Values.networkPolicy.exporter.ingress | nindent 4 }}
     {{- else }}
+    # Metrics port: scraped by Prometheus, which commonly runs in another
+    # namespace, so 9308 ingress is namespace-scoped by default. Override
+    # networkPolicy.exporter.ingress to restrict to the monitoring namespace/pods.
     - from:
         - namespaceSelector:
             matchLabels:
@@ -167,36 +138,13 @@ spec:
     {{- if .Values.networkPolicy.exporter.egress }}
     {{- toYaml .Values.networkPolicy.exporter.egress | nindent 4 }}
     {{- else }}
+    # Scrapes brokers over the client listener only.
     - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
+        {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-broker")) | nindent 8 }}
       ports:
         - protocol: TCP
           port: 9092
-        - protocol: TCP
-          port: 9093
-        - protocol: TCP
-          port: 9308
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
-      ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
-      ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
+    {{- include "kafka.netpol.dnsEgress" (dict "ctx" $) | nindent 4 }}
     {{- end }}
 {{- end }}
 {{- end }}
-

--- a/kafka/templates/kafka-networkpolicies.yaml
+++ b/kafka/templates/kafka-networkpolicies.yaml
@@ -39,8 +39,6 @@ spec:
         {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-broker" "kafka-controller")) | nindent 8 }}
       ports:
         - protocol: TCP
-          port: 9092
-        - protocol: TCP
           port: 9093
     {{- include "kafka.netpol.dnsEgress" (dict "ctx" $) | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
## Pod-scope NetworkPolicy intra-cluster traffic (#51)

First PR of Phase 1 (security hardening).

The policies already `podSelector` their target and scope DNS egress, but intra-cluster peers were **namespace-wide** — the KRaft controller quorum port `:9093` was reachable from *any* pod in the namespace, and all egress was namespace-wide.

### Changes
- **Controller ingress `:9093`** — now only from **broker + controller** pods (the quorum peers), not the whole namespace. This is the main fix.
- **Egress** — restricted to the specific component pods each role actually talks to:
  - controller → broker/controller pods (`:9092`/`:9093`)
  - broker → controller pods (`:9093`) and broker pods (`:9092`)
  - exporter → broker pods (`:9092`)
  - all keep DNS egress (namespace + kube-system, `:53`).
- **Left namespace-scoped by design:** broker `:9092` (client listener — clients are arbitrary pods) and exporter `:9308` (Prometheus, commonly cross-namespace). Both keep their existing `networkPolicy.<component>.ingress` override hooks for operators who want to tighten further.
- Adds reusable `kafka.netpol.podPeer` / `kafka.netpol.dnsEgress` helpers.

### Verification
- `helm lint` passes; NetworkPolicy renders valid YAML (3 policies); full chart renders.
- Controller ingress verified pod-scoped (`component In [kafka-broker, kafka-controller]`); egress peers verified per role; override hooks verified still functional.

Bumps chart to **0.3.0**.

Closes #51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Tightened Kafka network access controls by limiting internal controller, broker, and exporter communication to required pod-to-pod connections.
  * Restricted DNS egress to approved cluster services.
  * Kept namespace-scoped access for client and metrics endpoints with override support.
* **Release**
  * Updated the Helm chart and package metadata to version 0.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->