### PR TITLE
fix(kafka): enable TLS hostname verification (0.4.1)

### DIFF
--- a/kafka/Chart.yaml
+++ b/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka
 description: Apache Kafka in KRaft mode (no ZooKeeper) with SASL authentication, TLS, declarative topic management, and a metrics exporter
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: 4.1.0
 dependencies:
   - name: common

--- a/kafka/artifacthub-pkg.yml
+++ b/kafka/artifacthub-pkg.yml
@@ -1,7 +1,7 @@
-version: 0.4.0
+version: 0.4.1
 name: kafka
 displayName: Kafka
-createdAt: "2026-07-27T00:00:00Z"
+createdAt: "2026-07-29T00:00:00Z"
 description: Apache Kafka in KRaft mode (no ZooKeeper) with SASL authentication, TLS, declarative topic management, and a metrics exporter
 homeURL: "https://cagriekin.github.io/charts"
 logoPath: ""
@@ -18,18 +18,4 @@ links:
 screenshots: []
 changes:
   - kind: security
-    description: "Pod-scope NetworkPolicy intra-cluster traffic: the controller quorum port (9093) is now reachable only from broker/controller pods instead of the whole namespace, and all egress is restricted to specific component pods. Client (9092) and metrics (9308) ingress remain namespace-scoped with override hooks."
-  - kind: security
-    description: "Require TLS by default; run without it only with the explicit kafka.auth.allowInsecure opt-in."
-  - kind: security
-    description: "Inter-broker and controller listeners now use mutual TLS (mTLS) via a dedicated INTERNAL listener on port 9094."
-  - kind: security
-    description: "External client authentication defaults to SASL/SCRAM-SHA-512 (SCRAM-SHA-256 and PLAIN also supported); credentials are no longer written into any JAAS file or config for SCRAM."
-  - kind: security
-    description: "Enable StandardAuthorizer with deny-by-default and declarative multi-user ACL roles (producer/consumer/admin) plus a raw ACL escape hatch."
-  - kind: added
-    description: "Multi-user support with per-user passwords generated randomly on first install and persisted across upgrades."
-  - kind: added
-    description: "Chart-managed self-signed CA (cert-manager) is used by default when no issuerRef or existingSecret is provided, so the chart installs out-of-the-box with TLS/mTLS."
-  - kind: changed
-    description: "BREAKING: the kafka.auth API was replaced. kafka.auth.username/password/existingSecret/existingSecretKeys/sasl are removed in favour of kafka.auth.users, kafka.auth.saslMechanism, kafka.auth.allowInsecure, and kafka.auth.authorization. See values.yaml."
+    description: "Enable TLS hostname verification (ssl.endpoint.identification.algorithm=https) explicitly on broker, controller and client SSL connections; configurable via kafka.tls.endpointIdentificationAlgorithm."

--- a/kafka/templates/_helpers.tpl
+++ b/kafka/templates/_helpers.tpl
@@ -211,6 +211,25 @@ SSL enables mTLS via ssl.client.auth=required; PLAINTEXT is insecure.
 {{- end }}
 
 {{/*
+Resolved TLS endpoint identification algorithm (hostname verification), used on
+every SSL config block. Defaults to "https" when the key is unset -- including
+when a user override replaces the whole kafka.tls map and drops the key -- so
+verification is never silently disabled. An explicit empty string disables it
+(documented escape hatch). Any other value fails the render up front instead of
+CrashLooping brokers on an invalid Kafka config.
+*/}}
+{{- define "kafka.tls.endpointIdentificationAlgorithm" -}}
+{{- $eia := "https" -}}
+{{- if hasKey .Values.kafka.tls "endpointIdentificationAlgorithm" -}}
+{{- $eia = .Values.kafka.tls.endpointIdentificationAlgorithm -}}
+{{- end -}}
+{{- if not (or (eq $eia "https") (eq $eia "")) -}}
+{{- fail (printf "kafka.tls.endpointIdentificationAlgorithm must be \"https\" (verify hostnames, default) or \"\" (disable, INSECURE); got %q." $eia) -}}
+{{- end -}}
+{{- $eia -}}
+{{- end }}
+
+{{/*
 Fail the render when TLS is disabled without an explicit insecure opt-in.
 */}}
 {{- define "kafka.auth.validateTls" -}}

--- a/kafka/templates/kafka-configmap.yaml
+++ b/kafka/templates/kafka-configmap.yaml
@@ -44,6 +44,7 @@ data:
     ssl.truststore.type=PKCS12
     ssl.truststore.location=/opt/kafka/tls/truststore.p12
     ssl.truststore.password={{ include "kafka.tls.storePassword" . }}
+    ssl.endpoint.identification.algorithm={{ .Values.kafka.tls.endpointIdentificationAlgorithm }}
     listener.name.controller.ssl.client.auth=required
     ssl.principal.mapping.rules={{ $principalRule }}
     {{- end }}
