### PR TITLE
feat(kafka): secure-by-default — TLS/mTLS, SCRAM, ACLs, multi-user (0.4.0)

### DIFF
--- a/.github/workflows/kafka-test.yaml
+++ b/.github/workflows/kafka-test.yaml
@@ -17,6 +17,10 @@ env:
   IMAGES: >-
     apache/kafka:4.1.0
     danielqsj/kafka-exporter:v1.9.0
+    quay.io/jetstack/cert-manager-controller:v1.16.2
+    quay.io/jetstack/cert-manager-webhook:v1.16.2
+    quay.io/jetstack/cert-manager-cainjector:v1.16.2
+    quay.io/jetstack/cert-manager-startupapicheck:v1.16.2
 
 jobs:
   changes:
@@ -107,6 +111,13 @@ jobs:
             docker save "$image" -o "/tmp/kind-images/${safe_name}.tar"
             kind load image-archive "/tmp/kind-images/${safe_name}.tar" --name kafka-test
           done
+
+      - name: Install cert-manager
+        run: |
+          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
+          kubectl -n cert-manager rollout status deploy/cert-manager --timeout=180s
+          kubectl -n cert-manager rollout status deploy/cert-manager-webhook --timeout=180s
+          kubectl -n cert-manager rollout status deploy/cert-manager-cainjector --timeout=180s
 
       - name: Run template tests
         run: make -C kafka test-template

--- a/kafka/Chart.yaml
+++ b/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka
 description: Apache Kafka in KRaft mode (no ZooKeeper) with SASL authentication, TLS, declarative topic management, and a metrics exporter
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: 4.1.0
 dependencies:
   - name: common

--- a/kafka/Chart.yaml
+++ b/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka
 description: Apache Kafka in KRaft mode (no ZooKeeper) with SASL authentication, TLS, declarative topic management, and a metrics exporter
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: 4.1.0
 dependencies:
   - name: common

--- a/kafka/artifacthub-pkg.yml
+++ b/kafka/artifacthub-pkg.yml
@@ -1,7 +1,7 @@
-version: 0.2.1
+version: 0.3.0
 name: kafka
 displayName: Kafka
-createdAt: "2026-07-23T00:00:00Z"
+createdAt: "2026-07-26T00:00:00Z"
 description: Apache Kafka in KRaft mode (no ZooKeeper) with SASL authentication, TLS, declarative topic management, and a metrics exporter
 homeURL: "https://cagriekin.github.io/charts"
 logoPath: ""
@@ -17,11 +17,5 @@ links:
     url: https://github.com/cagriekin/charts
 screenshots: []
 changes:
-  - kind: fixed
-    description: "Correct shell variable escaping in broker/controller/topic-init start scripts so pods no longer crash on startup"
-  - kind: fixed
-    description: "Stop corrupting user-supplied SASL passwords (upgrade note: an install that set a base64-looking kafka.auth.password on <=0.2.0 will now store the literal value; re-verify client credentials after upgrading)"
-  - kind: fixed
-    description: "Handle special characters in SASL credentials safely when building JAAS config: escape sed metacharacters (| & \\), and reject double-quote/backslash/newline that the JAAS format cannot represent"
-  - kind: fixed
-    description: "Render a valid exporter PodDisruptionBudget by default (maxUnavailable: 1)"
+  - kind: security
+    description: "Pod-scope NetworkPolicy intra-cluster traffic: the controller quorum port (9093) is now reachable only from broker/controller pods instead of the whole namespace, and all egress is restricted to specific component pods. Client (9092) and metrics (9308) ingress remain namespace-scoped with override hooks."

--- a/kafka/artifacthub-pkg.yml
+++ b/kafka/artifacthub-pkg.yml
@@ -1,7 +1,7 @@
-version: 0.3.0
+version: 0.4.0
 name: kafka
 displayName: Kafka
-createdAt: "2026-07-26T00:00:00Z"
+createdAt: "2026-07-27T00:00:00Z"
 description: Apache Kafka in KRaft mode (no ZooKeeper) with SASL authentication, TLS, declarative topic management, and a metrics exporter
 homeURL: "https://cagriekin.github.io/charts"
 logoPath: ""
@@ -18,4 +18,14 @@ links:
 screenshots: []
 changes:
   - kind: security
-    description: "Pod-scope NetworkPolicy intra-cluster traffic: the controller quorum port (9093) is now reachable only from broker/controller pods instead of the whole namespace, and all egress is restricted to specific component pods. Client (9092) and metrics (9308) ingress remain namespace-scoped with override hooks."
+    description: "Require TLS by default; run without it only with the explicit kafka.auth.allowInsecure opt-in."
+  - kind: security
+    description: "Inter-broker and controller listeners now use mutual TLS (mTLS) via a dedicated INTERNAL listener on port 9094."
+  - kind: security
+    description: "External client authentication defaults to SASL/SCRAM-SHA-512 (SCRAM-SHA-256 and PLAIN also supported); credentials are no longer written into any JAAS file or config for SCRAM."
+  - kind: security
+    description: "Enable StandardAuthorizer with deny-by-default and declarative multi-user ACL roles (producer/consumer/admin) plus a raw ACL escape hatch."
+  - kind: added
+    description: "Multi-user support with per-user passwords generated randomly on first install and persisted across upgrades."
+  - kind: changed
+    description: "BREAKING: the kafka.auth API was replaced. kafka.auth.username/password/existingSecret/existingSecretKeys/sasl are removed in favour of kafka.auth.users, kafka.auth.saslMechanism, kafka.auth.allowInsecure, and kafka.auth.authorization. See values.yaml."

--- a/kafka/artifacthub-pkg.yml
+++ b/kafka/artifacthub-pkg.yml
@@ -27,5 +27,7 @@ changes:
     description: "Enable StandardAuthorizer with deny-by-default and declarative multi-user ACL roles (producer/consumer/admin) plus a raw ACL escape hatch."
   - kind: added
     description: "Multi-user support with per-user passwords generated randomly on first install and persisted across upgrades."
+  - kind: added
+    description: "Chart-managed self-signed CA (cert-manager) is used by default when no issuerRef or existingSecret is provided, so the chart installs out-of-the-box with TLS/mTLS."
   - kind: changed
     description: "BREAKING: the kafka.auth API was replaced. kafka.auth.username/password/existingSecret/existingSecretKeys/sasl are removed in favour of kafka.auth.users, kafka.auth.saslMechanism, kafka.auth.allowInsecure, and kafka.auth.authorization. See values.yaml."

--- a/kafka/templates/NOTES.txt
+++ b/kafka/templates/NOTES.txt
@@ -1,6 +1,7 @@
 {{- if .Values.kafka.enabled }}
 {{- $fullname := include "kafka.fullname" . }}
 {{- $namespace := default "default" .Release.Namespace }}
+{{- $mechanism := include "kafka.auth.mechanism" . }}
 
 Kafka cluster {{ $fullname }} is rolling out.
 
@@ -11,28 +12,54 @@ Controllers (KRaft quorum)
 - {{ $fullname }}-kafka-controller-{{ $i }}.{{ $fullname }}-kafka-controller.{{ $namespace }}.svc.cluster.local:9093
 {{- end }}
 
-Brokers
--------
+Brokers (client bootstrap)
+--------------------------
 {{- $replicas := int .Values.kafka.broker.replicaCount }}
 {{- range $i, $_ := until $replicas }}
 - {{ $fullname }}-kafka-broker-{{ $i }}.{{ $fullname }}-kafka-broker.{{ $namespace }}.svc.cluster.local:9092
 {{- end }}
 
-Authentication
---------------
-- SASL/PLAIN credentials stored in secret `{{ include "kafka.auth.secretName" . }}`
-- Client configuration mounted via configmap `{{ $fullname }}-kafka-broker-config`
+Security
+--------
 {{- if .Values.kafka.tls.enabled }}
-- TLS encryption enabled (SASL_SSL)
+- Transport: TLS. External clients use SASL_SSL on port 9092; inter-broker and
+  controller listeners use mutual TLS (mTLS).
 {{- else }}
-- TLS encryption disabled (SASL_PLAINTEXT)
+- Transport: INSECURE (kafka.auth.allowInsecure=true). Client credentials travel
+  in cleartext and inter-broker/controller traffic is unauthenticated. Do NOT use
+  in production.
+{{- end }}
+- Client authentication: SASL/{{ $mechanism }}.
+{{- if .Values.kafka.auth.authorization.enabled }}
+- Authorization: StandardAuthorizer (allow.everyone.if.no.acl.found={{ .Values.kafka.auth.authorization.allowEveryoneIfNoAcl }}).
+  Grant access with kafka.auth.authorization.acls.
+{{- end }}
+
+Users & credentials
+-------------------
+{{- range $u := .Values.kafka.auth.users }}
+{{- if $u.existingSecret }}
+- {{ $u.username }}: password sourced from existing secret `{{ $u.existingSecret }}`.
+{{- else }}
+- {{ $u.username }}: kubectl get secret {{ include "kafka.auth.secretName" $ }} -n {{ $namespace }} -o jsonpath='{.data.{{ $u.username }}-password}' | base64 -d
+{{- end }}
+{{- end }}
+
+Sample client.properties (external client, SASL/{{ $mechanism }}{{ if .Values.kafka.tls.enabled }} over TLS{{ end }}):
+
+  security.protocol={{ include "kafka.clientProtocol" . }}
+  sasl.mechanism={{ $mechanism }}
+  sasl.jaas.config={{ if eq $mechanism "PLAIN" }}org.apache.kafka.common.security.plain.PlainLoginModule{{ else }}org.apache.kafka.common.security.scram.ScramLoginModule{{ end }} required username="<user>" password="<password>";
+{{- if .Values.kafka.tls.enabled }}
+  ssl.truststore.type=PKCS12
+  ssl.truststore.location=<path-to-truststore.p12>   # built from the CA in secret {{ include "kafka.tls.secretName" . }}
 {{- end }}
 
 Topics
 ------
 {{- $topics := default (dict) .Values.kafka.topics }}
 {{- if eq (len $topics) 0 }}
-- No declarative topics were provided. Update `kafka.topics` to have the init job reconcile topics.
+- No declarative topics were provided. Update `kafka.topics` to have the bootstrap job reconcile topics.
 {{- else }}
 {{- range $name, $topic := $topics }}
 - {{ $name }} (partitions: {{ default 1 $topic.partitions }}, replication factor: {{ default 1 $topic.replicationFactor }})
@@ -52,8 +79,10 @@ Exporter
 
 Next Steps
 ----------
-- Wait for `kubectl rollout status statefulset/{{ $fullname }}-kafka-broker` to report success.
-- Distribute the SASL credentials to clients and begin provisioning topics.
+- StatefulSets use updateStrategy=OnDelete: after `helm upgrade`, restart pods one
+  at a time (`kubectl delete pod ...`), waiting for each to become Ready.
+- The bootstrap Job provisions SASL users, topics, and ACLs; check its logs if
+  clients cannot authenticate.
 {{- else }}
 Kafka workloads are disabled (`kafka.enabled=false`); no resources were rendered.
 {{- end }}

--- a/kafka/templates/_helpers.tpl
+++ b/kafka/templates/_helpers.tpl
@@ -225,6 +225,46 @@ Format: 1@controller-0.svc:9093,2@controller-1.svc:9093,3@controller-2.svc:9093
 {{- end }}
 
 {{/*
+NetworkPolicy peer that selects in-cluster Kafka pods of the given component(s),
+in the release namespace. Used to pod-scope intra-cluster traffic instead of
+allowing the whole namespace.
+Usage: include "kafka.netpol.podPeer" (dict "ctx" . "components" (list "kafka-broker" "kafka-controller"))
+*/}}
+{{- define "kafka.netpol.podPeer" -}}
+- podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kafka.name" .ctx }}
+      app.kubernetes.io/instance: {{ .ctx.Release.Name }}
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+        {{- range .components }}
+          - {{ . }}
+        {{- end }}
+{{- end }}
+
+{{/*
+NetworkPolicy egress rule allowing DNS resolution (to the release namespace and
+kube-system, where CoreDNS typically runs).
+Usage: include "kafka.netpol.dnsEgress" (dict "ctx" .)
+*/}}
+{{- define "kafka.netpol.dnsEgress" -}}
+- to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ .ctx.Release.Namespace }}
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+  ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+{{- end }}
+
+{{/*
 Generate Kafka cluster ID.
 */}}
 {{- define "kafka.kafka.clusterId" -}}

--- a/kafka/templates/_helpers.tpl
+++ b/kafka/templates/_helpers.tpl
@@ -310,13 +310,36 @@ must be provided.
 {{- end }}
 
 {{/*
-Validate TLS configuration. Called from the Certificate template so the
-error surfaces during rendering.
+Whether the chart provisions its own self-signed CA (no external issuer and no
+externally-supplied TLS secret). Returns a non-empty string when true.
+*/}}
+{{- define "kafka.tls.selfSigned" -}}
+{{- if and .Values.kafka.tls.enabled (not .Values.kafka.tls.existingSecret) (not .Values.kafka.tls.certManager.issuerRef.name) -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+issuerRef block for the leaf (server/client) Certificate. Uses the operator's
+issuer when kafka.tls.certManager.issuerRef.name is set, otherwise the
+chart-managed self-signed CA Issuer.
+*/}}
+{{- define "kafka.tls.issuerRef" -}}
+{{- if .Values.kafka.tls.certManager.issuerRef.name -}}
+name: {{ .Values.kafka.tls.certManager.issuerRef.name }}
+kind: {{ .Values.kafka.tls.certManager.issuerRef.kind }}
+group: {{ .Values.kafka.tls.certManager.issuerRef.group }}
+{{- else -}}
+name: {{ include "kafka.fullname" . }}-kafka-ca
+kind: Issuer
+group: cert-manager.io
+{{- end -}}
+{{- end }}
+
+{{/*
+Retained as a no-op: TLS configuration no longer requires an external issuer or
+existingSecret (the chart supplies a self-signed CA by default). The
+tls-disabled guard lives in kafka.auth.validateTls.
 */}}
 {{- define "kafka.tls.validate" -}}
-{{- if .Values.kafka.tls.enabled -}}
-{{- if and (not .Values.kafka.tls.existingSecret) (not .Values.kafka.tls.certManager.issuerRef.name) -}}
-{{- fail "kafka.tls.enabled requires either kafka.tls.existingSecret or kafka.tls.certManager.issuerRef.name to be set" -}}
-{{- end -}}
-{{- end -}}
 {{- end }}

--- a/kafka/templates/_helpers.tpl
+++ b/kafka/templates/_helpers.tpl
@@ -19,10 +19,18 @@ app.kubernetes.io/part-of: {{ include "kafka.name" . }}
 {{- include "common.selectorLabels" . }}
 {{- end }}
 
+{{/*
+Kafka metrics exporter pod spec.
+In TLS mode the exporter authenticates to the broker INTERNAL (mTLS) listener
+using the chart client certificate, whose principal is a super-user -- no SASL
+credentials are needed. In insecure mode it connects to the CLIENT listener in
+plaintext with no auth.
+*/}}
 {{- define "kafka.exporterPodSpec" -}}
 {{- $fullname := include "kafka.fullname" . }}
 {{- $namespace := default "default" .Release.Namespace }}
 {{- $replicas := int .Values.kafka.broker.replicaCount }}
+{{- $tls := .Values.kafka.tls.enabled }}
 serviceAccountName: {{ include "kafka.serviceAccountName" . }}
 {{- with .Values.exporters.kafka.priorityClassName }}
 priorityClassName: {{ . | quote }}
@@ -39,43 +47,26 @@ containers:
       - /bin/sh
       - -c
       - |
-        kafka_exporter \
+        exec kafka_exporter \
           {{- range $i := until $replicas }}
+          {{- if $tls }}
+          --kafka.server={{ $fullname }}-kafka-broker-{{ $i }}.{{ $fullname }}-kafka-broker.{{ $namespace }}.svc.cluster.local:9094 \
+          {{- else }}
           --kafka.server={{ $fullname }}-kafka-broker-{{ $i }}.{{ $fullname }}-kafka-broker.{{ $namespace }}.svc.cluster.local:9092 \
           {{- end }}
-          --sasl.enabled \
-          --sasl.mechanism=plain \
-          --sasl.username="$KAFKA_SASL_USERNAME" \
-          {{- if $.Values.kafka.tls.enabled }}
-          --sasl.password="$KAFKA_SASL_PASSWORD" \
+          {{- end }}
+          {{- if $tls }}
           --tls.enabled \
-          --tls.ca-file=/opt/kafka/tls-pem/{{ $.Values.kafka.tls.caFilename }}
+          --tls.ca-file=/opt/kafka/tls-pem/{{ .Values.kafka.tls.caFilename }} \
+          --tls.cert-file=/opt/kafka/tls-pem/{{ .Values.kafka.tls.certFilename }} \
+          --tls.key-file=/opt/kafka/tls-pem/{{ .Values.kafka.tls.keyFilename }}
           {{- else }}
-          --sasl.password="$KAFKA_SASL_PASSWORD"
+          --kafka.version=2.0.0
           {{- end }}
     ports:
       - name: metrics
         containerPort: 9308
         protocol: TCP
