### PR TITLE
fix(kafka): drop ArgoCD hook annotations from topic-init job (0.4.1)

### DIFF
--- a/kafka/Chart.yaml
+++ b/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka
 description: Apache Kafka in KRaft mode (no ZooKeeper) with SASL authentication, TLS, declarative topic management, and a metrics exporter
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: 4.1.0
 dependencies:
   - name: common

--- a/kafka/artifacthub-pkg.yml
+++ b/kafka/artifacthub-pkg.yml
@@ -1,7 +1,7 @@
-version: 0.4.0
+version: 0.4.1
 name: kafka
 displayName: Kafka
-createdAt: "2026-07-27T00:00:00Z"
+createdAt: "2026-07-29T00:00:00Z"
 description: Apache Kafka in KRaft mode (no ZooKeeper) with SASL authentication, TLS, declarative topic management, and a metrics exporter
 homeURL: "https://cagriekin.github.io/charts"
 logoPath: ""
@@ -17,19 +17,5 @@ links:
     url: https://github.com/cagriekin/charts
 screenshots: []
 changes:
-  - kind: security
-    description: "Pod-scope NetworkPolicy intra-cluster traffic: the controller quorum port (9093) is now reachable only from broker/controller pods instead of the whole namespace, and all egress is restricted to specific component pods. Client (9092) and metrics (9308) ingress remain namespace-scoped with override hooks."
-  - kind: security
-    description: "Require TLS by default; run without it only with the explicit kafka.auth.allowInsecure opt-in."
-  - kind: security
-    description: "Inter-broker and controller listeners now use mutual TLS (mTLS) via a dedicated INTERNAL listener on port 9094."
-  - kind: security
-    description: "External client authentication defaults to SASL/SCRAM-SHA-512 (SCRAM-SHA-256 and PLAIN also supported); credentials are no longer written into any JAAS file or config for SCRAM."
-  - kind: security
-    description: "Enable StandardAuthorizer with deny-by-default and declarative multi-user ACL roles (producer/consumer/admin) plus a raw ACL escape hatch."
-  - kind: added
-    description: "Multi-user support with per-user passwords generated randomly on first install and persisted across upgrades."
-  - kind: added
-    description: "Chart-managed self-signed CA (cert-manager) is used by default when no issuerRef or existingSecret is provided, so the chart installs out-of-the-box with TLS/mTLS."
   - kind: changed
-    description: "BREAKING: the kafka.auth API was replaced. kafka.auth.username/password/existingSecret/existingSecretKeys/sasl are removed in favour of kafka.auth.users, kafka.auth.saslMechanism, kafka.auth.allowInsecure, and kafka.auth.authorization. See values.yaml."
+    description: "Remove ArgoCD-specific hook annotations from the topic-init Job; Helm hooks (post-install/post-upgrade) are honored natively by ArgoCD."

--- a/kafka/templates/kafka-topic-init-job.yaml
+++ b/kafka/templates/kafka-topic-init-job.yaml
@@ -11,11 +11,11 @@ kind: Job
 metadata:
   name: {{ $jobName }}
   annotations:
+    # Helm hooks run the job after the brokers are up. ArgoCD natively honors
+    # these helm.sh/hook annotations (post-install/post-upgrade map to a PostSync
+    # hook), so no ArgoCD-specific hook annotations are needed on chart resources.
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
-    argocd.argoproj.io/sync-options: Replace=true
     # One-shot Job: liveness/readiness probes are not applicable (the container runs
     # to completion). Resources are still set; only the probe policy checks are waived.
     ignore-check.kube-linter.io/no-liveness-probe: "one-shot topic-init job"

--- a/kafka/tests/test-template.sh
+++ b/kafka/tests/test-template.sh
@@ -36,6 +36,8 @@ assert_contains "full: controller statefulset present" "${full}" "kafka-controll
 assert_contains "full: broker statefulset present" "${full}" "kafka-broker"
 assert_contains "full: exporter deployment present" "${full}" "kafka-exporter"
 assert_contains "full: topic init job present" "${full}" "kafka-topic-init"
+assert_contains "full: topic init keeps Helm hook" "${full}" "helm.sh/hook: post-install,post-upgrade"
+assert_not_contains "full: topic init has no ArgoCD hook annotations" "${full}" "argocd.argoproj.io"
 assert_contains "full: topics configmap present" "${full}" "kafka-topics"
 assert_contains "full: exporter service present" "${full}" "port: 9308"
 assert_contains "full: controller port 9093" "${full}" "port: 9093"


### PR DESCRIPTION
Closes #42.

Removes the ArgoCD-specific hook annotations from the topic-init Job:
- `argocd.argoproj.io/hook: PostSync`
- `argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation`
- `argocd.argoproj.io/sync-options: Replace=true`

ArgoCD natively honors the `helm.sh/hook` annotations (post-install/post-upgrade map to a PostSync hook), so the tool-specific annotations were redundant and `Replace=true` was potentially harmful. Helm hooks are retained. Added render assertions (Helm hook kept, no ArgoCD annotations).