@@ -110,6 +111,7 @@ data:
     ssl.truststore.type=PKCS12
     ssl.truststore.location=/opt/kafka/tls/truststore.p12
     ssl.truststore.password={{ include "kafka.tls.storePassword" . }}
+    ssl.endpoint.identification.algorithm={{ .Values.kafka.tls.endpointIdentificationAlgorithm }}
     listener.name.internal.ssl.client.auth=required
     listener.name.controller.ssl.client.auth=required
     ssl.principal.mapping.rules={{ $principalRule }}

--- a/kafka/templates/kafka-configmap.yaml
+++ b/kafka/templates/kafka-configmap.yaml
@@ -44,7 +44,7 @@ data:
     ssl.truststore.type=PKCS12
     ssl.truststore.location=/opt/kafka/tls/truststore.p12
     ssl.truststore.password={{ include "kafka.tls.storePassword" . }}
-    ssl.endpoint.identification.algorithm={{ .Values.kafka.tls.endpointIdentificationAlgorithm }}
+    ssl.endpoint.identification.algorithm={{ include "kafka.tls.endpointIdentificationAlgorithm" . }}
     listener.name.controller.ssl.client.auth=required
     ssl.principal.mapping.rules={{ $principalRule }}
     {{- end }}
@@ -111,7 +111,7 @@ data:
     ssl.truststore.type=PKCS12
     ssl.truststore.location=/opt/kafka/tls/truststore.p12
     ssl.truststore.password={{ include "kafka.tls.storePassword" . }}
-    ssl.endpoint.identification.algorithm={{ .Values.kafka.tls.endpointIdentificationAlgorithm }}
+    ssl.endpoint.identification.algorithm={{ include "kafka.tls.endpointIdentificationAlgorithm" . }}
     listener.name.internal.ssl.client.auth=required
     listener.name.controller.ssl.client.auth=required
     ssl.principal.mapping.rules={{ $principalRule }}

--- a/kafka/templates/kafka-topic-init-job.yaml
+++ b/kafka/templates/kafka-topic-init-job.yaml
@@ -119,6 +119,7 @@ spec:
           ssl.truststore.type=PKCS12
           ssl.truststore.location=/tmp/kafka-tls/truststore.p12
           ssl.truststore.password={{ include "kafka.tls.storePassword" . }}
+          ssl.endpoint.identification.algorithm={{ .Values.kafka.tls.endpointIdentificationAlgorithm }}
           EOF
           {{- else }}
           cat > "$CC" <<EOF

--- a/kafka/templates/kafka-topic-init-job.yaml
+++ b/kafka/templates/kafka-topic-init-job.yaml
@@ -119,7 +119,7 @@ spec:
           ssl.truststore.type=PKCS12
           ssl.truststore.location=/tmp/kafka-tls/truststore.p12
           ssl.truststore.password={{ include "kafka.tls.storePassword" . }}
-          ssl.endpoint.identification.algorithm={{ .Values.kafka.tls.endpointIdentificationAlgorithm }}
+          ssl.endpoint.identification.algorithm={{ include "kafka.tls.endpointIdentificationAlgorithm" . }}
           EOF
           {{- else }}
           cat > "$CC" <<EOF

