### PR TITLE
fix(redis): update Redis to 8.8.1-trixie (1.5.1)

### DIFF
--- a/redis/Chart.yaml
+++ b/redis/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: redis
 description: Redis standalone or Sentinel-managed HA replication, with ACLs, TLS, AOF persistence, and a Prometheus metrics exporter
 type: application
-version: 1.5.0
-appVersion: "8"
+version: 1.5.1
+appVersion: "8.8.1"
 home: https://github.com/cagriekin/charts/tree/master/redis
 icon: https://www.vectorlogo.zone/logos/redis/redis-icon.svg
 sources:

--- a/redis/README.md
+++ b/redis/README.md
@@ -215,7 +215,7 @@ window.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `redis.image.repository` / `redis.image.tag` | Redis image | `redis` / `8.6.2-trixie` |
+| `redis.image.repository` / `redis.image.tag` | Redis image | `redis` / `8.8.1-trixie` |
 | `redis.persistence.enabled` / `size` / `storageClass` | Persistence | `true` / `1Gi` / `""` |
 | `redis.persistence.retain` | Keep data PVCs on uninstall / scale-down (`false` = auto-delete) | `true` |
 | `redis.resources` | Requests/limits | see `values.yaml` |

--- a/redis/tests/values-full-test.yaml
+++ b/redis/tests/values-full-test.yaml
@@ -5,7 +5,7 @@ redis:
     enabled: false
   image:
     repository: redis
-    tag: "8.6.2-trixie"
+    tag: "8.8.1-trixie"
     pullPolicy: IfNotPresent
   persistence:
     enabled: false

--- a/redis/tests/values-minimal.yaml
+++ b/redis/tests/values-minimal.yaml
@@ -7,7 +7,7 @@ redis:
     enabled: false
   image:
     repository: redis
-    tag: "8.6.2-trixie"
+    tag: "8.8.1-trixie"
     pullPolicy: IfNotPresent
   persistence:
     enabled: false

--- a/redis/tests/values-performance.yaml
+++ b/redis/tests/values-performance.yaml
@@ -11,7 +11,7 @@ redis:
     enabled: false
   image:
     repository: redis
-    tag: "8.6.2-trixie"
+    tag: "8.8.1-trixie"
     pullPolicy: IfNotPresent
   persistence:
     enabled: false

--- a/redis/tests/values-persistence-test.yaml
+++ b/redis/tests/values-persistence-test.yaml
@@ -3,7 +3,7 @@ architecture: standalone
 redis:
   image:
     repository: redis
-    tag: "8.6.2-trixie"
+    tag: "8.8.1-trixie"
     pullPolicy: IfNotPresent
   persistence:
     enabled: true

--- a/redis/values.yaml
+++ b/redis/values.yaml
@@ -17,7 +17,7 @@ imagePullSecrets: []
 redis:
   image:
     repository: redis
-    tag: "8.6.2-trixie"
+    tag: "8.8.1-trixie"
     pullPolicy: IfNotPresent
 
   # Number of REPLICAS, excluding the master. Total redis pods = replicaCount + 1.
@@ -186,7 +186,7 @@ sentinel:
   parallelSyncs: 1
   image:
     repository: redis
-    tag: "8.6.2-trixie"
+    tag: "8.8.1-trixie"
     pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
Bumps the default Redis image (standalone + sentinel) from `8.6.2-trixie` to `8.8.1-trixie` — the latest 8.x stable (released 2026-07-23), a **security release** fixing crafted `RESTORE` payloads in RedisBloom/TDigest (out-of-bounds writes / potential RCE).

- `redis/values.yaml`: image tag → `8.8.1-trixie` (main + sentinel)
- `redis/Chart.yaml`: `appVersion` "8" → "8.8.1", chart `1.5.0` → `1.5.1`
- README default + test fixtures updated to match

Verified `8.8.1-trixie` is a live, active multi-arch tag on Docker Hub; `helm lint` passes and the rendered image is `redis:8.8.1-trixie`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the Redis container and Sentinel images to version `8.8.1-trixie`.
  - Updated the Helm chart application version to Redis `8.8.1`.

- **Documentation**
  - Updated configuration documentation to reflect the new Redis image version.

- **Tests**
  - Updated test and performance configurations to use Redis `8.8.1-trixie`.
  - Preserved existing authentication, persistence, resource, and service settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->