-    {{- if .Values.kafka.auth.existingSecret }}
-    env:
-      - name: KAFKA_SASL_USERNAME
-        valueFrom:
-          secretKeyRef:
-            name: {{ include "kafka.auth.secretName" . }}
-            key: {{ include "kafka.auth.usernameKey" . | trim }}
-      - name: KAFKA_SASL_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: {{ include "kafka.auth.secretName" . }}
-            key: {{ include "kafka.auth.passwordKey" . | trim }}
-    {{- else }}
-    env:
-      - name: KAFKA_SASL_USERNAME
-        value: {{ include "kafka.auth.username" . | quote }}
-      - name: KAFKA_SASL_PASSWORD
-        value: {{ include "kafka.auth.password" . | quote }}
-    {{- end }}
     resources:
       {{- toYaml .Values.exporters.kafka.resources | nindent 6 }}
     livenessProbe:
@@ -94,13 +85,13 @@ containers:
     securityContext:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- if $.Values.kafka.tls.enabled }}
+    {{- if $tls }}
     volumeMounts:
       - name: kafka-tls-pem
         mountPath: /opt/kafka/tls-pem
         readOnly: true
     {{- end }}
-{{- if $.Values.kafka.tls.enabled }}
+{{- if $tls }}
 volumes:
   - name: kafka-tls-pem
     secret:
@@ -132,82 +123,100 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Return the Kafka auth secret name (existing or managed by chart).
+Name of the chart-managed Secret holding per-user SASL passwords
+(one key per user: "<username>-password").
 */}}
 {{- define "kafka.auth.secretName" -}}
-{{- if .Values.kafka.auth.existingSecret }}
-{{- .Values.kafka.auth.existingSecret }}
-{{- else }}
-{{- printf "%s-kafka-secret" (include "kafka.fullname" .) }}
-{{- end }}
+{{- printf "%s-kafka-secret" (include "kafka.fullname" .) -}}
 {{- end }}
 
 {{/*
-Return the Kafka auth username.
+Effective SASL mechanism for external clients.
 */}}
-{{- define "kafka.auth.username" -}}
-{{- $fallback := .Values.kafka.auth.username | default "user1" -}}
-{{- if .Values.kafka.auth.existingSecret }}
-{{- $secret := lookup "v1" "Secret" (default "default" .Release.Namespace) .Values.kafka.auth.existingSecret }}
-{{- if $secret }}
-{{- $key := include "kafka.auth.usernameKey" . | trim }}
-{{- if not (hasKey $secret.data $key) }}
-{{- fail (printf "Kafka auth existingSecret %q must contain key %q" .Values.kafka.auth.existingSecret $key) }}
-{{- end }}
-{{- index $secret.data $key | b64dec -}}
-{{- else }}
-{{- /* Lookup failed - likely RBAC issue. Use fallback; secret will be mounted at runtime. */}}
-{{- $fallback -}}
-{{- end }}
-{{- else }}
-{{- $fallback -}}
-{{- end }}
+{{- define "kafka.auth.mechanism" -}}
+{{- .Values.kafka.auth.saslMechanism | default "SCRAM-SHA-512" -}}
 {{- end }}
 
 {{/*
-Return the Kafka auth password in plain text.
+Lowercased mechanism, used in per-listener config keys (e.g. scram-sha-512).
 */}}
-{{- define "kafka.auth.password" -}}
-{{- $fallback := default (include "kafka.kafka.password" .) .Values.kafka.auth.password -}}
-{{- if .Values.kafka.auth.existingSecret }}
-{{- $secret := lookup "v1" "Secret" (default "default" .Release.Namespace) .Values.kafka.auth.existingSecret }}
-{{- if $secret }}
-{{- $key := include "kafka.auth.passwordKey" . | trim }}
-{{- if not (hasKey $secret.data $key) }}
-{{- fail (printf "Kafka auth existingSecret %q must contain key %q" .Values.kafka.auth.existingSecret $key) }}
-{{- end }}
-{{- index $secret.data $key | b64dec -}}
-{{- else }}
-{{- /* Lookup failed - likely RBAC issue. Use fallback; secret will be mounted at runtime. */}}
-{{- $fallback -}}
-{{- end }}
-{{- else }}
-{{- $fallback -}}
-{{- end }}
+{{- define "kafka.auth.mechanismLower" -}}
+{{- include "kafka.auth.mechanism" . | lower -}}
 {{- end }}
 
 {{/*
-Return the secret key used for username retrieval.
+Resolve a chart-managed user's password at render time (used only by the
+Secret template). Precedence: explicit password -> value persisted in the
+existing chart Secret (so it is stable across upgrades) -> a fresh random
+value on first install.
+Usage: include "kafka.auth.userPassword" (dict "ctx" $ "user" $user)
 */}}
-{{- define "kafka.auth.usernameKey" -}}
-{{- $keys := .Values.kafka.auth.existingSecretKeys -}}
-{{- if and .Values.kafka.auth.existingSecret $keys (hasKey $keys "username") }}
-{{- index $keys "username" -}}
-{{- else }}
-username
-{{- end }}
+{{- define "kafka.auth.userPassword" -}}
+{{- $ctx := .ctx -}}
+{{- $user := .user -}}
+{{- if $user.password -}}
+{{- $user.password -}}
+{{- else -}}
+{{- $ns := default "default" $ctx.Release.Namespace -}}
+{{- $key := printf "%s-password" $user.username -}}
+{{- $existing := lookup "v1" "Secret" $ns (include "kafka.auth.secretName" $ctx) -}}
+{{- if and $existing (hasKey ($existing.data | default dict) $key) -}}
+{{- index $existing.data $key | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end -}}
 {{- end }}
 
 {{/*
-Return the secret key used for password retrieval.
+Principal derived from the chart's TLS client certificate (CN == fullname),
+after ssl.principal.mapping.rules maps the DN down to the CN.
 */}}
-{{- define "kafka.auth.passwordKey" -}}
-{{- $keys := .Values.kafka.auth.existingSecretKeys -}}
-{{- if and .Values.kafka.auth.existingSecret $keys (hasKey $keys "password") }}
-{{- index $keys "password" -}}
-{{- else }}
-password
+{{- define "kafka.auth.certPrincipal" -}}
+{{- printf "User:%s" (include "kafka.fullname" .) -}}
 {{- end }}
+
+{{/*
+super.users list (semicolon-separated). Always includes the internal identity
+(the cert principal under TLS/mTLS, or ANONYMOUS in insecure/no-TLS mode so
+inter-broker traffic is authorized), plus any configured superUsers.
+*/}}
+{{- define "kafka.auth.superUsers" -}}
+{{- $ctx := . -}}
+{{- $list := list -}}
+{{- if $ctx.Values.kafka.tls.enabled -}}
+{{- $list = append $list (include "kafka.auth.certPrincipal" $ctx) -}}
+{{- else -}}
+{{- $list = append $list "User:ANONYMOUS" -}}
+{{- end -}}
+{{- range $ctx.Values.kafka.auth.authorization.superUsers -}}
+{{- $list = append $list (printf "User:%s" .) -}}
+{{- end -}}
+{{- $list | uniq | join ";" -}}
+{{- end }}
+
+{{/*
+Transport protocol for the external CLIENT listener.
+*/}}
+{{- define "kafka.clientProtocol" -}}
+{{- if .Values.kafka.tls.enabled -}}SASL_SSL{{- else -}}SASL_PLAINTEXT{{- end -}}
+{{- end }}
+
+{{/*
+Transport protocol for the internal (inter-broker) and controller listeners.
+SSL enables mTLS via ssl.client.auth=required; PLAINTEXT is insecure.
+*/}}
+{{- define "kafka.internalProtocol" -}}
+{{- if .Values.kafka.tls.enabled -}}SSL{{- else -}}PLAINTEXT{{- end -}}
+{{- end }}
+
+{{/*
+Fail the render when TLS is disabled without an explicit insecure opt-in.
+*/}}
+{{- define "kafka.auth.validateTls" -}}
+{{- if and (not .Values.kafka.tls.enabled) (not .Values.kafka.auth.allowInsecure) -}}
+{{- fail "kafka.tls.enabled is false but kafka.auth.allowInsecure is not set. Production requires TLS: set kafka.tls.enabled=true (with kafka.tls.certManager.issuerRef.name or kafka.tls.existingSecret), or explicitly set kafka.auth.allowInsecure=true to run WITHOUT TLS (INSECURE: client credentials travel in cleartext and inter-broker/controller traffic is unauthenticated)." -}}
+{{- end -}}
 {{- end }}
 
 {{/*
@@ -272,20 +281,10 @@ Generate Kafka cluster ID.
 {{- end }}
 
 {{/*
-Generate deterministic Kafka password when not provided.
-*/}}
-{{- define "kafka.kafka.password" -}}
-{{- $salt := "kafka-password-salt" -}}
-{{- $input := printf "%s-%s-%s" .Release.Name .Chart.Name $salt -}}
-{{- $hash := $input | sha256sum -}}
-{{- $hash -}}
-{{- end }}
-
-{{/*
-Generate a content-based suffix for the Kafka topic init job so updates trigger a new job name.
+Generate a content-based suffix for the Kafka bootstrap job so updates trigger a new job name.
 */}}
 {{- define "kafka.topicInit.hash" -}}
-{{- $payload := dict "chartVersion" .Chart.Version "image" (printf "%s/%s:%s" .Values.kafka.image.registry .Values.kafka.image.repository .Values.kafka.image.tag) "topics" .Values.kafka.topics -}}
+{{- $payload := dict "chartVersion" .Chart.Version "image" (printf "%s/%s:%s" .Values.kafka.image.registry .Values.kafka.image.repository .Values.kafka.image.tag) "topics" .Values.kafka.topics "acls" .Values.kafka.auth.authorization.acls "users" (.Values.kafka.auth.users | default list) -}}
 {{- toYaml $payload | sha256sum | trunc 10 | trimSuffix "-" -}}
 {{- end }}
 
@@ -319,27 +318,5 @@ error surfaces during rendering.
 {{- if and (not .Values.kafka.tls.existingSecret) (not .Values.kafka.tls.certManager.issuerRef.name) -}}
 {{- fail "kafka.tls.enabled requires either kafka.tls.existingSecret or kafka.tls.certManager.issuerRef.name to be set" -}}
 {{- end -}}
-{{- end -}}
-{{- end }}
-
-{{/*
-Return the broker listener protocol based on TLS setting.
-*/}}
-{{- define "kafka.broker.listenerProtocol" -}}
-{{- if .Values.kafka.tls.enabled -}}
-SASL_SSL
-{{- else -}}
-SASL_PLAINTEXT
-{{- end -}}
-{{- end }}
-
-{{/*
-Return the controller listener security protocol based on TLS setting.
-*/}}
-{{- define "kafka.controller.listenerSecurityProtocol" -}}
-{{- if .Values.kafka.tls.enabled -}}
-SSL
-{{- else -}}
-PLAINTEXT
 {{- end -}}
 {{- end }}

--- a/kafka/templates/kafka-broker-deployment.yaml
+++ b/kafka/templates/kafka-broker-deployment.yaml
@@ -47,6 +47,7 @@ spec:
       {{- $brokerLogDir := .Values.kafka.broker.logDir }}
       {{- $brokerLogDirParent := dir $brokerLogDir }}
       {{- $controllerCount := int .Values.kafka.controller.replicaCount }}
+      {{- $mechanism := include "kafka.auth.mechanism" . }}
       initContainers:
         {{- if .Values.kafka.tls.enabled }}
         - name: tls-init
@@ -134,8 +135,6 @@ spec:
               mountPath: "{{ $brokerLogDirParent }}"
             - name: kafka-config
               mountPath: /opt/kafka/config/kraft
-            - name: kafka-secret
-              mountPath: /opt/kafka/secrets
       containers:
         - name: kafka-broker
           image: "{{ .Values.kafka.image.registry }}/{{ .Values.kafka.image.repository }}:{{ .Values.kafka.image.tag }}"
@@ -150,38 +149,37 @@ spec:
               NODE_ID=$(expr $POD_ORDINAL + {{ $controllerCount }} + 1)
               export KAFKA_NODE_ID=$NODE_ID
 
-              SECRET_USERNAME_KEY="{{ include "kafka.auth.usernameKey" . | trim }}"
-              SECRET_PASSWORD_KEY="{{ include "kafka.auth.passwordKey" . | trim }}"
-              KAFKA_USERNAME=$(cat /opt/kafka/secrets/${SECRET_USERNAME_KEY})
-              KAFKA_PASSWORD=$(cat /opt/kafka/secrets/${SECRET_PASSWORD_KEY})
-
-              # The JAAS config format cannot represent these characters in a quoted
-              # value (the parser does not honor escapes), so reject them up front with
-              # a clear message instead of silently producing a broken config.
-              CREDS="${KAFKA_USERNAME}${KAFKA_PASSWORD}"
-              if [ "${CREDS//[\"\\]/}" != "$CREDS" ] || [[ "$CREDS" == *$'\n'* ]]; then
-                echo "ERROR: Kafka SASL username/password must not contain '\"', '\\', or newline characters (Kafka JAAS config limitation)." >&2
-                exit 1
-              fi
-
               mkdir -p /tmp/kafka-config
               cp /opt/kafka/config/kraft/server.properties /tmp/kafka-config/
-
-              # Escape characters that are special in a sed replacement (& | \) so that
-              # credentials containing them cannot break or inject into the substitution.
-              sed_escape() { printf '%s' "$1" | sed -e 's/[&|\\]/\\&/g'; }
-              ESC_USERNAME=$(sed_escape "${KAFKA_USERNAME}")
-              ESC_PASSWORD=$(sed_escape "${KAFKA_PASSWORD}")
-
-              sed -e "s|PLACEHOLDER_USERNAME|${ESC_USERNAME}|g" -e "s|PLACEHOLDER_PASSWORD|${ESC_PASSWORD}|g" /opt/kafka/config/kraft/kafka_server_jaas.conf.template > /tmp/kafka-config/kafka_server_jaas.conf
-
               sed -i "s|PLACEHOLDER_NODE_ID|${NODE_ID}|g" /tmp/kafka-config/server.properties
               sed -i "s|PLACEHOLDER_POD_NAME|${POD_NAME}|g" /tmp/kafka-config/server.properties
+              {{- if eq $mechanism "PLAIN" }}
+
+              # PLAIN (legacy): build a server JAAS from the mounted per-user secret.
+              # SCRAM (the default) needs no JAAS/credentials here -- it validates
+              # against KRaft metadata. Inter-broker auth uses mTLS, not this.
+              JAAS=/tmp/kafka-config/kafka_jaas.conf
+              {
+                echo 'KafkaServer {'
+                echo '  org.apache.kafka.common.security.plain.PlainLoginModule required'
+                {{- range $u := .Values.kafka.auth.users }}
+                {{- if not $u.existingSecret }}
+                printf '  user_%s="%s"\n' '{{ $u.username }}' "$(cat /opt/kafka/secrets/{{ $u.username }}-password)"
+                {{- end }}
+                {{- end }}
+                echo '  ;'
+                echo '};'
+              } > "$JAAS"
+              export KAFKA_OPTS="-Djava.security.auth.login.config=$JAAS"
+              {{- end }}
 
               exec /opt/kafka/bin/kafka-server-start.sh /tmp/kafka-config/server.properties
           ports:
             - name: broker
               containerPort: 9092
+              protocol: TCP
+            - name: internal
+              containerPort: 9094
               protocol: TCP
           readinessProbe:
             tcpSocket:
@@ -208,8 +206,6 @@ spec:
               value: {{ .Values.kafka.broker.jvm.heapOpts | quote }}
             - name: KAFKA_JVM_PERFORMANCE_OPTS
               value: {{ .Values.kafka.broker.jvm.performanceOpts | quote }}