--- a/kafka/tests/test-template.sh
+++ b/kafka/tests/test-template.sh
@@ -113,6 +113,15 @@ noverify=$(helm template test-kafka "${CHART_DIR}" \
 assert_contains "tls-noverify: verification can be disabled" "${noverify}" "ssl.endpoint.identification.algorithm="
 assert_not_contains "tls-noverify: not left as https" "${noverify}" "ssl.endpoint.identification.algorithm=https"
 
+# Unset key (e.g. a values override that drops it) must default to https, not empty.
+eia_unset=$(helm template test-kafka "${CHART_DIR}" --set kafka.tls.endpointIdentificationAlgorithm=null 2>&1)
+assert_contains "tls-eia: unset key defaults to https" "${eia_unset}" "ssl.endpoint.identification.algorithm=https"
+
+# An invalid value must fail the render, not pass through to CrashLoop the brokers.
+eia_bad=$(helm template test-kafka "${CHART_DIR}" --set kafka.tls.endpointIdentificationAlgorithm=HTTPS 2>&1) && eia_bad_rc=0 || eia_bad_rc=$?
+assert_eq "tls-eia: invalid value fails render" "1" "${eia_bad_rc}"
+assert_contains "tls-eia: error names the setting" "${eia_bad}" "endpointIdentificationAlgorithm must be"
+
 # --- Guard: TLS disabled without the insecure opt-in fails ---
 guard=$(helm template test-kafka "${CHART_DIR}" \
   --set kafka.tls.enabled=false 2>&1) && guard_rc=0 || guard_rc=$?

--- a/kafka/tests/test-template.sh
+++ b/kafka/tests/test-template.sh
@@ -64,6 +64,7 @@ assert_contains "defaults: mTLS on internal listener" "${defaults}" "listener.na
 assert_contains "defaults: SCRAM-SHA-512 mechanism" "${defaults}" "sasl.enabled.mechanisms=SCRAM-SHA-512"
 assert_contains "defaults: StandardAuthorizer" "${defaults}" "StandardAuthorizer"
 assert_contains "defaults: deny by default" "${defaults}" "allow.everyone.if.no.acl.found=false"
+assert_contains "defaults: TLS hostname verification on" "${defaults}" "ssl.endpoint.identification.algorithm=https"
 assert_contains "defaults: self-signed Issuer created" "${defaults}" "test-kafka-kafka-selfsigned"
 assert_contains "defaults: CA Issuer created" "${defaults}" "test-kafka-kafka-ca"
 assert_contains "defaults: leaf Certificate created" "${defaults}" "kind: Certificate"
@@ -105,6 +106,12 @@ assert_contains "insecure: SASL_PLAINTEXT client listener" "${insecure}" "CLIENT
 assert_contains "insecure: ANONYMOUS super-user" "${insecure}" "User:ANONYMOUS"
 assert_not_contains "insecure: no Certificate" "${insecure}" "kind: Certificate"
 assert_not_contains "insecure: no tls-init" "${insecure}" "tls-init"
+
+# --- TLS hostname verification is configurable (escape hatch) ---
+noverify=$(helm template test-kafka "${CHART_DIR}" \
+  --set kafka.tls.endpointIdentificationAlgorithm="" 2>&1)
+assert_contains "tls-noverify: verification can be disabled" "${noverify}" "ssl.endpoint.identification.algorithm="
+assert_not_contains "tls-noverify: not left as https" "${noverify}" "ssl.endpoint.identification.algorithm=https"
 
 # --- Guard: TLS disabled without the insecure opt-in fails ---
 guard=$(helm template test-kafka "${CHART_DIR}" \

--- a/kafka/values.yaml
+++ b/kafka/values.yaml
@@ -24,9 +24,14 @@ kafka:
     # TLS hostname verification for inter-broker, controller-quorum and client
     # SSL connections. "https" (default) verifies the peer certificate SANs match
     # the host being dialed, closing the MITM window inside the trust domain. The
-    # chart-managed certificate already carries the per-pod service SANs. Set to ""
-    # to disable verification (INSECURE) only for a documented edge case, e.g. an
-    # existingSecret whose certificate lacks the required SANs.
+    # chart-managed certificate already carries the per-pod service SANs. Only
+    # "https" and "" are accepted; any other value fails the render. If the key is
+    # omitted entirely (e.g. a values override that replaces this whole tls map),
+    # it defaults to "https" so verification is never silently disabled.
+    # Set to "" to disable verification (INSECURE) only for a documented edge case,
+    # e.g. an existingSecret (or a custom kafka.bootstrapServer host) whose
+    # certificate lacks the required SANs -- prefer adding the host to
+    # certManager.additionalDnsNames instead of turning verification off.
     endpointIdentificationAlgorithm: https
     certManager:
       issuerRef:

--- a/kafka/values.yaml
+++ b/kafka/values.yaml
@@ -21,6 +21,13 @@ kafka:
     certFilename: tls.crt
     keyFilename: tls.key
     caFilename: ca.crt
+    # TLS hostname verification for inter-broker, controller-quorum and client
+    # SSL connections. "https" (default) verifies the peer certificate SANs match
+    # the host being dialed, closing the MITM window inside the trust domain. The
+    # chart-managed certificate already carries the per-pod service SANs. Set to ""
+    # to disable verification (INSECURE) only for a documented edge case, e.g. an
+    # existingSecret whose certificate lacks the required SANs.
+    endpointIdentificationAlgorithm: https
     certManager:
       issuerRef:
         # Leave name empty to use a chart-managed self-signed CA (a SelfSigned


### PR DESCRIPTION
Closes #247.

Explicitly sets `ssl.endpoint.identification.algorithm=https` on the broker, controller-quorum and topic-init client SSL connections, and exposes it via `kafka.tls.endpointIdentificationAlgorithm` (default `https`).

Previously the setting was unset, so verification relied on the Kafka version default rather than being an explicit, auditable guarantee — and there was no escape hatch. The chart-managed certificate already carries the per-pod service SANs (wildcard `*.<fullname>-kafka-{broker,controller}.<ns>.svc.cluster.local`), so verification is compatible with the default TLS path. Operators with an existingSecret whose cert lacks the required SANs can set the value to `""` to disable (INSECURE, documented).

Added render tests for both the enabled default and the disable escape hatch.