-            - name: KAFKA_OPTS
-              value: "-Djava.security.auth.login.config=/tmp/kafka-config/kafka_server_jaas.conf"
           {{- with .Values.kafka.broker.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -221,8 +217,11 @@ spec:
               mountPath: "{{ $brokerLogDirParent }}"
             - name: kafka-config
               mountPath: /opt/kafka/config/kraft
+            {{- if eq $mechanism "PLAIN" }}
             - name: kafka-secret
               mountPath: /opt/kafka/secrets
+              readOnly: true
+            {{- end }}
             {{- if .Values.kafka.tls.enabled }}
             - name: kafka-tls
               mountPath: /opt/kafka/tls
@@ -232,9 +231,11 @@ spec:
         - name: kafka-config
           configMap:
             name: {{ include "kafka.fullname" . }}-kafka-broker-config
+        {{- if eq $mechanism "PLAIN" }}
         - name: kafka-secret
           secret:
             secretName: {{ include "kafka.auth.secretName" . }}
+        {{- end }}
         {{- if .Values.kafka.tls.enabled }}
         - name: kafka-tls-pem
           secret:

--- a/kafka/templates/kafka-broker-deployment.yaml
+++ b/kafka/templates/kafka-broker-deployment.yaml
@@ -76,6 +76,10 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.kafka.broker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: kafka-tls-pem
               mountPath: /opt/kafka/tls-pem

--- a/kafka/templates/kafka-broker-service.yaml
+++ b/kafka/templates/kafka-broker-service.yaml
@@ -18,6 +18,10 @@ spec:
       targetPort: broker
       protocol: TCP
       name: broker
+    - port: 9094
+      targetPort: internal
+      protocol: TCP
+      name: internal
   selector:
     app.kubernetes.io/name: {{ include "kafka.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/kafka/templates/kafka-certificate.yaml
+++ b/kafka/templates/kafka-certificate.yaml
@@ -33,7 +33,5 @@ spec:
     - {{ . | quote }}
     {{- end }}
   issuerRef:
-    name: {{ .Values.kafka.tls.certManager.issuerRef.name }}
-    kind: {{ .Values.kafka.tls.certManager.issuerRef.kind }}
-    group: {{ .Values.kafka.tls.certManager.issuerRef.group }}
+    {{- include "kafka.tls.issuerRef" . | nindent 4 }}
 {{- end }}

--- a/kafka/templates/kafka-certificate.yaml
+++ b/kafka/templates/kafka-certificate.yaml
@@ -15,6 +15,7 @@ metadata:
     helm.sh/chart: {{ include "kafka.chart" . }}
 spec:
   secretName: {{ include "kafka.tls.secretName" . }}
+  commonName: {{ $fullname }}
   duration: {{ .Values.kafka.tls.certManager.duration }}
   renewBefore: {{ .Values.kafka.tls.certManager.renewBefore }}
   privateKey:

--- a/kafka/templates/kafka-configmap.yaml
+++ b/kafka/templates/kafka-configmap.yaml
@@ -72,7 +72,7 @@ data:
     process.roles=broker
     node.id=PLACEHOLDER_NODE_ID
     controller.quorum.voters={{ $voters }}
-    listeners=CLIENT://:9092,INTERNAL://:9094,CONTROLLER://:9093
+    listeners=CLIENT://:9092,INTERNAL://:9094
     listener.security.protocol.map=CLIENT:{{ $clientProto }},INTERNAL:{{ $internalProto }},CONTROLLER:{{ $internalProto }}
     controller.listener.names=CONTROLLER
     inter.broker.listener.name=INTERNAL
@@ -121,7 +121,7 @@ data:
     process.roles=broker
     node.id=PLACEHOLDER_NODE_ID
     controller.quorum.voters={{ $voters }}
-    listeners=CLIENT://:9092,INTERNAL://:9094,CONTROLLER://:9093
+    listeners=CLIENT://:9092,INTERNAL://:9094
     listener.security.protocol.map=CLIENT:{{ $clientProto }},INTERNAL:{{ $internalProto }},CONTROLLER:{{ $internalProto }}
     controller.listener.names=CONTROLLER
     inter.broker.listener.name=INTERNAL

--- a/kafka/templates/kafka-configmap.yaml
+++ b/kafka/templates/kafka-configmap.yaml
@@ -1,11 +1,21 @@
 {{- if .Values.kafka.enabled }}
-{{- $brokerProtocol := include "kafka.broker.listenerProtocol" . -}}
-{{- $controllerSecProtocol := include "kafka.controller.listenerSecurityProtocol" . -}}
+{{- include "kafka.auth.validateTls" . }}
+{{- $fullname := include "kafka.fullname" . }}
+{{- $namespace := default "default" .Release.Namespace }}
+{{- $clientProto := include "kafka.clientProtocol" . }}
+{{- $internalProto := include "kafka.internalProtocol" . }}
+{{- $mechanism := include "kafka.auth.mechanism" . }}
+{{- $mechanismLower := include "kafka.auth.mechanismLower" . }}
+{{- $authz := .Values.kafka.auth.authorization.enabled }}
+{{- $tls := .Values.kafka.tls.enabled }}
+{{- $superUsers := include "kafka.auth.superUsers" . }}
+{{- $voters := include "kafka.kafka.controllerQuorumVoters" . }}
+{{- $principalRule := "RULE:^.*CN=([^,]+).*$/$1/,DEFAULT" }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "kafka.fullname" . }}-kafka-controller-config
+  name: {{ $fullname }}-kafka-controller-config
   labels:
     app.kubernetes.io/name: {{ include "kafka.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -14,43 +24,42 @@ metadata:
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     helm.sh/chart: {{ include "kafka.chart" . }}
 data:
-  kafka_server_jaas.conf.template: |
-    KafkaServer {
-        org.apache.kafka.common.security.plain.PlainLoginModule required
-        username="PLACEHOLDER_USERNAME"
-        password="PLACEHOLDER_PASSWORD"
-        user_PLACEHOLDER_USERNAME="PLACEHOLDER_PASSWORD";
-    };
   server.properties: |
     process.roles=controller
     node.id=PLACEHOLDER_NODE_ID
-    controller.quorum.voters={{ include "kafka.kafka.controllerQuorumVoters" . }}
+    controller.quorum.voters={{ $voters }}
     listeners=CONTROLLER://:9093
-    listener.security.protocol.map=CONTROLLER:{{ $controllerSecProtocol }}
+    listener.security.protocol.map=CONTROLLER:{{ $internalProto }}
     controller.listener.names=CONTROLLER
     log.dirs={{ .Values.kafka.controller.logDir }}
-    {{- if .Values.kafka.tls.enabled }}
+    {{- if $authz }}
+    authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer
+    allow.everyone.if.no.acl.found={{ .Values.kafka.auth.authorization.allowEveryoneIfNoAcl }}
+    super.users={{ $superUsers }}
+    {{- end }}
+    {{- if $tls }}
     ssl.keystore.type=PKCS12
     ssl.keystore.location=/opt/kafka/tls/keystore.p12
     ssl.keystore.password={{ include "kafka.tls.storePassword" . }}
     ssl.truststore.type=PKCS12
     ssl.truststore.location=/opt/kafka/tls/truststore.p12
     ssl.truststore.password={{ include "kafka.tls.storePassword" . }}
-    ssl.endpoint.identification.algorithm=
+    listener.name.controller.ssl.client.auth=required
+    ssl.principal.mapping.rules={{ $principalRule }}
     {{- end }}
-  client.properties: |
-    security.protocol={{ $brokerProtocol }}
-    sasl.mechanism=PLAIN
-    {{- if .Values.kafka.tls.enabled }}
-    ssl.truststore.type=PKCS12
-    ssl.truststore.location=/opt/kafka/tls/truststore.p12
-    ssl.truststore.password={{ include "kafka.tls.storePassword" . }}
-    {{- end }}
+  server-init.properties: |
+    process.roles=controller
+    node.id=PLACEHOLDER_NODE_ID
+    controller.quorum.voters={{ $voters }}
+    listeners=CONTROLLER://:9093
+    listener.security.protocol.map=CONTROLLER:{{ $internalProto }}
+    controller.listener.names=CONTROLLER
+    log.dirs={{ .Values.kafka.controller.logDir }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "kafka.fullname" . }}-kafka-broker-config
+  name: {{ $fullname }}-kafka-broker-config
   labels:
     app.kubernetes.io/name: {{ include "kafka.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -59,22 +68,20 @@ metadata:
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     helm.sh/chart: {{ include "kafka.chart" . }}
 data:
-  kafka_server_jaas.conf.template: |
-    KafkaServer {
-        org.apache.kafka.common.security.plain.PlainLoginModule required
-        username="PLACEHOLDER_USERNAME"
-        password="PLACEHOLDER_PASSWORD"
-        user_PLACEHOLDER_USERNAME="PLACEHOLDER_PASSWORD";
-    };
   server.properties: |
     process.roles=broker
     node.id=PLACEHOLDER_NODE_ID
-    controller.quorum.voters={{ include "kafka.kafka.controllerQuorumVoters" . }}
-    listeners={{ $brokerProtocol }}://:9092
-    listener.security.protocol.map={{ $brokerProtocol }}:{{ $brokerProtocol }},CONTROLLER:{{ $controllerSecProtocol }}
+    controller.quorum.voters={{ $voters }}
+    listeners=CLIENT://:9092,INTERNAL://:9094,CONTROLLER://:9093
+    listener.security.protocol.map=CLIENT:{{ $clientProto }},INTERNAL:{{ $internalProto }},CONTROLLER:{{ $internalProto }}
     controller.listener.names=CONTROLLER
-    advertised.listeners={{ $brokerProtocol }}://PLACEHOLDER_POD_NAME.{{ include "kafka.fullname" . }}-kafka-broker.{{ default "default" .Release.Namespace }}.svc.cluster.local:9092
-    inter.broker.listener.name={{ $brokerProtocol }}
+    inter.broker.listener.name=INTERNAL
+    advertised.listeners=CLIENT://PLACEHOLDER_POD_NAME.{{ $fullname }}-kafka-broker.{{ $namespace }}.svc.cluster.local:9092,INTERNAL://PLACEHOLDER_POD_NAME.{{ $fullname }}-kafka-broker.{{ $namespace }}.svc.cluster.local:9094
+    sasl.enabled.mechanisms={{ $mechanism }}
+    listener.name.client.sasl.enabled.mechanisms={{ $mechanism }}
+    {{- if ne $mechanism "PLAIN" }}
+    listener.name.client.{{ $mechanismLower }}.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required;
+    {{- end }}
     num.partitions={{ .Values.kafka.broker.config.numPartitions }}
     default.replication.factor={{ .Values.kafka.broker.config.defaultReplicationFactor }}
     min.insync.replicas={{ .Values.kafka.broker.config.minInsyncReplicas }}
@@ -91,17 +98,21 @@ data:
     auto.create.topics.enable={{ .Values.kafka.autoCreateTopicsEnable }}
     delete.topic.enable={{ .Values.kafka.deleteTopicEnable }}
     log.dirs={{ .Values.kafka.broker.logDir }}
-    sasl.enabled.mechanisms=PLAIN
-    sasl.mechanism.inter.broker.protocol=PLAIN
-    sasl.jaas.config=/opt/kafka/config/kraft/kafka_server_jaas.conf
-    {{- if .Values.kafka.tls.enabled }}
+    {{- if $authz }}
+    authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer
+    allow.everyone.if.no.acl.found={{ .Values.kafka.auth.authorization.allowEveryoneIfNoAcl }}
+    super.users={{ $superUsers }}
+    {{- end }}
+    {{- if $tls }}
     ssl.keystore.type=PKCS12
     ssl.keystore.location=/opt/kafka/tls/keystore.p12
     ssl.keystore.password={{ include "kafka.tls.storePassword" . }}
     ssl.truststore.type=PKCS12
     ssl.truststore.location=/opt/kafka/tls/truststore.p12
     ssl.truststore.password={{ include "kafka.tls.storePassword" . }}
-    ssl.endpoint.identification.algorithm=
+    listener.name.internal.ssl.client.auth=required
+    listener.name.controller.ssl.client.auth=required
+    ssl.principal.mapping.rules={{ $principalRule }}
     {{- end }}
     {{- range $key, $value := .Values.kafka.broker.extraConfig }}
     {{ $key }}={{ $value }}
@@ -109,34 +120,11 @@ data:
   server-init.properties: |
     process.roles=broker
     node.id=PLACEHOLDER_NODE_ID
-    controller.quorum.voters={{ include "kafka.kafka.controllerQuorumVoters" . }}
-    listeners={{ $brokerProtocol }}://:9092
-    listener.security.protocol.map={{ $brokerProtocol }}:{{ $brokerProtocol }},CONTROLLER:{{ $controllerSecProtocol }}
+    controller.quorum.voters={{ $voters }}
+    listeners=CLIENT://:9092,INTERNAL://:9094,CONTROLLER://:9093
+    listener.security.protocol.map=CLIENT:{{ $clientProto }},INTERNAL:{{ $internalProto }},CONTROLLER:{{ $internalProto }}
     controller.listener.names=CONTROLLER
-    inter.broker.listener.name={{ $brokerProtocol }}
-    num.partitions={{ .Values.kafka.broker.config.numPartitions }}
-    default.replication.factor={{ .Values.kafka.broker.config.defaultReplicationFactor }}
-    offsets.topic.replication.factor={{ .Values.kafka.broker.config.offsetsTopicReplicationFactor }}
-    transaction.state.log.min.isr={{ .Values.kafka.broker.config.transactionStateLogMinIsr }}
-    transaction.state.log.replication.factor={{ .Values.kafka.broker.config.transactionStateLogReplicationFactor }}
-    auto.create.topics.enable={{ .Values.kafka.autoCreateTopicsEnable }}
-    delete.topic.enable={{ .Values.kafka.deleteTopicEnable }}
+    inter.broker.listener.name=INTERNAL
+    sasl.enabled.mechanisms={{ $mechanism }}
     log.dirs={{ .Values.kafka.broker.logDir }}
-    sasl.enabled.mechanisms=PLAIN
-    sasl.mechanism.inter.broker.protocol=PLAIN
-    sasl.jaas.config=/opt/kafka/config/kraft/kafka_server_jaas.conf
-  client.properties: |
-    security.protocol={{ $brokerProtocol }}
-    sasl.mechanism=PLAIN
-    {{- if .Values.kafka.tls.enabled }}
-    ssl.truststore.type=PKCS12
-    ssl.truststore.location=/tmp/kafka-config/truststore.p12
-    ssl.truststore.password={{ include "kafka.tls.storePassword" . }}
-    {{- end }}
-  client_jaas.conf.template: |
-    KafkaClient {
-        org.apache.kafka.common.security.plain.PlainLoginModule required
-        username="PLACEHOLDER_USERNAME"
-        password="PLACEHOLDER_PASSWORD";
-    };
 {{- end }}

--- a/kafka/templates/kafka-controller-deployment.yaml
+++ b/kafka/templates/kafka-controller-deployment.yaml
@@ -74,6 +74,10 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.kafka.controller.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: kafka-tls-pem
               mountPath: /opt/kafka/tls-pem

--- a/kafka/templates/kafka-controller-deployment.yaml
+++ b/kafka/templates/kafka-controller-deployment.yaml
@@ -102,12 +102,12 @@ spec:
 
               if [ ! -f "${LOG_DIR}/meta.properties" ]; then
                 mkdir -p /tmp/kafka-controller-config
-                cp /opt/kafka/config/kraft/server.properties /tmp/kafka-controller-config/
+                cp /opt/kafka/config/kraft/server-init.properties /tmp/kafka-controller-config/
 
-                sed -i "s/PLACEHOLDER_NODE_ID/$NODE_ID/g" /tmp/kafka-controller-config/server.properties
+                sed -i "s/PLACEHOLDER_NODE_ID/$NODE_ID/g" /tmp/kafka-controller-config/server-init.properties
 
                 /opt/kafka/bin/kafka-storage.sh format \
-                  --config /tmp/kafka-controller-config/server.properties \
+                  --config /tmp/kafka-controller-config/server-init.properties \
                   --cluster-id {{ include "kafka.kafka.clusterId" . | quote }} \
                   --ignore-formatted
               fi

--- a/kafka/templates/kafka-issuer.yaml
+++ b/kafka/templates/kafka-issuer.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.kafka.enabled (include "kafka.tls.selfSigned" .) }}
+{{- $fullname := include "kafka.fullname" . }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ $fullname }}-kafka-selfsigned
+  labels:
+    app.kubernetes.io/name: {{ include "kafka.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: kafka-tls
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    helm.sh/chart: {{ include "kafka.chart" . }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $fullname }}-kafka-ca
+  labels:
+    app.kubernetes.io/name: {{ include "kafka.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: kafka-tls
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    helm.sh/chart: {{ include "kafka.chart" . }}
+spec:
+  isCA: true
+  commonName: {{ $fullname }}-kafka-ca
+  secretName: {{ $fullname }}-kafka-ca
+  duration: 87600h
+  renewBefore: 2160h
+  privateKey:
+    algorithm: RSA
+    size: 4096
+  usages:
+    - cert sign
+    - crl sign
+  issuerRef:
+    name: {{ $fullname }}-kafka-selfsigned
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ $fullname }}-kafka-ca
+  labels:
+    app.kubernetes.io/name: {{ include "kafka.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: kafka-tls
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    helm.sh/chart: {{ include "kafka.chart" . }}
+spec:
+  ca:
+    secretName: {{ $fullname }}-kafka-ca
+{{- end }}

--- a/kafka/templates/kafka-networkpolicies.yaml
+++ b/kafka/templates/kafka-networkpolicies.yaml
@@ -24,10 +24,9 @@ spec:
     {{- if .Values.networkPolicy.controller.ingress }}
     {{- toYaml .Values.networkPolicy.controller.ingress | nindent 4 }}
     {{- else }}
+    # KRaft quorum port: reachable only from broker and controller pods.
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
+        {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-broker" "kafka-controller")) | nindent 8 }}
       ports:
         - protocol: TCP
           port: 9093
@@ -37,32 +36,13 @@ spec:
     {{- toYaml .Values.networkPolicy.controller.egress | nindent 4 }}
     {{- else }}
     - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
+        {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-broker" "kafka-controller")) | nindent 8 }}
       ports:
         - protocol: TCP
           port: 9092
         - protocol: TCP
           port: 9093
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
-      ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
-      ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
+    {{- include "kafka.netpol.dnsEgress" (dict "ctx" $) | nindent 4 }}
     {{- end }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -89,6 +69,9 @@ spec:
     {{- if .Values.networkPolicy.broker.ingress }}
     {{- toYaml .Values.networkPolicy.broker.ingress | nindent 4 }}
     {{- else }}
+    # Client-facing listener: brokers serve arbitrary client pods (and each
+    # other), so 9092 ingress is namespace-scoped by default. Override
+    # networkPolicy.broker.ingress to restrict to specific client pods.
     - from:
         - namespaceSelector:
             matchLabels:
@@ -101,33 +84,18 @@ spec:
     {{- if .Values.networkPolicy.broker.egress }}
     {{- toYaml .Values.networkPolicy.broker.egress | nindent 4 }}
     {{- else }}
+    # To controllers (quorum) and other brokers (replication) only.
     - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
+        {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-controller")) | nindent 8 }}
       ports:
-        - protocol: TCP
-          port: 9092
         - protocol: TCP
           port: 9093
     - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
+        {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-broker")) | nindent 8 }}
       ports:
-        - protocol: UDP
-          port: 53
         - protocol: TCP
-          port: 53
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
-      ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
+          port: 9092
+    {{- include "kafka.netpol.dnsEgress" (dict "ctx" $) | nindent 4 }}
     {{- end }}
 {{- if .Values.exporters.kafka.enabled }}
 ---
@@ -155,6 +123,9 @@ spec:
     {{- if .Values.networkPolicy.exporter.ingress }}
     {{- toYaml .Values.networkPolicy.exporter.ingress | nindent 4 }}
     {{- else }}
+    # Metrics port: scraped by Prometheus, which commonly runs in another
+    # namespace, so 9308 ingress is namespace-scoped by default. Override
+    # networkPolicy.exporter.ingress to restrict to the monitoring namespace/pods.
     - from:
         - namespaceSelector:
             matchLabels:
@@ -167,36 +138,13 @@ spec:
     {{- if .Values.networkPolicy.exporter.egress }}
     {{- toYaml .Values.networkPolicy.exporter.egress | nindent 4 }}
     {{- else }}
+    # Scrapes brokers over the client listener only.
     - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
+        {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-broker")) | nindent 8 }}
       ports:
         - protocol: TCP
           port: 9092
-        - protocol: TCP
-          port: 9093
-        - protocol: TCP
-          port: 9308
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
-      ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
-      ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
+    {{- include "kafka.netpol.dnsEgress" (dict "ctx" $) | nindent 4 }}
     {{- end }}
 {{- end }}
 {{- end }}
-

--- a/kafka/templates/kafka-networkpolicies.yaml
+++ b/kafka/templates/kafka-networkpolicies.yaml
@@ -35,13 +35,13 @@ spec:
     {{- if .Values.networkPolicy.controller.egress }}
     {{- toYaml .Values.networkPolicy.controller.egress | nindent 4 }}
     {{- else }}
+    # Controllers only initiate to other controllers (KRaft quorum on 9093);
+    # brokers reach out to controllers, not the reverse.
     - to:
-        {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-broker" "kafka-controller")) | nindent 8 }}
+        {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-controller")) | nindent 8 }}
       ports:
         - protocol: TCP
           port: 9093
-        - protocol: TCP
-          port: 9094
     {{- include "kafka.netpol.dnsEgress" (dict "ctx" $) | nindent 4 }}
     {{- end }}
 ---

--- a/kafka/templates/kafka-networkpolicies.yaml
+++ b/kafka/templates/kafka-networkpolicies.yaml
@@ -39,9 +39,9 @@ spec:
         {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-broker" "kafka-controller")) | nindent 8 }}
       ports:
         - protocol: TCP
-          port: 9092
-        - protocol: TCP
           port: 9093
+        - protocol: TCP
+          port: 9094
     {{- include "kafka.netpol.dnsEgress" (dict "ctx" $) | nindent 4 }}
     {{- end }}
 ---
@@ -79,12 +79,20 @@ spec:
       ports:
         - protocol: TCP
           port: 9092
+    # Internal (inter-broker mTLS) listener: only brokers/controllers, the
+    # metrics exporter, and the bootstrap job connect here.
+    - from:
+        {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-broker" "kafka-controller" "kafka-exporter" "kafka-topic-init")) | nindent 8 }}
+      ports:
+        - protocol: TCP
+          port: 9094
     {{- end }}
   egress:
     {{- if .Values.networkPolicy.broker.egress }}
     {{- toYaml .Values.networkPolicy.broker.egress | nindent 4 }}
     {{- else }}
-    # To controllers (quorum) and other brokers (replication) only.
+    # To controllers (quorum, 9093) and other brokers (replication over the
+    # INTERNAL mTLS listener, 9094) only.
     - to:
         {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-controller")) | nindent 8 }}
       ports:
@@ -94,7 +102,7 @@ spec:
         {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-broker")) | nindent 8 }}
       ports:
         - protocol: TCP
-          port: 9092
+          port: 9094
     {{- include "kafka.netpol.dnsEgress" (dict "ctx" $) | nindent 4 }}
     {{- end }}
 {{- if .Values.exporters.kafka.enabled }}
@@ -138,12 +146,17 @@ spec:
     {{- if .Values.networkPolicy.exporter.egress }}
     {{- toYaml .Values.networkPolicy.exporter.egress | nindent 4 }}
     {{- else }}
-    # Scrapes brokers over the client listener only.
+    # Scrapes brokers: mTLS INTERNAL listener (9094) under TLS, else client (9092).
     - to:
         {{- include "kafka.netpol.podPeer" (dict "ctx" $ "components" (list "kafka-broker")) | nindent 8 }}
       ports:
+        {{- if .Values.kafka.tls.enabled }}
+        - protocol: TCP
+          port: 9094
+        {{- else }}
         - protocol: TCP
           port: 9092
+        {{- end }}
     {{- include "kafka.netpol.dnsEgress" (dict "ctx" $) | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/kafka/templates/kafka-secret.yaml
+++ b/kafka/templates/kafka-secret.yaml
@@ -1,8 +1,15 @@
-{{- if and .Values.kafka.enabled (not .Values.kafka.auth.existingSecret) }}
+{{- if .Values.kafka.enabled }}
+{{- $chartUsers := list }}
+{{- range .Values.kafka.auth.users }}
+{{- if not .existingSecret }}
+{{- $chartUsers = append $chartUsers . }}
+{{- end }}
+{{- end }}
+{{- if $chartUsers }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "kafka.fullname" . }}-kafka-secret
+  name: {{ include "kafka.auth.secretName" . }}
   labels:
     app.kubernetes.io/name: {{ include "kafka.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -12,6 +19,8 @@ metadata:
     helm.sh/chart: {{ include "kafka.chart" . }}
 type: Opaque
 stringData:
-  password: {{ include "kafka.auth.password" . | quote }}
-  username: {{ include "kafka.auth.username" . | quote }}
+  {{- range $u := $chartUsers }}
+  {{ $u.username }}-password: {{ include "kafka.auth.userPassword" (dict "ctx" $ "user" $u) | quote }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/kafka/templates/kafka-topic-init-job.yaml
+++ b/kafka/templates/kafka-topic-init-job.yaml
@@ -85,19 +85,19 @@ spec:
         image: {{ .Values.kafka.image.registry }}/{{ .Values.kafka.image.repository }}:{{ .Values.kafka.image.tag }}
         imagePullPolicy: {{ .Values.kafka.image.pullPolicy }}
         env:
-          # The Kafka CLI tools default to -Xmx256M; with only 256Mi of container
-          # memory the JVM (heap + metaspace + stacks) is OOM-killed, which surfaces
-          # as silent AdminClient connection timeouts. Cap the heap and give the
-          # container headroom for heap + JVM overhead.
+          # The Kafka CLI tools (AdminClient) need ~256M heap; a smaller heap
+          # thrashes and a container smaller than heap+JVM-overhead gets OOM-killed,
+          # both surfacing as silent connection timeouts. Give it the default heap
+          # and a container with headroom.
           - name: KAFKA_HEAP_OPTS
-            value: "-Xmx192m -Xms64m"
+            value: "-Xmx256m -Xms64m"
         resources:
           requests:
             cpu: 50m
-            memory: 128Mi
+            memory: 256Mi
           limits:
-            cpu: 200m
-            memory: 512Mi
+            cpu: 250m
+            memory: 1Gi
         command:
         - /bin/bash
         - -c
@@ -136,7 +136,7 @@ spec:
           SLEEP_SECONDS=${KAFKA_BOOTSTRAP_SLEEP:-5}
           echo "Waiting for Kafka bootstrap server ${BS} ..."
           ATTEMPT=1
-          until /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server "${BS}" --command-config "${CC}" >/dev/null 2>&1; do
+          until /opt/kafka/bin/kafka-topics.sh --list --bootstrap-server "${BS}" --command-config "${CC}" >/dev/null 2>&1; do
             if [ "${ATTEMPT}" -ge "${MAX_ATTEMPTS}" ]; then
               echo "Kafka bootstrap server still unreachable after ${ATTEMPT} attempts; giving up." >&2
               exit 1

--- a/kafka/templates/kafka-topic-init-job.yaml
+++ b/kafka/templates/kafka-topic-init-job.yaml
@@ -1,5 +1,10 @@
 {{- if .Values.kafka.enabled }}
 {{- $jobName := printf "%s-kafka-topic-init-%s" (include "kafka.fullname" .) (include "kafka.topicInit.hash" .) | trunc 63 | trimSuffix "-" }}
+{{- $fullname := include "kafka.fullname" . }}
+{{- $namespace := default "default" .Release.Namespace }}
+{{- $tls := .Values.kafka.tls.enabled }}
+{{- $mechanism := include "kafka.auth.mechanism" . }}
+{{- $root := . }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -25,6 +30,8 @@ metadata:
     job-name: {{ $jobName }}
 spec:
   ttlSecondsAfterFinished: 300
+  backoffLimit: 6
+  activeDeadlineSeconds: 1200
   template:
     metadata:
       labels:
@@ -37,9 +44,39 @@ spec:
         job-name: {{ $jobName }}
     spec:
       restartPolicy: OnFailure
+      {{- if $tls }}
+      initContainers:
+      - name: tls-init
+        image: {{ .Values.kafka.image.registry }}/{{ .Values.kafka.image.repository }}:{{ .Values.kafka.image.tag }}
+        imagePullPolicy: {{ .Values.kafka.image.pullPolicy }}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          STORE_PASS="{{ include "kafka.tls.storePassword" . }}"
+          openssl pkcs12 -export \
+            -in /opt/kafka/tls-pem/{{ .Values.kafka.tls.certFilename }} \
+            -inkey /opt/kafka/tls-pem/{{ .Values.kafka.tls.keyFilename }} \
+            -out /tmp/kafka-tls/keystore.p12 \
+            -password "pass:${STORE_PASS}"
+          keytool -importcert \
+            -file /opt/kafka/tls-pem/{{ .Values.kafka.tls.caFilename }} \
+            -keystore /tmp/kafka-tls/truststore.p12 \
+            -storetype PKCS12 \
+            -storepass "${STORE_PASS}" \
+            -noprompt -alias ca
+        volumeMounts:
+        - name: kafka-tls-pem
+          mountPath: /opt/kafka/tls-pem
+          readOnly: true
+        - name: kafka-tls
+          mountPath: /tmp/kafka-tls
+      {{- end }}
       containers:
       - name: kafka-topic-init
         image: {{ .Values.kafka.image.registry }}/{{ .Values.kafka.image.repository }}:{{ .Values.kafka.image.tag }}
+        imagePullPolicy: {{ .Values.kafka.image.pullPolicy }}
         resources:
           requests:
             cpu: 50m
@@ -47,176 +84,179 @@ spec:
           limits:
             cpu: 200m
             memory: 256Mi
-        volumeMounts:
-        - name: kafka-config
-          mountPath: /opt/kafka/config/kraft
-        - name: kafka-secret
-          mountPath: /opt/kafka/secrets
-          readOnly: true
-        - name: kafka-config-runtime
-          mountPath: /tmp/kafka-config
-        {{- if .Values.kafka.tls.enabled }}
-        - name: kafka-tls-pem
-          mountPath: /opt/kafka/tls-pem
-          readOnly: true
-        {{- end }}
-        {{- $root := . }}
         command:
         - /bin/bash
         - -c
         - |
           set -e
-
-          SECRET_USERNAME_KEY="{{ include "kafka.auth.usernameKey" . | trim }}"
-          SECRET_PASSWORD_KEY="{{ include "kafka.auth.passwordKey" . | trim }}"
-          KAFKA_USERNAME=$(cat /opt/kafka/secrets/${SECRET_USERNAME_KEY})
-          KAFKA_PASSWORD=$(cat /opt/kafka/secrets/${SECRET_PASSWORD_KEY})
-
-          # The JAAS config format cannot represent these characters in a quoted
-          # value (the parser does not honor escapes), so reject them up front with
-          # a clear message instead of silently producing a broken config.
-          CREDS="${KAFKA_USERNAME}${KAFKA_PASSWORD}"
-          if [ "${CREDS//[\"\\]/}" != "$CREDS" ] || [[ "$CREDS" == *$'\n'* ]]; then
-            echo "ERROR: Kafka SASL username/password must not contain '\"', '\\', or newline characters (Kafka JAAS config limitation)." >&2
-            exit 1
-          fi
-
           mkdir -p /tmp/kafka-config
-          cp /opt/kafka/config/kraft/client.properties /tmp/kafka-config/
-          cp /opt/kafka/config/kraft/client_jaas.conf.template /tmp/kafka-config/
+          CC=/tmp/kafka-config/client.properties
 
-          # Escape characters that are special in a sed replacement (& | \) so that
-          # credentials containing them cannot break or inject into the substitution.
-          sed_escape() { printf '%s' "$1" | sed -e 's/[&|\\]/\\&/g'; }
-          ESC_USERNAME=$(sed_escape "${KAFKA_USERNAME}")
-          ESC_PASSWORD=$(sed_escape "${KAFKA_PASSWORD}")
-
-          sed -e "s|PLACEHOLDER_USERNAME|${ESC_USERNAME}|g" -e "s|PLACEHOLDER_PASSWORD|${ESC_PASSWORD}|g" /opt/kafka/config/kraft/client_jaas.conf.template > /tmp/kafka-config/client_jaas.conf
-
-          export KAFKA_OPTS="-Djava.security.auth.login.config=/tmp/kafka-config/client_jaas.conf"
-
-          {{- if .Values.kafka.tls.enabled }}
-          # Build PKCS12 truststore from mounted CA certificate for TLS connections
-          STORE_PASS="{{ include "kafka.tls.storePassword" . }}"
-          keytool -importcert \
-            -file /opt/kafka/tls-pem/{{ .Values.kafka.tls.caFilename }} \
-            -keystore /tmp/kafka-config/truststore.p12 \
-            -storetype PKCS12 \
-            -storepass "${STORE_PASS}" \
-            -noprompt -alias ca
+          # The bootstrap Job authenticates on the INTERNAL listener (9094): via
+          # mTLS (client cert = super-user principal) under TLS, or PLAINTEXT
+          # (ANONYMOUS super-user) in insecure mode. This avoids the SCRAM
+          # chicken-and-egg (creating users requires an already-authorized admin).
+          {{- if $tls }}
+          cat > "$CC" <<EOF
+          security.protocol=SSL
+          ssl.keystore.type=PKCS12
+          ssl.keystore.location=/tmp/kafka-tls/keystore.p12
+          ssl.keystore.password={{ include "kafka.tls.storePassword" . }}
+          ssl.truststore.type=PKCS12
+          ssl.truststore.location=/tmp/kafka-tls/truststore.p12
+          ssl.truststore.password={{ include "kafka.tls.storePassword" . }}
+          EOF
+          {{- else }}
+          cat > "$CC" <<EOF
+          security.protocol=PLAINTEXT
+          EOF
           {{- end }}
 
           {{- if .Values.kafka.bootstrapServer }}
-          BOOTSTRAP_SERVER="{{ .Values.kafka.bootstrapServer }}"
+          BS="{{ .Values.kafka.bootstrapServer }}"
           {{- else }}
-          BOOTSTRAP_SERVER="{{ include "kafka.fullname" . }}-kafka-broker-0.{{ include "kafka.fullname" . }}-kafka-broker.{{ default "default" .Release.Namespace }}.svc.cluster.local:9092"
+          BS="{{ $fullname }}-kafka-broker-0.{{ $fullname }}-kafka-broker.{{ $namespace }}.svc.cluster.local:9094"
           {{- end }}
+
           MAX_ATTEMPTS=${KAFKA_BOOTSTRAP_RETRIES:-30}
           SLEEP_SECONDS=${KAFKA_BOOTSTRAP_SLEEP:-5}
-
-          echo "Waiting for Kafka bootstrap server ${BOOTSTRAP_SERVER} to become reachable..."
+          echo "Waiting for Kafka bootstrap server ${BS} ..."
           ATTEMPT=1
-          until echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: Testing connection to ${BOOTSTRAP_SERVER}" && /opt/kafka/bin/kafka-broker-api-versions.sh \
-            --bootstrap-server "${BOOTSTRAP_SERVER}" \
-            --command-config /tmp/kafka-config/client.properties; do
+          until /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server "${BS}" --command-config "${CC}" >/dev/null 2>&1; do
             if [ "${ATTEMPT}" -ge "${MAX_ATTEMPTS}" ]; then
               echo "Kafka bootstrap server still unreachable after ${ATTEMPT} attempts; giving up." >&2
               exit 1
             fi
-
-            echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS} failed. Broker not ready yet; sleeping ${SLEEP_SECONDS}s..."
+            echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: not ready; sleeping ${SLEEP_SECONDS}s..."
             ATTEMPT=$((ATTEMPT + 1))
             sleep "${SLEEP_SECONDS}"
           done
-
           echo "Kafka bootstrap server reachable."
 
-          echo "Creating topics..."
-          export KAFKA_OPTS="-Djava.security.auth.login.config=/tmp/kafka-config/client_jaas.conf"
+          {{- if ne $mechanism "PLAIN" }}
+          echo "Provisioning SASL/{{ $mechanism }} credentials..."
+          {{- range $u := .Values.kafka.auth.users }}
+          {{- if not $u.existingSecret }}
+          USER_PW=$(cat /opt/kafka/secrets/{{ $u.username }}-password)
+          /opt/kafka/bin/kafka-configs.sh --bootstrap-server "${BS}" --command-config "${CC}" \
+            --alter --add-config "{{ $mechanism }}=[iterations=8192,password=${USER_PW}]" \
+            --entity-type users --entity-name {{ $u.username | quote }}
+          unset USER_PW
+          echo "Provisioned user {{ $u.username }}."
+          {{- end }}
+          {{- end }}
+          {{- end }}
 
+          echo "Creating topics..."
 {{- range $topicName, $topic := $root.Values.kafka.topics }}
-          echo "Ensuring {{ $topicName }} topic exists with correct configuration..."
+          echo "Ensuring {{ $topicName }} exists..."
           DESIRED_PARTITIONS={{ default 1 $topic.partitions }}
           DESIRED_REPLICATION={{ default 1 $topic.replicationFactor }}
-
-          /opt/kafka/bin/kafka-topics.sh \
-            --create \
-            --bootstrap-server ${BOOTSTRAP_SERVER} \
-            --command-config /tmp/kafka-config/client.properties \
-            --topic {{ $topicName }} \
+          /opt/kafka/bin/kafka-topics.sh --create \
+            --bootstrap-server "${BS}" --command-config "${CC}" \
+            --topic {{ $topicName | quote }} \
             --partitions ${DESIRED_PARTITIONS} \
             --replication-factor ${DESIRED_REPLICATION} \
             {{- with $topic.config }}
-            {{- range $confKey, $confValue := . }}
-            --config {{ $confKey }}={{ $confValue }} \
+            {{- range $k, $v := . }}
+            --config {{ $k }}={{ $v }} \
             {{- end }}
             {{- end }}
             --if-not-exists
-
-          TOPIC_DESC=$(timeout 30 /opt/kafka/bin/kafka-topics.sh \
-            --describe \
-            --bootstrap-server ${BOOTSTRAP_SERVER} \
-            --command-config /tmp/kafka-config/client.properties \
-            --topic {{ $topicName }} 2>/dev/null || echo "")
-
-          if [ -n "$TOPIC_DESC" ]; then
-            echo "Debug: TOPIC_DESC='$TOPIC_DESC'"
-
-            CURRENT_PARTITIONS=$(echo "$TOPIC_DESC" | awk -F'\t' '{for(i=1;i<=NF;i++) if($i ~ /PartitionCount/) {split($i,a,":"); print a[2]}}' | tr -d ' ')
-            CURRENT_REPLICATION=$(echo "$TOPIC_DESC" | awk -F'\t' '{for(i=1;i<=NF;i++) if($i ~ /ReplicationFactor/) {split($i,a,":"); print a[2]}}' | tr -d ' ')
-
-            CURRENT_PARTITIONS=${CURRENT_PARTITIONS:-0}
-            CURRENT_REPLICATION=${CURRENT_REPLICATION:-0}
-
-            echo "Debug: Parsed CURRENT_PARTITIONS='$CURRENT_PARTITIONS', CURRENT_REPLICATION='$CURRENT_REPLICATION'"
-
-            ALTER_NEEDED=false
-
-            if [ "$CURRENT_PARTITIONS" -gt 0 ] && [ "$DESIRED_PARTITIONS" -gt "$CURRENT_PARTITIONS" ]; then
-              echo "Topic {{ $topicName }} partitions need to be increased from $CURRENT_PARTITIONS to $DESIRED_PARTITIONS"
-              ALTER_NEEDED=true
-            fi
-
-            if [ "$CURRENT_REPLICATION" -gt 0 ] && [ "$CURRENT_REPLICATION" != "$DESIRED_REPLICATION" ]; then
-              echo "Warning: Topic {{ $topicName }} has replication factor $CURRENT_REPLICATION, but desired is $DESIRED_REPLICATION."
-              echo "Replication factor changes require manual intervention using kafka-reassign-partitions tool."
-            fi
-
-            if [ "$ALTER_NEEDED" = true ]; then
-              echo "Altering topic {{ $topicName }} partitions..."
-              /opt/kafka/bin/kafka-topics.sh \
-                --alter \
-                --bootstrap-server ${BOOTSTRAP_SERVER} \
-                --command-config /tmp/kafka-config/client.properties \
-                --topic {{ $topicName }} \
-                --partitions ${DESIRED_PARTITIONS}
-              echo "Topic {{ $topicName }} altered successfully"
-            elif [ "$CURRENT_PARTITIONS" -gt 0 ] && [ "$CURRENT_PARTITIONS" = "$DESIRED_PARTITIONS" ]; then
-              echo "Topic {{ $topicName }} already has correct partition count ($CURRENT_PARTITIONS)"
-            fi
-          else
-            echo "Warning: Could not describe topic {{ $topicName }}, skipping alteration check"
+          CURRENT_PARTITIONS=$(/opt/kafka/bin/kafka-topics.sh --describe \
+            --bootstrap-server "${BS}" --command-config "${CC}" \
+            --topic {{ $topicName | quote }} 2>/dev/null \
+            | awk -F'\t' '{for(i=1;i<=NF;i++) if($i ~ /PartitionCount/){split($i,a,":"); print a[2]}}' | tr -d ' ' | head -n1)
+          CURRENT_PARTITIONS=${CURRENT_PARTITIONS:-0}
+          if [ "${CURRENT_PARTITIONS}" -gt 0 ] && [ "${DESIRED_PARTITIONS}" -gt "${CURRENT_PARTITIONS}" ]; then
+            echo "Increasing {{ $topicName }} partitions ${CURRENT_PARTITIONS} -> ${DESIRED_PARTITIONS}"
+            /opt/kafka/bin/kafka-topics.sh --alter \
+              --bootstrap-server "${BS}" --command-config "${CC}" \
+              --topic {{ $topicName | quote }} --partitions ${DESIRED_PARTITIONS}
           fi
-
 {{- end }}
 
-          echo "Topics created successfully. Listing all topics:"
-          /opt/kafka/bin/kafka-topics.sh \
-            --list \
-            --bootstrap-server ${BOOTSTRAP_SERVER} \
-            --command-config /tmp/kafka-config/client.properties
+          {{- if .Values.kafka.auth.authorization.enabled }}
+          echo "Applying ACLs..."
+{{- range $acl := .Values.kafka.auth.authorization.acls }}
+{{- $principal := printf "User:%s" $acl.principal }}
+{{- if $acl.role }}
+{{- if eq $acl.role "producer" }}
+{{- range $t := $acl.topics }}
+          /opt/kafka/bin/kafka-acls.sh --bootstrap-server "${BS}" --command-config "${CC}" \
+            --add --allow-principal {{ $principal | quote }} --producer --topic {{ $t | quote }}
+{{- end }}
+{{- else if eq $acl.role "consumer" }}
+{{- $groups := $acl.groups | default (list "*") }}
+{{- range $t := $acl.topics }}
+{{- range $g := $groups }}
+          /opt/kafka/bin/kafka-acls.sh --bootstrap-server "${BS}" --command-config "${CC}" \
+            --add --allow-principal {{ $principal | quote }} --consumer --topic {{ $t | quote }} --group {{ $g | quote }}
+{{- end }}
+{{- end }}
+{{- else if eq $acl.role "admin" }}
+{{- range $t := $acl.topics }}
+          /opt/kafka/bin/kafka-acls.sh --bootstrap-server "${BS}" --command-config "${CC}" \
+            --add --allow-principal {{ $principal | quote }} --operation All --topic {{ $t | quote }}
+{{- end }}
+          /opt/kafka/bin/kafka-acls.sh --bootstrap-server "${BS}" --command-config "${CC}" \
+            --add --allow-principal {{ $principal | quote }} --operation All --group '*'
+{{- else }}
+          echo "Unknown ACL role '{{ $acl.role }}' for principal {{ $acl.principal }}; skipping." >&2
+{{- end }}
+{{- else }}
+{{- $permFlag := "--allow-principal" }}
+{{- if eq ($acl.permission | default "allow") "deny" }}{{- $permFlag = "--deny-principal" }}{{- end }}
+{{- $resourceFlag := "--topic" }}
+{{- if eq $acl.resourceType "group" }}{{- $resourceFlag = "--group" }}{{- else if eq $acl.resourceType "transactionalId" }}{{- $resourceFlag = "--transactional-id" }}{{- end }}
+          ACL_CMD="/opt/kafka/bin/kafka-acls.sh --bootstrap-server ${BS} --command-config ${CC} --add {{ $permFlag }} '{{ $principal }}'"
+{{- range $op := $acl.operations }}
+          ACL_CMD="${ACL_CMD} --operation {{ $op }}"
+{{- end }}
+{{- if eq $acl.resourceType "cluster" }}
+          ACL_CMD="${ACL_CMD} --cluster"
+{{- else }}
+          ACL_CMD="${ACL_CMD} {{ $resourceFlag }} '{{ $acl.resourceName }}'"
+{{- end }}
+{{- with $acl.patternType }}
+          ACL_CMD="${ACL_CMD} --resource-pattern-type {{ . }}"
+{{- end }}
+{{- with $acl.host }}
+          ACL_CMD="${ACL_CMD} --host '{{ . }}'"
+{{- end }}
+          eval "${ACL_CMD}"
+{{- end }}
+{{- end }}
+          {{- end }}
+
+          echo "Bootstrap complete. Topics:"
+          /opt/kafka/bin/kafka-topics.sh --list --bootstrap-server "${BS}" --command-config "${CC}"
+        volumeMounts:
+        - name: kafka-config-runtime
+          mountPath: /tmp/kafka-config
+        {{- if ne $mechanism "PLAIN" }}
+        - name: kafka-secret
+          mountPath: /opt/kafka/secrets
+          readOnly: true
+        {{- end }}
+        {{- if $tls }}
+        - name: kafka-tls
+          mountPath: /tmp/kafka-tls
+          readOnly: true
+        {{- end }}
       volumes:
-      - name: kafka-config
-        configMap:
-          name: {{ include "kafka.fullname" . }}-kafka-broker-config
+      - name: kafka-config-runtime
+        emptyDir: {}
+      {{- if ne $mechanism "PLAIN" }}
       - name: kafka-secret
         secret:
           secretName: {{ include "kafka.auth.secretName" . }}
-      - name: kafka-config-runtime
-        emptyDir: {}
-      {{- if .Values.kafka.tls.enabled }}
+      {{- end }}
+      {{- if $tls }}
       - name: kafka-tls-pem
         secret:
           secretName: {{ include "kafka.tls.secretName" . }}
+      - name: kafka-tls
+        emptyDir: {}
       {{- end }}
 {{- end }}

--- a/kafka/templates/kafka-topic-init-job.yaml
+++ b/kafka/templates/kafka-topic-init-job.yaml
@@ -66,6 +66,13 @@ spec:
             -storetype PKCS12 \
             -storepass "${STORE_PASS}" \
             -noprompt -alias ca
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
         volumeMounts:
         - name: kafka-tls-pem
           mountPath: /opt/kafka/tls-pem

--- a/kafka/templates/kafka-topic-init-job.yaml
+++ b/kafka/templates/kafka-topic-init-job.yaml
@@ -84,13 +84,20 @@ spec:
       - name: kafka-topic-init
         image: {{ .Values.kafka.image.registry }}/{{ .Values.kafka.image.repository }}:{{ .Values.kafka.image.tag }}
         imagePullPolicy: {{ .Values.kafka.image.pullPolicy }}
+        env:
+          # The Kafka CLI tools default to -Xmx256M; with only 256Mi of container
+          # memory the JVM (heap + metaspace + stacks) is OOM-killed, which surfaces
+          # as silent AdminClient connection timeouts. Cap the heap and give the
+          # container headroom for heap + JVM overhead.
+          - name: KAFKA_HEAP_OPTS
+            value: "-Xmx192m -Xms64m"
         resources:
           requests:
             cpu: 50m
-            memory: 64Mi
+            memory: 128Mi
           limits:
             cpu: 200m
-            memory: 256Mi
+            memory: 512Mi
         command:
         - /bin/bash
         - -c

--- a/kafka/tests/test-full.sh
+++ b/kafka/tests/test-full.sh
@@ -115,14 +115,19 @@ kubectl exec -n "${NAMESPACE}" "${BROKER_0}" -- bash -c "
 " >/dev/null 2>&1 || acl_rc=$?
 assert_eq "appuser (producer ACL) can write to test-topic-1" "0" "${acl_rc}"
 
-# appuser has NO ACL on test-topic-2, so a write must be denied.
-deny_rc=0
-kubectl exec -n "${NAMESPACE}" "${BROKER_0}" -- bash -c "
+# appuser has NO ACL on test-topic-2, so a write must be denied. Note that
+# kafka-console-producer exits 0 even on an authorization failure, so detect the
+# error message rather than the process exit code.
+deny_out=$(kubectl exec -n "${NAMESPACE}" "${BROKER_0}" -- bash -c "
   echo 'nope' | /opt/kafka/bin/kafka-console-producer.sh \
     --bootstrap-server ${BROKER_SVC} --topic test-topic-2 \
-    --producer.config /tmp/appuser.properties
-" >/dev/null 2>&1 || deny_rc=$?
-if [[ "${deny_rc}" -ne 0 ]]; then pass "appuser without ACL is denied on test-topic-2"; else fail "appuser without ACL is denied on test-topic-2"; fi
+    --producer.config /tmp/appuser.properties 2>&1
+" || true)
+if echo "${deny_out}" | grep -qiE 'authorization failed|TOPIC_AUTHORIZATION_FAILED'; then
+  pass "appuser without ACL is denied on test-topic-2"
+else
+  fail "appuser without ACL is denied on test-topic-2" "${deny_out}"
+fi
 
 # --- Exporter tests ---
 echo ""
@@ -138,12 +143,19 @@ exporter_port=$(kubectl get svc -n "${NAMESPACE}" "${FULLNAME}-kafka-exporter" -
 assert_eq "exporter service port is 9308" "9308" "${exporter_port}"
 
 exporter_svc="${FULLNAME}-kafka-exporter"
-kubectl port-forward -n "${NAMESPACE}" "svc/${exporter_svc}" 19308:9308 &
-PF_PID=$!
-sleep 2
-metrics_output=$(wget -qO- "http://127.0.0.1:19308/metrics" 2>/dev/null | grep -m1 '^kafka_' || echo "")
-kill "${PF_PID}" 2>/dev/null || true
-wait "${PF_PID}" 2>/dev/null || true
+# The exporter can restart a few times on a fresh cluster until the broker DNS
+# resolves, so poll /metrics until kafka_ series appear (bounded).
+metrics_output=""
+for _ in $(seq 1 12); do
+  kubectl port-forward -n "${NAMESPACE}" "svc/${exporter_svc}" 19308:9308 >/dev/null 2>&1 &
+  PF_PID=$!
+  sleep 3
+  metrics_output=$( { curl -sf "http://127.0.0.1:19308/metrics" 2>/dev/null || wget -qO- "http://127.0.0.1:19308/metrics" 2>/dev/null; } | grep -m1 '^kafka_' || echo "")
+  kill "${PF_PID}" 2>/dev/null || true
+  wait "${PF_PID}" 2>/dev/null || true
+  [ -n "${metrics_output}" ] && break
+  sleep 5
+done
 assert_contains "exporter returns kafka metrics" "${metrics_output}" "kafka_"
 
 end_suite

--- a/kafka/tests/test-full.sh
+++ b/kafka/tests/test-full.sh
@@ -9,6 +9,22 @@ NAMESPACE="${NAMESPACE:-kafka-test-full}"
 RELEASE="${RELEASE:-kafka-full}"
 FULLNAME="${RELEASE}"
 
+# On any failure (e.g. a helm --wait timeout), dump cluster state so CI logs are
+# self-diagnosing instead of a bare "timed out waiting for the condition".
+dump_diagnostics() {
+  local rc=$?
+  [ "${rc}" -eq 0 ] && return 0
+  echo "=== FAILURE DIAGNOSTICS (rc=${rc}, namespace ${NAMESPACE}) ==="
+  kubectl get pods,jobs,certificate,issuer -n "${NAMESPACE}" 2>&1 || true
+  kubectl get events -n "${NAMESPACE}" --sort-by=.lastTimestamp 2>&1 | tail -25 || true
+  for p in $(kubectl get pods -n "${NAMESPACE}" -o name 2>/dev/null); do
+    echo "--- ${p} ---"
+    kubectl describe "${p}" -n "${NAMESPACE}" 2>&1 | sed -n '/Events:/,$p' | tail -12 || true
+    kubectl logs "${p}" -n "${NAMESPACE}" --all-containers --tail=40 2>&1 | tail -40 || true
+  done
+}
+trap dump_diagnostics EXIT
+
 begin_suite "Full Install (1 controller + 2 brokers + exporter + topics + ACLs, TLS/mTLS/SCRAM)"
 
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -

--- a/kafka/tests/test-full.sh
+++ b/kafka/tests/test-full.sh
@@ -9,20 +9,21 @@ NAMESPACE="${NAMESPACE:-kafka-test-full}"
 RELEASE="${RELEASE:-kafka-full}"
 FULLNAME="${RELEASE}"
 
-begin_suite "Full Install (1 controller + 2 brokers + exporter + topics)"
+begin_suite "Full Install (1 controller + 2 brokers + exporter + topics + ACLs, TLS/mTLS/SCRAM)"
 
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 
+# TLS on by default (chart self-signed CA). The bootstrap Job provisions SCRAM
+# users, declared topics, and ACLs before helm returns.
 helm upgrade --install "${RELEASE}" "${CHART_DIR}" \
   -n "${NAMESPACE}" \
   -f "${SCRIPT_DIR}/values-full-test.yaml" \
-  --wait --timeout 10m
+  --wait --timeout 12m
 
 CONTROLLER="${FULLNAME}-kafka-controller-0"
 BROKER_0="${FULLNAME}-kafka-broker-0"
 BROKER_1="${FULLNAME}-kafka-broker-1"
 
-# helm --wait already ensures pods are ready; verify phase directly
 ctrl_phase=$(kubectl get pod -n "${NAMESPACE}" "${CONTROLLER}" -o jsonpath='{.status.phase}')
 assert_eq "controller pod is Running" "Running" "${ctrl_phase}"
 
@@ -31,85 +32,85 @@ for pod in "${BROKER_0}" "${BROKER_1}"; do
   assert_eq "${pod} is Running" "Running" "${phase}"
 done
 
-# Wait for declared topics (topic init job runs as post-install/post-upgrade hook)
-BROKER_SVC="${BROKER_0}.${FULLNAME}-kafka-broker.${NAMESPACE}.svc.cluster.local:9092"
-KAFKA_CLI_SETUP='
-  KAFKA_USERNAME=$(cat /opt/kafka/secrets/username)
-  KAFKA_PASSWORD=$(cat /opt/kafka/secrets/password)
-  mkdir -p /tmp/kafka-config
-  cp /opt/kafka/config/kraft/client.properties /tmp/kafka-config/
-  sed -e "s|PLACEHOLDER_USERNAME|${KAFKA_USERNAME}|g" -e "s|PLACEHOLDER_PASSWORD|${KAFKA_PASSWORD}|g" \
-    /opt/kafka/config/kraft/client_jaas.conf.template > /tmp/kafka-config/client_jaas.conf
-  export KAFKA_OPTS="-Djava.security.auth.login.config=/tmp/kafka-config/client_jaas.conf"
-'
+# PKCS12 store password is deterministic: sha256("<release>-tls-store")[:32]
+STOREPASS=$(printf '%s' "${RELEASE}-tls-store" | sha256sum | cut -c1-32)
+TESTUSER_PW=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o jsonpath='{.data.testuser-password}' | base64 -d)
+APPUSER_PW=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o jsonpath='{.data.appuser-password}' | base64 -d)
 
-echo "  Waiting for declared topics to appear..."
-topics_output=""
-topic_timeout=60
-topic_elapsed=0
-while [[ ${topic_elapsed} -lt ${topic_timeout} ]]; do
-  topics_output=$(kubectl exec -n "${NAMESPACE}" "${BROKER_0}" -- bash -c "
-    ${KAFKA_CLI_SETUP}
-    /opt/kafka/bin/kafka-topics.sh \
-      --bootstrap-server ${BROKER_SVC} \
-      --list \
-      --command-config /tmp/kafka-config/client.properties 2>/dev/null
-  " 2>/dev/null || echo "")
-  if grep -q "test-topic-1" <<< "${topics_output}" && grep -q "test-topic-2" <<< "${topics_output}"; then
-    break
-  fi
-  sleep 2
-  topic_elapsed=$((topic_elapsed + 2))
-done
+# Write a SASL_SSL/SCRAM client config for a given user inside a pod.
+write_client_props() {
+  local pod="$1" user="$2" pw="$3"
+  kubectl exec -n "${NAMESPACE}" "${pod}" -- bash -c "cat > /tmp/${user}.properties <<EOF
+security.protocol=SASL_SSL
+sasl.mechanism=SCRAM-SHA-512
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${user}\" password=\"${pw}\";
+ssl.truststore.location=/opt/kafka/tls/truststore.p12
+ssl.truststore.password=${STOREPASS}
+ssl.truststore.type=PKCS12
+EOF"
+}
+
+write_client_props "${BROKER_0}" testuser "${TESTUSER_PW}"
+write_client_props "${BROKER_1}" testuser "${TESTUSER_PW}"
+write_client_props "${BROKER_0}" appuser "${APPUSER_PW}"
+
+BROKER_SVC="${BROKER_0}.${FULLNAME}-kafka-broker.${NAMESPACE}.svc.cluster.local:9092"
+BROKER_1_SVC="${BROKER_1}.${FULLNAME}-kafka-broker.${NAMESPACE}.svc.cluster.local:9092"
+
+# Declared topics were created by the bootstrap Job.
+topics_output=$(kubectl exec -n "${NAMESPACE}" "${BROKER_0}" -- bash -c "
+  /opt/kafka/bin/kafka-topics.sh --bootstrap-server ${BROKER_SVC} --list \
+    --command-config /tmp/testuser.properties 2>/dev/null
+" || echo "")
 assert_contains "test-topic-1 exists" "${topics_output}" "test-topic-1"
 assert_contains "test-topic-2 exists" "${topics_output}" "test-topic-2"
 
-# Batch topic describe + cross-broker produce/consume + topic list into single execs per broker
-# to minimize JVM startups
-
-# Describe topic and produce from broker-0 in one exec
-CROSS_TOPIC="cross-test-$(date +%s)"
-TEST_VALUE="cross-broker-$(date +%s)"
-
-broker0_output=$(kubectl exec -n "${NAMESPACE}" "${BROKER_0}" -- bash -c "
-  ${KAFKA_CLI_SETUP}
-
-  T1_DESC=\$(/opt/kafka/bin/kafka-topics.sh \
-    --bootstrap-server ${BROKER_SVC} \
-    --describe --topic test-topic-1 \
-    --command-config /tmp/kafka-config/client.properties 2>/dev/null \
-    | grep 'PartitionCount' | sed 's/.*PartitionCount:[[:space:]]*//' | cut -f1)
-  echo \"T1_PARTITIONS=\${T1_DESC}\"
-
-  echo '${TEST_VALUE}' | /opt/kafka/bin/kafka-console-producer.sh \
-    --bootstrap-server ${BROKER_SVC} \
-    --topic ${CROSS_TOPIC} \
-    --producer.config /tmp/kafka-config/client.properties 2>/dev/null
-  echo 'PRODUCE_DONE=true'
-" 2>/dev/null || echo "")
-
-t1_partitions=$(echo "${broker0_output}" | grep '^T1_PARTITIONS=' | head -1 | cut -d= -f2-)
+# test-topic-1 has 3 partitions
+t1_partitions=$(kubectl exec -n "${NAMESPACE}" "${BROKER_0}" -- bash -c "
+  /opt/kafka/bin/kafka-topics.sh --bootstrap-server ${BROKER_SVC} --describe --topic test-topic-1 \
+    --command-config /tmp/testuser.properties 2>/dev/null \
+    | grep 'PartitionCount' | sed 's/.*PartitionCount:[[:space:]]*//' | cut -f1
+" || echo "")
 assert_eq "test-topic-1 has 3 partitions" "3" "${t1_partitions}"
 
-# Consume from broker-1
-BROKER_1_SVC="${BROKER_1}.${FULLNAME}-kafka-broker.${NAMESPACE}.svc.cluster.local:9092"
+# Cross-broker produce (broker-0) / consume (broker-1) as the superuser
+CROSS_TOPIC="cross-test-$(date +%s)"
+TEST_VALUE="cross-broker-$(date +%s)"
+kubectl exec -n "${NAMESPACE}" "${BROKER_0}" -- bash -c "
+  echo '${TEST_VALUE}' | /opt/kafka/bin/kafka-console-producer.sh \
+    --bootstrap-server ${BROKER_SVC} --topic ${CROSS_TOPIC} \
+    --producer.config /tmp/testuser.properties
+"
 consumed=$(kubectl exec -n "${NAMESPACE}" "${BROKER_1}" -- bash -c "
-  ${KAFKA_CLI_SETUP}
-  # Write consumed message to a file so timeout exit code does not lose stdout
   timeout 60 /opt/kafka/bin/kafka-console-consumer.sh \
-    --bootstrap-server ${BROKER_1_SVC} \
-    --topic ${CROSS_TOPIC} \
-    --from-beginning \
-    --max-messages 1 \
-    --consumer.config /tmp/kafka-config/client.properties 2>/dev/null > /tmp/consumed.out || true
-  cat /tmp/consumed.out
-" 2>/dev/null || echo "")
+    --bootstrap-server ${BROKER_1_SVC} --topic ${CROSS_TOPIC} \
+    --from-beginning --max-messages 1 \
+    --consumer.config /tmp/testuser.properties 2>/dev/null
+" || echo "")
 assert_eq "cross-broker produce/consume works" "${TEST_VALUE}" "${consumed}"
+
+# --- ACL enforcement: appuser has a producer role on test-topic-1 ---
+acl_value="acl-$(date +%s)"
+acl_rc=0
+kubectl exec -n "${NAMESPACE}" "${BROKER_0}" -- bash -c "
+  echo '${acl_value}' | /opt/kafka/bin/kafka-console-producer.sh \
+    --bootstrap-server ${BROKER_SVC} --topic test-topic-1 \
+    --producer.config /tmp/appuser.properties
+" >/dev/null 2>&1 || acl_rc=$?
+assert_eq "appuser (producer ACL) can write to test-topic-1" "0" "${acl_rc}"
+
+# appuser has NO ACL on test-topic-2, so a write must be denied.
+deny_rc=0
+kubectl exec -n "${NAMESPACE}" "${BROKER_0}" -- bash -c "
+  echo 'nope' | /opt/kafka/bin/kafka-console-producer.sh \
+    --bootstrap-server ${BROKER_SVC} --topic test-topic-2 \
+    --producer.config /tmp/appuser.properties
+" >/dev/null 2>&1 || deny_rc=$?
+if [[ "${deny_rc}" -ne 0 ]]; then pass "appuser without ACL is denied on test-topic-2"; else fail "appuser without ACL is denied on test-topic-2"; fi
 
 # --- Exporter tests ---
 echo ""
 echo "  -- Exporter tests --"
-
 wait_for_deployment_ready "${NAMESPACE}" "${FULLNAME}-kafka-exporter" 300
 
 exporter_pod=$(kubectl get pods -n "${NAMESPACE}" -l "app.kubernetes.io/component=kafka-exporter" \
@@ -120,16 +121,13 @@ assert_eq "exporter pod is Running" "Running" "${exporter_phase}"
 exporter_port=$(kubectl get svc -n "${NAMESPACE}" "${FULLNAME}-kafka-exporter" -o jsonpath='{.spec.ports[0].port}')
 assert_eq "exporter service port is 9308" "9308" "${exporter_port}"
 
-# Fetch metrics via port-forward instead of spinning up an ephemeral pod
 exporter_svc="${FULLNAME}-kafka-exporter"
 kubectl port-forward -n "${NAMESPACE}" "svc/${exporter_svc}" 19308:9308 &
 PF_PID=$!
-sleep 1
-
+sleep 2
 metrics_output=$(wget -qO- "http://127.0.0.1:19308/metrics" 2>/dev/null | grep -m1 '^kafka_' || echo "")
 kill "${PF_PID}" 2>/dev/null || true
 wait "${PF_PID}" 2>/dev/null || true
-
 assert_contains "exporter returns kafka metrics" "${metrics_output}" "kafka_"
 
 end_suite

--- a/kafka/tests/test-minimal.sh
+++ b/kafka/tests/test-minimal.sh
@@ -10,6 +10,22 @@ RELEASE="${RELEASE:-kafka-minimal}"
 FULLNAME="${RELEASE}"
 USER_NAME="testuser"
 
+# On any failure (e.g. a helm --wait timeout), dump cluster state so CI logs are
+# self-diagnosing instead of a bare "timed out waiting for the condition".
+dump_diagnostics() {
+  local rc=$?
+  [ "${rc}" -eq 0 ] && return 0
+  echo "=== FAILURE DIAGNOSTICS (rc=${rc}, namespace ${NAMESPACE}) ==="
+  kubectl get pods,jobs,certificate,issuer -n "${NAMESPACE}" 2>&1 || true
+  kubectl get events -n "${NAMESPACE}" --sort-by=.lastTimestamp 2>&1 | tail -25 || true
+  for p in $(kubectl get pods -n "${NAMESPACE}" -o name 2>/dev/null); do
+    echo "--- ${p} ---"
+    kubectl describe "${p}" -n "${NAMESPACE}" 2>&1 | sed -n '/Events:/,$p' | tail -12 || true
+    kubectl logs "${p}" -n "${NAMESPACE}" --all-containers --tail=40 2>&1 | tail -40 || true
+  done
+}
+trap dump_diagnostics EXIT
+
 begin_suite "Minimal Install (1 controller + 1 broker, TLS/mTLS/SCRAM)"
 
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -

--- a/kafka/tests/test-minimal.sh
+++ b/kafka/tests/test-minimal.sh
@@ -8,84 +8,87 @@ source "${SCRIPT_DIR}/helpers.sh"
 NAMESPACE="${NAMESPACE:-kafka-test-minimal}"
 RELEASE="${RELEASE:-kafka-minimal}"
 FULLNAME="${RELEASE}"
+USER_NAME="testuser"
 
-begin_suite "Minimal Install (1 controller + 1 broker)"
+begin_suite "Minimal Install (1 controller + 1 broker, TLS/mTLS/SCRAM)"
 
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 
+# TLS is on by default (chart-managed self-signed CA via cert-manager). The
+# post-install bootstrap Job provisions the SCRAM users before helm returns.
 helm upgrade --install "${RELEASE}" "${CHART_DIR}" \
   -n "${NAMESPACE}" \
   -f "${SCRIPT_DIR}/values-minimal.yaml" \
-  --wait --timeout 5m
+  --wait --timeout 8m
 
 CONTROLLER="${FULLNAME}-kafka-controller-0"
 BROKER="${FULLNAME}-kafka-broker-0"
 
-# helm --wait already ensures pods are ready; verify phase directly
 ctrl_phase=$(kubectl get pod -n "${NAMESPACE}" "${CONTROLLER}" -o jsonpath='{.status.phase}')
 assert_eq "controller pod is Running" "Running" "${ctrl_phase}"
 
 broker_phase=$(kubectl get pod -n "${NAMESPACE}" "${BROKER}" -o jsonpath='{.status.phase}')
 assert_eq "broker pod is Running" "Running" "${broker_phase}"
 
-# Test: controller service exists
+# controller service exists on 9093
 ctrl_port=$(kubectl get svc -n "${NAMESPACE}" "${FULLNAME}-kafka-controller" -o jsonpath='{.spec.ports[0].port}')
 assert_eq "controller service port is 9093" "9093" "${ctrl_port}"
 
-# Test: broker service exists (headless)
+# broker service is headless
 broker_svc_ip=$(kubectl get svc -n "${NAMESPACE}" "${FULLNAME}-kafka-broker" -o jsonpath='{.spec.clusterIP}')
 assert_eq "broker service is headless" "None" "${broker_svc_ip}"
 
-# Test: secret exists
-secret_exists=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o name 2>/dev/null || echo "")
-assert_contains "kafka secret exists" "${secret_exists}" "secret"
+# per-user password secret exists
+secret_key=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o jsonpath="{.data.${USER_NAME}-password}" 2>/dev/null || echo "")
+if [[ -n "${secret_key}" ]]; then pass "per-user SCRAM secret key present"; else fail "per-user SCRAM secret key present"; fi
 
-# Helper: JAAS setup for Kafka CLI (reused across execs)
+# TLS materials issued by cert-manager
+tls_secret=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-tls" -o name 2>/dev/null || echo "")
+assert_contains "cert-manager issued the broker TLS secret" "${tls_secret}" "secret"
+
+# --- SASL_SSL + SCRAM produce/consume as a client user ---
 BROKER_SVC="${BROKER}.${FULLNAME}-kafka-broker.${NAMESPACE}.svc.cluster.local:9092"
-KAFKA_CLI_SETUP='
-  KAFKA_USERNAME=$(cat /opt/kafka/secrets/username)
-  KAFKA_PASSWORD=$(cat /opt/kafka/secrets/password)
-  mkdir -p /tmp/kafka-config
-  cp /opt/kafka/config/kraft/client.properties /tmp/kafka-config/
-  sed -e "s|PLACEHOLDER_USERNAME|${KAFKA_USERNAME}|g" -e "s|PLACEHOLDER_PASSWORD|${KAFKA_PASSWORD}|g" \
-    /opt/kafka/config/kraft/client_jaas.conf.template > /tmp/kafka-config/client_jaas.conf
-  export KAFKA_OPTS="-Djava.security.auth.login.config=/tmp/kafka-config/client_jaas.conf"
-'
+PASSWORD=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o jsonpath="{.data.${USER_NAME}-password}" | base64 -d)
+# PKCS12 store password is deterministic: sha256("<release>-tls-store")[:32]
+STOREPASS=$(printf '%s' "${RELEASE}-tls-store" | sha256sum | cut -c1-32)
 
-# Test: produce and consume a message via SASL
+# Write a SASL_SSL/SCRAM client config inside the broker pod (reuses the pod's
+# mTLS truststore, which trusts the chart CA).
+kubectl exec -n "${NAMESPACE}" "${BROKER}" -- bash -c "cat > /tmp/client.properties <<EOF
+security.protocol=SASL_SSL
+sasl.mechanism=SCRAM-SHA-512
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${USER_NAME}\" password=\"${PASSWORD}\";
+ssl.truststore.location=/opt/kafka/tls/truststore.p12
+ssl.truststore.password=${STOREPASS}
+ssl.truststore.type=PKCS12
+EOF"
+
 TEST_TOPIC="test-$(date +%s)"
 TEST_VALUE="hello-$(date +%s)"
 
-# Produce (auto-creates topic)
 kubectl exec -n "${NAMESPACE}" "${BROKER}" -- bash -c "
-  ${KAFKA_CLI_SETUP}
   echo '${TEST_VALUE}' | /opt/kafka/bin/kafka-console-producer.sh \
     --bootstrap-server ${BROKER_SVC} \
     --topic ${TEST_TOPIC} \
-    --producer.config /tmp/kafka-config/client.properties 2>/dev/null
-" 2>/dev/null
+    --producer.config /tmp/client.properties
+"
 
-# Consume
 consumed=$(kubectl exec -n "${NAMESPACE}" "${BROKER}" -- bash -c "
-  ${KAFKA_CLI_SETUP}
   timeout 60 /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server ${BROKER_SVC} \
     --topic ${TEST_TOPIC} \
     --from-beginning \
     --max-messages 1 \
-    --consumer.config /tmp/kafka-config/client.properties 2>/dev/null > /tmp/consumed.out || true
-  cat /tmp/consumed.out
-" 2>/dev/null || echo "")
-assert_eq "can produce and consume message" "${TEST_VALUE}" "${consumed}"
+    --consumer.config /tmp/client.properties 2>/dev/null
+" || echo "")
+assert_eq "can produce and consume over SASL_SSL/SCRAM" "${TEST_VALUE}" "${consumed}"
 
-# Test: list topics
 topics_output=$(kubectl exec -n "${NAMESPACE}" "${BROKER}" -- bash -c "
-  ${KAFKA_CLI_SETUP}
   /opt/kafka/bin/kafka-topics.sh \
     --bootstrap-server ${BROKER_SVC} \
     --list \
-    --command-config /tmp/kafka-config/client.properties 2>/dev/null
-" 2>/dev/null || echo "")
+    --command-config /tmp/client.properties 2>/dev/null
+" || echo "")
 assert_contains "auto-created topic exists" "${topics_output}" "${TEST_TOPIC}"
 
 end_suite

--- a/kafka/tests/test-template.sh
+++ b/kafka/tests/test-template.sh
@@ -17,18 +17,19 @@ assert_eq "helm lint with minimal values passes" "0" "${lint_rc}"
 lint_output=$(helm lint "${CHART_DIR}" -f "${SCRIPT_DIR}/values-full-test.yaml" 2>&1) && lint_rc=0 || lint_rc=$?
 assert_eq "helm lint with full values passes" "0" "${lint_rc}"
 
-# Render minimal template
+# Render minimal template (TLS on via chart self-signed CA)
 minimal=$(helm template test-kafka "${CHART_DIR}" -f "${SCRIPT_DIR}/values-minimal.yaml" 2>&1)
 
 assert_contains "minimal: controller statefulset present" "${minimal}" "kafka-controller"
 assert_contains "minimal: broker statefulset present" "${minimal}" "kafka-broker"
 assert_contains "minimal: controller service present" "${minimal}" "kind: Service"
 assert_contains "minimal: secret created" "${minimal}" "kind: Secret"
+assert_contains "minimal: per-user password key" "${minimal}" "testuser-password"
 assert_contains "minimal: configmap created" "${minimal}" "kind: ConfigMap"
 assert_not_contains "minimal: no exporter deployment" "${minimal}" "kafka-exporter"
 assert_not_contains "minimal: no topics in configmap" "${minimal}" "test-topic"
 
-# Render full template
+# Render full template (TLS on via chart self-signed CA)
 full=$(helm template test-kafka "${CHART_DIR}" -f "${SCRIPT_DIR}/values-full-test.yaml" 2>&1)
 
 assert_contains "full: controller statefulset present" "${full}" "kafka-controller"
@@ -39,11 +40,15 @@ assert_contains "full: topics configmap present" "${full}" "kafka-topics"
 assert_contains "full: exporter service present" "${full}" "port: 9308"
 assert_contains "full: controller port 9093" "${full}" "port: 9093"
 assert_contains "full: broker port 9092" "${full}" "port: 9092"
-assert_contains "full: SASL configured" "${full}" "SASL_PLAINTEXT"
+assert_contains "full: internal listener port 9094" "${full}" "port: 9094"
+assert_contains "full: SASL_SSL client listener" "${full}" "SASL_SSL"
+assert_contains "full: authorizer enabled" "${full}" "StandardAuthorizer"
+assert_contains "full: job provisions SCRAM users" "${full}" "kafka-configs.sh"
+assert_contains "full: job applies ACLs" "${full}" "kafka-acls.sh"
 assert_contains "full: serviceaccount created" "${full}" "kind: ServiceAccount"
 assert_contains "full: broker replicas 2" "${full}" "replicas: 2"
 
-# Render default template and verify enterprise defaults
+# Render default template and verify enterprise secure defaults
 defaults=$(helm template test-kafka "${CHART_DIR}" 2>&1)
 
 assert_contains "defaults: controller replicas 3" "${defaults}" "replicas: 3"
@@ -53,10 +58,19 @@ assert_contains "defaults: broker config replication factor" "${defaults}" "defa
 assert_contains "defaults: broker config min ISR" "${defaults}" "min.insync.replicas=2"
 assert_contains "defaults: log retention configured" "${defaults}" "log.retention.hours=168"
 assert_contains "defaults: auto create topics disabled" "${defaults}" "auto.create.topics.enable=false"
+# secure-by-default
+assert_contains "defaults: TLS on, SASL_SSL client listener" "${defaults}" "CLIENT:SASL_SSL"
+assert_contains "defaults: mTLS on internal listener" "${defaults}" "listener.name.internal.ssl.client.auth=required"
+assert_contains "defaults: SCRAM-SHA-512 mechanism" "${defaults}" "sasl.enabled.mechanisms=SCRAM-SHA-512"
+assert_contains "defaults: StandardAuthorizer" "${defaults}" "StandardAuthorizer"
+assert_contains "defaults: deny by default" "${defaults}" "allow.everyone.if.no.acl.found=false"
+assert_contains "defaults: self-signed Issuer created" "${defaults}" "test-kafka-kafka-selfsigned"
+assert_contains "defaults: CA Issuer created" "${defaults}" "test-kafka-kafka-ca"
+assert_contains "defaults: leaf Certificate created" "${defaults}" "kind: Certificate"
+assert_contains "defaults: tls-init init container present" "${defaults}" "tls-init"
 
-# --- TLS with cert-manager ---
+# --- TLS with an operator-supplied cert-manager issuer ---
 tls_cm=$(helm template test-kafka "${CHART_DIR}" \
-  --set kafka.tls.enabled=true \
   --set kafka.tls.certManager.issuerRef.name=my-issuer 2>&1)
 
 assert_contains "tls-cm: Certificate resource created" "${tls_cm}" "kind: Certificate"
@@ -66,34 +80,38 @@ assert_contains "tls-cm: wildcard broker SAN" "${tls_cm}" "*.test-kafka-kafka-br
 assert_contains "tls-cm: broker listener uses SASL_SSL" "${tls_cm}" "SASL_SSL"
 assert_contains "tls-cm: controller protocol uses SSL" "${tls_cm}" "CONTROLLER:SSL"
 assert_contains "tls-cm: ssl keystore configured" "${tls_cm}" "ssl.keystore.type=PKCS12"
-assert_contains "tls-cm: ssl truststore configured" "${tls_cm}" "ssl.truststore.type=PKCS12"
-assert_contains "tls-cm: tls-init init container present" "${tls_cm}" "tls-init"
-assert_contains "tls-cm: tls PEM volume mount present" "${tls_cm}" "kafka-tls-pem"
-assert_contains "tls-cm: exporter tls flag present" "${tls_cm}" "tls.enabled"
-assert_contains "tls-cm: exporter ca-file flag present" "${tls_cm}" "tls.ca-file"
-assert_not_contains "tls-cm: no SASL_PLAINTEXT when TLS enabled" "${tls_cm}" "SASL_PLAINTEXT"
+assert_contains "tls-cm: exporter mTLS cert flag present" "${tls_cm}" "tls.cert-file"
+assert_not_contains "tls-cm: no chart self-signed issuer when external issuer set" "${tls_cm}" "kafka-selfsigned"
 
 # --- TLS with existing secret (no cert-manager Certificate) ---
 tls_es=$(helm template test-kafka "${CHART_DIR}" \
-  --set kafka.tls.enabled=true \
   --set kafka.tls.existingSecret=my-tls-secret 2>&1)
 
 assert_not_contains "tls-existing: no Certificate resource" "${tls_es}" "kind: Certificate"
+assert_not_contains "tls-existing: no self-signed issuer" "${tls_es}" "kafka-selfsigned"
 assert_contains "tls-existing: volumes reference existing secret" "${tls_es}" "secretName: my-tls-secret"
 assert_contains "tls-existing: SASL_SSL listeners" "${tls_es}" "SASL_SSL"
 
-# --- TLS fail-fast: enabled without secret or issuer ---
-tls_fail=$(helm template test-kafka "${CHART_DIR}" \
-  --set kafka.tls.enabled=true 2>&1) && tls_fail_rc=0 || tls_fail_rc=$?
+# --- Bare defaults render (self-signed CA), no fail-fast ---
+helm template test-kafka "${CHART_DIR}" >/dev/null 2>&1 && ss_rc=0 || ss_rc=$?
+assert_eq "self-signed: bare defaults render successfully" "0" "${ss_rc}"
 
-assert_eq "tls-fail: template fails when no secret or issuer" "1" "${tls_fail_rc}"
-assert_contains "tls-fail: error mentions required config" "${tls_fail}" "kafka.tls.existingSecret or kafka.tls.certManager.issuerRef.name"
+# --- Insecure opt-out ---
+insecure=$(helm template test-kafka "${CHART_DIR}" \
+  --set kafka.tls.enabled=false \
+  --set kafka.auth.allowInsecure=true 2>&1)
 
-# --- TLS disabled: no TLS artifacts ---
-assert_not_contains "defaults: no Certificate when TLS disabled" "${defaults}" "kind: Certificate"
-assert_not_contains "defaults: no tls-init when TLS disabled" "${defaults}" "tls-init"
-assert_not_contains "defaults: no ssl keystore when TLS disabled" "${defaults}" "ssl.keystore"
-assert_not_contains "defaults: no SASL_SSL when TLS disabled" "${defaults}" "SASL_SSL"
+assert_contains "insecure: SASL_PLAINTEXT client listener" "${insecure}" "CLIENT:SASL_PLAINTEXT"
+assert_contains "insecure: ANONYMOUS super-user" "${insecure}" "User:ANONYMOUS"
+assert_not_contains "insecure: no Certificate" "${insecure}" "kind: Certificate"
+assert_not_contains "insecure: no tls-init" "${insecure}" "tls-init"
+
+# --- Guard: TLS disabled without the insecure opt-in fails ---
+guard=$(helm template test-kafka "${CHART_DIR}" \
+  --set kafka.tls.enabled=false 2>&1) && guard_rc=0 || guard_rc=$?
+
+assert_eq "guard: template fails when TLS disabled without allowInsecure" "1" "${guard_rc}"
+assert_contains "guard: error mentions allowInsecure" "${guard}" "kafka.auth.allowInsecure"
 
 end_suite
 print_summary

--- a/kafka/tests/unit/defaults_test.yaml
+++ b/kafka/tests/unit/defaults_test.yaml
@@ -1,11 +1,15 @@
-suite: enterprise defaults
+suite: enterprise secure defaults
 templates:
   - templates/kafka-controller-deployment.yaml
+  - templates/kafka-broker-deployment.yaml
   - templates/kafka-controller-service.yaml
   - templates/kafka-configmap.yaml
   - templates/kafka-certificate.yaml
+  - templates/kafka-issuer.yaml
+  - templates/kafka-secret.yaml
 release:
   name: test-kafka
+  namespace: default
 tests:
   - it: controller replicas default to 3
     template: templates/kafka-controller-deployment.yaml
@@ -28,7 +32,17 @@ tests:
           path: spec.clusterIP
           value: None
 
-  - it: broker config has enterprise defaults
+  - it: broker exposes the internal (inter-broker mTLS) 9094 port
+    template: templates/kafka-broker-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: internal
+            containerPort: 9094
+            protocol: TCP
+
+  - it: broker config has enterprise replication defaults
     template: templates/kafka-configmap.yaml
     documentIndex: 1
     asserts:
@@ -40,33 +54,65 @@ tests:
           pattern: min\.insync\.replicas=2
       - matchRegex:
           path: data["server.properties"]
-          pattern: log\.retention\.hours=168
-      - matchRegex:
-          path: data["server.properties"]
           pattern: auto\.create\.topics\.enable=false
 
-  - it: no Certificate when TLS disabled
-    template: templates/kafka-certificate.yaml
+  - it: broker config is secure-by-default (TLS listeners, SCRAM, authorizer)
+    template: templates/kafka-configmap.yaml
+    documentIndex: 1
     asserts:
-      - hasDocuments:
-          count: 0
+      - matchRegex:
+          path: data["server.properties"]
+          pattern: listener\.security\.protocol\.map=CLIENT:SASL_SSL,INTERNAL:SSL,CONTROLLER:SSL
+      - matchRegex:
+          path: data["server.properties"]
+          pattern: sasl\.enabled\.mechanisms=SCRAM-SHA-512
+      - matchRegex:
+          path: data["server.properties"]
+          pattern: authorizer\.class\.name=org\.apache\.kafka\.metadata\.authorizer\.StandardAuthorizer
+      - matchRegex:
+          path: data["server.properties"]
+          pattern: allow\.everyone\.if\.no\.acl\.found=false
+      - matchRegex:
+          path: data["server.properties"]
+          pattern: super\.users=User:test-kafka;User:admin
+      - matchRegex:
+          path: data["server.properties"]
+          pattern: listener\.name\.internal\.ssl\.client\.auth=required
+      - matchRegex:
+          path: data["server.properties"]
+          pattern: ssl\.principal\.mapping\.rules=
 
-  - it: no tls-init init container when TLS disabled
-    template: templates/kafka-controller-deployment.yaml
-    asserts:
-      - notContains:
-          path: spec.template.spec.initContainers
-          content:
-            name: tls-init
-          any: true
-
-  - it: no ssl keystore or SASL_SSL in controller config when TLS disabled
+  - it: controller config enforces mTLS on the controller listener
     template: templates/kafka-configmap.yaml
     documentIndex: 0
     asserts:
-      - notMatchRegex:
+      - matchRegex:
           path: data["server.properties"]
-          pattern: ssl\.keystore
-      - notMatchRegex:
+          pattern: listener\.name\.controller\.ssl\.client\.auth=required
+      - matchRegex:
           path: data["server.properties"]
-          pattern: SASL_SSL
+          pattern: authorizer\.class\.name=org\.apache\.kafka\.metadata\.authorizer\.StandardAuthorizer
+
+  - it: leaf Certificate is created and references the chart CA issuer by default
+    template: templates/kafka-certificate.yaml
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: spec.issuerRef.name
+          value: test-kafka-kafka-ca
+      - equal:
+          path: spec.issuerRef.kind
+          value: Issuer
+
+  - it: chart provisions a self-signed CA chain by default (SelfSigned Issuer + CA Cert + CA Issuer)
+    template: templates/kafka-issuer.yaml
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: per-user password secret key is present
+    template: templates/kafka-secret.yaml
+    asserts:
+      - isNotNullOrEmpty:
+          path: stringData["admin-password"]

--- a/kafka/tests/unit/full_test.yaml
+++ b/kafka/tests/unit/full_test.yaml
@@ -88,13 +88,30 @@ tests:
           path: spec.ports[0].port
           value: 9092
 
-  - it: broker config uses SASL_PLAINTEXT when TLS disabled
+  - it: broker config is secure (SASL_SSL + SCRAM + authorizer) under default TLS
     template: templates/kafka-configmap.yaml
     documentIndex: 1
     asserts:
       - matchRegex:
           path: data["server.properties"]
-          pattern: SASL_PLAINTEXT
+          pattern: listener\.security\.protocol\.map=CLIENT:SASL_SSL,INTERNAL:SSL,CONTROLLER:SSL
+      - matchRegex:
+          path: data["server.properties"]
+          pattern: sasl\.enabled\.mechanisms=SCRAM-SHA-512
+      - matchRegex:
+          path: data["server.properties"]
+          pattern: super\.users=User:test-kafka;User:testuser
+
+  - it: topic-init job provisions SCRAM users and applies ACLs
+    template: templates/kafka-topic-init-job.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[-1]
+          pattern: kafka-configs\.sh
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[-1]
+          pattern: kafka-acls\.sh
 
   - it: serviceaccount created
     template: templates/serviceaccount.yaml

--- a/kafka/tests/unit/tls_test.yaml
+++ b/kafka/tests/unit/tls_test.yaml
@@ -1,13 +1,12 @@
-suite: TLS configuration
+suite: TLS / secure transport configuration
 release:
   name: test-kafka
   namespace: default
 tests:
-  # --- TLS with cert-manager ---
-  - it: certificate resource created with cert-manager
+  # --- external issuer ---
+  - it: leaf Certificate uses the operator-supplied issuer when set
     template: templates/kafka-certificate.yaml
     set:
-      kafka.tls.enabled: true
       kafka.tls.certManager.issuerRef.name: my-issuer
     asserts:
       - isKind:
@@ -17,122 +16,95 @@ tests:
           value: my-issuer
       - contains:
           path: spec.dnsNames
-          content: "*.test-kafka-kafka-controller.default.svc.cluster.local"
-      - contains:
-          path: spec.dnsNames
           content: "*.test-kafka-kafka-broker.default.svc.cluster.local"
 
-  - it: broker config uses SASL_SSL and PKCS12 stores with TLS
+  - it: no self-signed chain when an external issuer is supplied
+    template: templates/kafka-issuer.yaml
+    set:
+      kafka.tls.certManager.issuerRef.name: my-issuer
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # --- chart self-signed default ---
+  - it: self-signed CA chain is created by default
+    template: templates/kafka-issuer.yaml
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: metadata.name
+          value: test-kafka-kafka-selfsigned
+        documentIndex: 0
+      - isKind:
+          of: Issuer
+        documentIndex: 0
+      - isKind:
+          of: Certificate
+        documentIndex: 1
+      - equal:
+          path: spec.isCA
+          value: true
+        documentIndex: 1
+      - isKind:
+          of: Issuer
+        documentIndex: 2
+      - equal:
+          path: spec.ca.secretName
+          value: test-kafka-kafka-ca
+        documentIndex: 2
+
+  - it: broker uses SASL_SSL and PKCS12 stores under TLS
     template: templates/kafka-configmap.yaml
     documentIndex: 1
-    set:
-      kafka.tls.enabled: true
-      kafka.tls.certManager.issuerRef.name: my-issuer
     asserts:
       - matchRegex:
           path: data["server.properties"]
-          pattern: SASL_SSL
+          pattern: listener\.security\.protocol\.map=CLIENT:SASL_SSL,INTERNAL:SSL,CONTROLLER:SSL
       - matchRegex:
           path: data["server.properties"]
           pattern: ssl\.keystore\.type=PKCS12
-      - matchRegex:
-          path: data["server.properties"]
-          pattern: ssl\.truststore\.type=PKCS12
 
-  - it: controller config uses CONTROLLER SSL with TLS
-    template: templates/kafka-configmap.yaml
-    documentIndex: 0
-    set:
-      kafka.tls.enabled: true
-      kafka.tls.certManager.issuerRef.name: my-issuer
-    asserts:
-      - matchRegex:
-          path: data["server.properties"]
-          pattern: listener\.security\.protocol\.map=CONTROLLER:SSL
-
-  - it: controller config has no SASL_PLAINTEXT with TLS
-    template: templates/kafka-configmap.yaml
-    documentIndex: 1
-    set:
-      kafka.tls.enabled: true
-      kafka.tls.certManager.issuerRef.name: my-issuer
-    asserts:
-      - notMatchRegex:
-          path: data["server.properties"]
-          pattern: SASL_PLAINTEXT
-
-  - it: controller statefulset has tls-init container and tls-pem volume
-    template: templates/kafka-controller-deployment.yaml
-    set:
-      kafka.tls.enabled: true
-      kafka.tls.certManager.issuerRef.name: my-issuer
+  - it: broker mounts the TLS keystore init container under TLS
+    template: templates/kafka-broker-deployment.yaml
     asserts:
       - contains:
           path: spec.template.spec.initContainers
           content:
             name: tls-init
           any: true
-      - contains:
-          path: spec.template.spec.volumes
-          content:
-            name: kafka-tls-pem
-            secret:
-              secretName: test-kafka-kafka-tls
-          any: true
 
-  - it: exporter command has tls flags with TLS
-    template: templates/kafka-exporter-deployment.yaml
+  # --- insecure opt-out ---
+  - it: insecure mode flips to plaintext with ANONYMOUS super-user
+    template: templates/kafka-configmap.yaml
+    documentIndex: 1
     set:
-      kafka.tls.enabled: true
-      kafka.tls.certManager.issuerRef.name: my-issuer
+      kafka.tls.enabled: false
+      kafka.auth.allowInsecure: true
     asserts:
       - matchRegex:
-          path: spec.template.spec.containers[0].command[2]
-          pattern: --tls\.enabled
+          path: data["server.properties"]
+          pattern: listener\.security\.protocol\.map=CLIENT:SASL_PLAINTEXT,INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
       - matchRegex:
-          path: spec.template.spec.containers[0].command[2]
-          pattern: --tls\.ca-file
+          path: data["server.properties"]
+          pattern: super\.users=User:ANONYMOUS;User:admin
 
-  # --- TLS with existing secret (no cert-manager Certificate) ---
-  - it: no certificate resource with existing secret
-    template: templates/kafka-certificate.yaml
+  - it: no Certificate or issuer chain in insecure mode
+    templates:
+      - templates/kafka-certificate.yaml
+      - templates/kafka-issuer.yaml
     set:
-      kafka.tls.enabled: true
-      kafka.tls.existingSecret: my-tls-secret
+      kafka.tls.enabled: false
+      kafka.auth.allowInsecure: true
     asserts:
       - hasDocuments:
           count: 0
 
-  - it: broker volumes reference existing tls secret
-    template: templates/kafka-broker-deployment.yaml
-    set:
-      kafka.tls.enabled: true
-      kafka.tls.existingSecret: my-tls-secret
-    asserts:
-      - contains:
-          path: spec.template.spec.volumes
-          content:
-            name: kafka-tls-pem
-            secret:
-              secretName: my-tls-secret
-          any: true
-
-  - it: broker config uses SASL_SSL with existing secret
+  # --- guard ---
+  - it: disabling TLS without allowInsecure fails the render
     template: templates/kafka-configmap.yaml
-    documentIndex: 1
     set:
-      kafka.tls.enabled: true
-      kafka.tls.existingSecret: my-tls-secret
-    asserts:
-      - matchRegex:
-          path: data["server.properties"]
-          pattern: SASL_SSL
-
-  # --- TLS fail-fast: enabled without secret or issuer ---
-  - it: template fails when TLS enabled without secret or issuer
-    template: templates/kafka-certificate.yaml
-    set:
-      kafka.tls.enabled: true
+      kafka.tls.enabled: false
     asserts:
       - failedTemplate:
-          errorMessage: kafka.tls.enabled requires either kafka.tls.existingSecret or kafka.tls.certManager.issuerRef.name to be set
+          errorMessage: "kafka.tls.enabled is false but kafka.auth.allowInsecure is not set. Production requires TLS: set kafka.tls.enabled=true (with kafka.tls.certManager.issuerRef.name or kafka.tls.existingSecret), or explicitly set kafka.auth.allowInsecure=true to run WITHOUT TLS (INSECURE: client credentials travel in cleartext and inter-broker/controller traffic is unauthenticated)."

--- a/kafka/tests/values-full-test.yaml
+++ b/kafka/tests/values-full-test.yaml
@@ -58,10 +58,8 @@ kafka:
       performanceOpts: "-XX:+UseG1GC"
     affinity: {}
 
-  tls:
-    enabled: false
+  # TLS on (default) using the chart-managed self-signed CA; requires cert-manager.
   auth:
-    allowInsecure: true
     saslMechanism: SCRAM-SHA-512
     users:
       - username: testuser

--- a/kafka/tests/values-full-test.yaml
+++ b/kafka/tests/values-full-test.yaml
@@ -58,9 +58,29 @@ kafka:
       performanceOpts: "-XX:+UseG1GC"
     affinity: {}
 
+  tls:
+    enabled: false
   auth:
-    username: testuser
-    password: dGVzdHBhc3N3b3Jk
+    allowInsecure: true
+    saslMechanism: SCRAM-SHA-512
+    users:
+      - username: testuser
+        password: testpassword
+      - username: appuser
+        password: apppassword
+    authorization:
+      enabled: true
+      allowEveryoneIfNoAcl: false
+      superUsers:
+        - testuser
+      acls:
+        - principal: appuser
+          role: producer
+          topics: ["test-topic-1"]
+        - principal: appuser
+          role: consumer
+          topics: ["test-topic-1"]
+          groups: ["app-consumers"]
 
   autoCreateTopicsEnable: true
   deleteTopicEnable: true

--- a/kafka/tests/values-minimal.yaml
+++ b/kafka/tests/values-minimal.yaml
@@ -58,10 +58,8 @@ kafka:
       performanceOpts: "-XX:+UseG1GC"
     affinity: {}
 
-  tls:
-    enabled: false
+  # TLS on (default) using the chart-managed self-signed CA; requires cert-manager.
   auth:
-    allowInsecure: true
     saslMechanism: SCRAM-SHA-512
     users:
       - username: testuser

--- a/kafka/tests/values-minimal.yaml
+++ b/kafka/tests/values-minimal.yaml
@@ -58,9 +58,19 @@ kafka:
       performanceOpts: "-XX:+UseG1GC"
     affinity: {}
 
+  tls:
+    enabled: false
   auth:
-    username: testuser
-    password: dGVzdHBhc3N3b3Jk
+    allowInsecure: true
+    saslMechanism: SCRAM-SHA-512
+    users:
+      - username: testuser
+        password: testpassword
+    authorization:
+      enabled: true
+      allowEveryoneIfNoAcl: false
+      superUsers:
+        - testuser
 
   autoCreateTopicsEnable: true
   deleteTopicEnable: true

--- a/kafka/values.schema.json
+++ b/kafka/values.schema.json
@@ -18,6 +18,9 @@
         "tls": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
             "certManager": {
               "type": "object",
               "properties": {
@@ -49,14 +52,52 @@
         "auth": {
           "type": "object",
           "properties": {
-            "sasl": {
+            "saslMechanism": {
+              "enum": ["PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512"]
+            },
+            "allowInsecure": {
+              "type": "boolean"
+            },
+            "users": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "username": { "type": "string" },
+                  "password": { "type": "string" },
+                  "existingSecret": { "type": "string" },
+                  "existingSecretPasswordKey": { "type": "string" }
+                },
+                "required": ["username"]
+              }
+            },
+            "authorization": {
               "type": "object",
               "properties": {
-                "mechanism": {
-                  "enum": ["PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512"]
+                "enabled": { "type": "boolean" },
+                "allowEveryoneIfNoAcl": { "type": "boolean" },
+                "superUsers": {
+                  "type": "array",
+                  "items": { "type": "string" }
                 },
-                "securityProtocol": {
-                  "enum": ["PLAINTEXT", "SASL_PLAINTEXT", "SASL_SSL", "SSL"]
+                "acls": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "principal": { "type": "string" },
+                      "role": { "enum": ["producer", "consumer", "admin"] },
+                      "topics": { "type": "array", "items": { "type": "string" } },
+                      "groups": { "type": "array", "items": { "type": "string" } },
+                      "operations": { "type": "array", "items": { "type": "string" } },
+                      "resourceType": { "enum": ["topic", "group", "cluster", "transactionalId"] },
+                      "resourceName": { "type": "string" },
+                      "patternType": { "enum": ["literal", "prefixed"] },
+                      "host": { "type": "string" },
+                      "permission": { "enum": ["allow", "deny"] }
+                    },
+                    "required": ["principal"]
+                  }
                 }
               }
             }

--- a/kafka/values.yaml
+++ b/kafka/values.yaml
@@ -14,7 +14,9 @@ kafka:
   bootstrapServer: ""
 
   tls:
-    enabled: false
+    # TLS is required by default. To run without it (INSECURE), set
+    # tls.enabled=false AND auth.allowInsecure=true.
+    enabled: true
     existingSecret: ""
     certFilename: tls.crt
     keyFilename: tls.key
@@ -144,15 +146,43 @@ kafka:
     topologySpreadConstraints: []
 
   auth:
-    username: user1
-    password: ""
-    existingSecret: ""
-    existingSecretKeys:
-      username: username
-      password: password
-    sasl:
-      mechanism: PLAIN
-      securityProtocol: SASL_PLAINTEXT
+    # SASL mechanism for EXTERNAL clients (the CLIENT listener). Internal
+    # (inter-broker) and controller listeners always use mTLS when TLS is on.
+    # One of: SCRAM-SHA-512 (recommended), SCRAM-SHA-256, PLAIN (legacy/insecure).
+    saslMechanism: SCRAM-SHA-512
+    # Must be true to run with tls.enabled=false. INSECURE.
+    allowInsecure: false
+    # SASL users. SCRAM credentials are provisioned into KRaft metadata by the
+    # bootstrap Job. Passwords: explicit password wins; otherwise a random value
+    # is generated on first install and persisted across upgrades. Set
+    # existingSecret to source the password from a pre-existing Secret instead.
+    users:
+      - username: admin
+        password: ""
+        existingSecret: ""
+        existingSecretPasswordKey: password
+    authorization:
+      # StandardAuthorizer with deny-by-default.
+      enabled: true
+      allowEveryoneIfNoAcl: false
+      # Extra super-users (bypass ACLs). The internal cert principal is always a
+      # super-user; list SASL usernames here to grant them full access too.
+      superUsers:
+        - admin
+      # Declarative ACLs. Either role-based:
+      #   - principal: app
+      #     role: consumer            # producer | consumer | admin
+      #     topics: ["orders"]
+      #     groups: ["orders-consumers"]
+      # or raw:
+      #   - principal: app
+      #     operations: [Read, Describe]
+      #     resourceType: topic       # topic | group | cluster | transactionalId
+      #     resourceName: orders
+      #     patternType: literal      # literal | prefixed
+      #     host: "*"
+      #     permission: allow         # allow | deny
+      acls: []
 
   autoCreateTopicsEnable: false
   deleteTopicEnable: true

--- a/kafka/values.yaml
+++ b/kafka/values.yaml
@@ -23,6 +23,9 @@ kafka:
     caFilename: ca.crt
     certManager:
       issuerRef:
+        # Leave name empty to use a chart-managed self-signed CA (a SelfSigned
+        # Issuer + CA Certificate + CA Issuer are created for you). Requires
+        # cert-manager to be installed. Set name to use your own issuer instead.
         name: ""
         kind: ClusterIssuer
         group: cert-manager.io


### PR DESCRIPTION
## Kafka secure-by-default: TLS/mTLS + SCRAM + ACLs + multi-user (Phase 1, PR 2)

Unified security core. **Stacked on #255** (base will retarget to `master` once #255 merges). **⚠️ BREAKING:** the `kafka.auth` API is replaced.

Closes #43, #44, #46, #55, #242.

### What changed
- **Require TLS (#43):** `tls.enabled` defaults `true`; running without TLS requires an explicit `kafka.auth.allowInsecure=true` (render fails otherwise, with a clear message).
- **mTLS internal (#242):** dedicated `INTERNAL` listener (9094) for inter-broker, plus the `CONTROLLER` listener, both `ssl.client.auth=required`. Broker/controller identity comes from the cert (CN via `ssl.principal.mapping.rules`) and is auto-added to `super.users` — so the KRaft quorum is authenticated, not trust-by-network.
- **SCRAM external (#55):** clients use SASL/SCRAM-SHA-512 over `SASL_SSL` (256/PLAIN selectable). Brokers hold **no** SASL passwords — SCRAM is validated against KRaft metadata, so the credential-in-JAAS/`sed` machinery is gone.
- **AuthZ + multi-user (#46):** `StandardAuthorizer`, `allow.everyone.if.no.acl.found=false`, `kafka.auth.users` list, and declarative `authorization.acls` with producer/consumer/admin **roles** plus a **raw** escape hatch.
- **Secrets (#44):** per-user passwords random on first install, **persisted across upgrades** via `lookup`.
- **Bootstrap job:** connects via mTLS (cert = super-user) to provision SCRAM users → topics → ACLs, idempotently.
- **Exporter:** connects via mTLS (no SASL dependency). Hostname verification kept enabled.

### Verified
`helm lint` clean; renders in TLS mode (19 docs) and insecure mode; bare `tls.enabled=false` fails the guard as intended; `bash -n` exit 0 on all 8 rendered container scripts; no literal `$$`; all rendered YAML parses; ACL + SCRAM provisioning render correctly. Bumps chart to **0.4.0**.

### ⚠️ CI follow-ups required (not yet done)
Secure-by-default breaks three CI surfaces that assume the old behavior. These need a follow-up commit before merge:
1. **`kubeconform` / `kube-linter`** render charts with bare defaults (`helm template kafka kafka`), which now fails (no issuer). Needs either a chart-managed self-signed issuer default so defaults render, or per-chart CI render values.
2. **`helm-unittest`** (`tests/unit/*_test.yaml`) still assert the old `SASL_PLAINTEXT`/`auth.username` config — need rewriting for the new model.
3. **kind tests** (`test-minimal`/`test-full`) deploy to a cluster with no cert-manager and assert old-auth produce/consume — need cert-manager install + secure-path assertions (or an insecure-mode test).

Design choices embedded in the follow-up (self-signed issuer default? cert-manager in kind CI vs insecure test?) are called out for discussion.
