### PR TITLE
fix(kafka): random TLS store password in Secret, not ConfigMap (0.4.1)

### DIFF
--- a/kafka/Chart.yaml
+++ b/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka
 description: Apache Kafka in KRaft mode (no ZooKeeper) with SASL authentication, TLS, declarative topic management, and a metrics exporter
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: 4.1.0
 dependencies:
   - name: common

--- a/kafka/artifacthub-pkg.yml
+++ b/kafka/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ links:
 screenshots: []
 changes:
   - kind: security
-    description: "TLS PKCS12 store password is now a random per-install value persisted in the chart Secret and injected via secretKeyRef env; it is no longer derived from the release name or written into a ConfigMap."
+    description: "TLS PKCS12 store password is now an ephemeral per-pod value generated at container start and shared only within the pod via an emptyDir; it is no longer derived from the release name and is never written into a ConfigMap or Secret."

--- a/kafka/artifacthub-pkg.yml
+++ b/kafka/artifacthub-pkg.yml
@@ -1,7 +1,7 @@
-version: 0.4.0
+version: 0.4.1
 name: kafka
 displayName: Kafka
-createdAt: "2026-07-27T00:00:00Z"
+createdAt: "2026-07-29T00:00:00Z"
 description: Apache Kafka in KRaft mode (no ZooKeeper) with SASL authentication, TLS, declarative topic management, and a metrics exporter
 homeURL: "https://cagriekin.github.io/charts"
 logoPath: ""
@@ -18,18 +18,4 @@ links:
 screenshots: []
 changes:
   - kind: security
-    description: "Pod-scope NetworkPolicy intra-cluster traffic: the controller quorum port (9093) is now reachable only from broker/controller pods instead of the whole namespace, and all egress is restricted to specific component pods. Client (9092) and metrics (9308) ingress remain namespace-scoped with override hooks."
-  - kind: security
-    description: "Require TLS by default; run without it only with the explicit kafka.auth.allowInsecure opt-in."
-  - kind: security
-    description: "Inter-broker and controller listeners now use mutual TLS (mTLS) via a dedicated INTERNAL listener on port 9094."
-  - kind: security
-    description: "External client authentication defaults to SASL/SCRAM-SHA-512 (SCRAM-SHA-256 and PLAIN also supported); credentials are no longer written into any JAAS file or config for SCRAM."
-  - kind: security
-    description: "Enable StandardAuthorizer with deny-by-default and declarative multi-user ACL roles (producer/consumer/admin) plus a raw ACL escape hatch."
-  - kind: added
-    description: "Multi-user support with per-user passwords generated randomly on first install and persisted across upgrades."
-  - kind: added
-    description: "Chart-managed self-signed CA (cert-manager) is used by default when no issuerRef or existingSecret is provided, so the chart installs out-of-the-box with TLS/mTLS."
-  - kind: changed
-    description: "BREAKING: the kafka.auth API was replaced. kafka.auth.username/password/existingSecret/existingSecretKeys/sasl are removed in favour of kafka.auth.users, kafka.auth.saslMechanism, kafka.auth.allowInsecure, and kafka.auth.authorization. See values.yaml."
+    description: "TLS PKCS12 store password is now a random per-install value persisted in the chart Secret and injected via secretKeyRef env; it is no longer derived from the release name or written into a ConfigMap."

--- a/kafka/templates/_helpers.tpl
+++ b/kafka/templates/_helpers.tpl
@@ -289,42 +289,15 @@ Generate a content-based suffix for the Kafka bootstrap job so updates trigger a
 {{- end }}
 
 {{/*
-Secret key under which the random TLS PKCS12 store password is persisted (in the
-chart-managed Secret named by kafka.auth.secretName).
+The TLS PKCS12 keystore/truststore password is NOT rendered by the chart. The
+stores are rebuilt from the mounted PEM on every pod start, so the password only
+needs to be consistent within a single pod for that pod's lifetime. Each pod's
+tls-init container generates a fresh random password at runtime and writes it to
+a shared emptyDir file (STORE_PASS_FILE); the main container reads it and
+substitutes the PLACEHOLDER_STORE_PASSWORD marker into server.properties. The
+value therefore lives in no ConfigMap and no Secret, and no render-time value is
+produced -- so GitOps (ArgoCD/Flux) renders stay stable.
 */}}
-{{- define "kafka.tls.storePasswordKey" -}}
-tls-store-password
-{{- end }}
-
-{{/*
-Resolve the TLS PKCS12 keystore/truststore password at render time (used only by
-the Secret template). Random per install, persisted across upgrades via lookup of
-the existing chart Secret. randAlphaNum keeps it free of sed/JAAS-special chars.
-The value is never written into a ConfigMap: workloads read it from the Secret via
-env (secretKeyRef) and substitute the PLACEHOLDER_STORE_PASSWORD marker at startup.
-*/}}
-{{- define "kafka.tls.storePasswordValue" -}}
-{{- $ns := default "default" .Release.Namespace -}}
-{{- $key := include "kafka.tls.storePasswordKey" . | trim -}}
-{{- $existing := lookup "v1" "Secret" $ns (include "kafka.auth.secretName" .) -}}
-{{- if and $existing (hasKey ($existing.data | default dict) $key) -}}
-{{- index $existing.data $key | b64dec -}}
-{{- else -}}
-{{- randAlphaNum 32 -}}
-{{- end -}}
-{{- end }}
-
-{{/*
-Env var injecting the TLS store password into a container from the chart Secret.
-Usage: {{- include "kafka.tls.storePasswordEnv" . | nindent 12 }}
-*/}}
-{{- define "kafka.tls.storePasswordEnv" -}}
-- name: KAFKA_TLS_STORE_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: {{ include "kafka.auth.secretName" . }}
-      key: {{ include "kafka.tls.storePasswordKey" . | trim }}
-{{- end }}
 
 {{/*
 Return the TLS secret name. Uses existingSecret if set, otherwise the

--- a/kafka/templates/_helpers.tpl
+++ b/kafka/templates/_helpers.tpl
@@ -289,10 +289,41 @@ Generate a content-based suffix for the Kafka bootstrap job so updates trigger a
 {{- end }}
 
 {{/*
-Generate deterministic TLS PKCS12 store password.
+Secret key under which the random TLS PKCS12 store password is persisted (in the
+chart-managed Secret named by kafka.auth.secretName).
 */}}
-{{- define "kafka.tls.storePassword" -}}
-{{- printf "%s-tls-store" .Release.Name | sha256sum | trunc 32 -}}
+{{- define "kafka.tls.storePasswordKey" -}}
+tls-store-password
+{{- end }}
+
+{{/*
+Resolve the TLS PKCS12 keystore/truststore password at render time (used only by
+the Secret template). Random per install, persisted across upgrades via lookup of
+the existing chart Secret. randAlphaNum keeps it free of sed/JAAS-special chars.
+The value is never written into a ConfigMap: workloads read it from the Secret via
+env (secretKeyRef) and substitute the PLACEHOLDER_STORE_PASSWORD marker at startup.
+*/}}
+{{- define "kafka.tls.storePasswordValue" -}}
+{{- $ns := default "default" .Release.Namespace -}}
+{{- $key := include "kafka.tls.storePasswordKey" . | trim -}}
+{{- $existing := lookup "v1" "Secret" $ns (include "kafka.auth.secretName" .) -}}
+{{- if and $existing (hasKey ($existing.data | default dict) $key) -}}
+{{- index $existing.data $key | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Env var injecting the TLS store password into a container from the chart Secret.
+Usage: {{- include "kafka.tls.storePasswordEnv" . | nindent 12 }}
+*/}}
+{{- define "kafka.tls.storePasswordEnv" -}}
+- name: KAFKA_TLS_STORE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "kafka.auth.secretName" . }}
+      key: {{ include "kafka.tls.storePasswordKey" . | trim }}
 {{- end }}
 
 {{/*

--- a/kafka/templates/kafka-broker-deployment.yaml
+++ b/kafka/templates/kafka-broker-deployment.yaml
@@ -58,7 +58,10 @@ spec:
             - -c
             - |
               set -e
-              STORE_PASS="${KAFKA_TLS_STORE_PASSWORD}"
+              # Ephemeral per-pod store password: generated here, shared with the
+              # main container via the kafka-tls emptyDir, never persisted off-pod.
+              STORE_PASS="$(openssl rand -hex 16)"
+              printf '%s' "${STORE_PASS}" > /opt/kafka/tls/store-pass
 
               openssl pkcs12 -export \
                 -in /opt/kafka/tls-pem/{{ .Values.kafka.tls.certFilename }} \
@@ -72,8 +75,6 @@ spec:
                 -storetype PKCS12 \
                 -storepass "${STORE_PASS}" \
                 -noprompt -alias ca
-          env:
-            {{- include "kafka.tls.storePasswordEnv" . | nindent 12 }}
           {{- with .Values.kafka.broker.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -160,7 +161,8 @@ spec:
               sed -i "s|PLACEHOLDER_NODE_ID|${NODE_ID}|g" /tmp/kafka-config/server.properties
               sed -i "s|PLACEHOLDER_POD_NAME|${POD_NAME}|g" /tmp/kafka-config/server.properties
               {{- if .Values.kafka.tls.enabled }}
-              sed -i "s|PLACEHOLDER_STORE_PASSWORD|${KAFKA_TLS_STORE_PASSWORD}|g" /tmp/kafka-config/server.properties
+              STORE_PASS="$(cat /opt/kafka/tls/store-pass)"
+              sed -i "s|PLACEHOLDER_STORE_PASSWORD|${STORE_PASS}|g" /tmp/kafka-config/server.properties
               {{- end }}
               {{- if eq $mechanism "PLAIN" }}
 
@@ -215,9 +217,6 @@ spec:
               value: {{ .Values.kafka.broker.jvm.heapOpts | quote }}
             - name: KAFKA_JVM_PERFORMANCE_OPTS
               value: {{ .Values.kafka.broker.jvm.performanceOpts | quote }}
-            {{- if .Values.kafka.tls.enabled }}
-            {{- include "kafka.tls.storePasswordEnv" . | nindent 12 }}
-            {{- end }}
           {{- with .Values.kafka.broker.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/kafka/templates/kafka-broker-deployment.yaml
+++ b/kafka/templates/kafka-broker-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - -c
             - |
               set -e
-              STORE_PASS="{{ include "kafka.tls.storePassword" . }}"
+              STORE_PASS="${KAFKA_TLS_STORE_PASSWORD}"
 
               openssl pkcs12 -export \
                 -in /opt/kafka/tls-pem/{{ .Values.kafka.tls.certFilename }} \
@@ -72,6 +72,8 @@ spec:
                 -storetype PKCS12 \
                 -storepass "${STORE_PASS}" \
                 -noprompt -alias ca
+          env:
+            {{- include "kafka.tls.storePasswordEnv" . | nindent 12 }}
           {{- with .Values.kafka.broker.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -157,6 +159,9 @@ spec:
               cp /opt/kafka/config/kraft/server.properties /tmp/kafka-config/
               sed -i "s|PLACEHOLDER_NODE_ID|${NODE_ID}|g" /tmp/kafka-config/server.properties
               sed -i "s|PLACEHOLDER_POD_NAME|${POD_NAME}|g" /tmp/kafka-config/server.properties
+              {{- if .Values.kafka.tls.enabled }}
+              sed -i "s|PLACEHOLDER_STORE_PASSWORD|${KAFKA_TLS_STORE_PASSWORD}|g" /tmp/kafka-config/server.properties
+              {{- end }}
               {{- if eq $mechanism "PLAIN" }}
 
               # PLAIN (legacy): build a server JAAS from the mounted per-user secret.
@@ -210,6 +215,9 @@ spec:
               value: {{ .Values.kafka.broker.jvm.heapOpts | quote }}
             - name: KAFKA_JVM_PERFORMANCE_OPTS
               value: {{ .Values.kafka.broker.jvm.performanceOpts | quote }}
+            {{- if .Values.kafka.tls.enabled }}
+            {{- include "kafka.tls.storePasswordEnv" . | nindent 12 }}
+            {{- end }}
           {{- with .Values.kafka.broker.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/kafka/templates/kafka-configmap.yaml
+++ b/kafka/templates/kafka-configmap.yaml
@@ -40,10 +40,10 @@ data:
     {{- if $tls }}
     ssl.keystore.type=PKCS12
     ssl.keystore.location=/opt/kafka/tls/keystore.p12
-    ssl.keystore.password={{ include "kafka.tls.storePassword" . }}
+    ssl.keystore.password=PLACEHOLDER_STORE_PASSWORD
     ssl.truststore.type=PKCS12
     ssl.truststore.location=/opt/kafka/tls/truststore.p12
-    ssl.truststore.password={{ include "kafka.tls.storePassword" . }}
+    ssl.truststore.password=PLACEHOLDER_STORE_PASSWORD
     listener.name.controller.ssl.client.auth=required
     ssl.principal.mapping.rules={{ $principalRule }}
     {{- end }}
@@ -106,10 +106,10 @@ data:
     {{- if $tls }}
     ssl.keystore.type=PKCS12
     ssl.keystore.location=/opt/kafka/tls/keystore.p12
-    ssl.keystore.password={{ include "kafka.tls.storePassword" . }}
+    ssl.keystore.password=PLACEHOLDER_STORE_PASSWORD
     ssl.truststore.type=PKCS12
     ssl.truststore.location=/opt/kafka/tls/truststore.p12
-    ssl.truststore.password={{ include "kafka.tls.storePassword" . }}
+    ssl.truststore.password=PLACEHOLDER_STORE_PASSWORD
     listener.name.internal.ssl.client.auth=required
     listener.name.controller.ssl.client.auth=required
     ssl.principal.mapping.rules={{ $principalRule }}

--- a/kafka/templates/kafka-controller-deployment.yaml
+++ b/kafka/templates/kafka-controller-deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - -c
             - |
               set -e
-              STORE_PASS="{{ include "kafka.tls.storePassword" . }}"
+              STORE_PASS="${KAFKA_TLS_STORE_PASSWORD}"
 
               openssl pkcs12 -export \
                 -in /opt/kafka/tls-pem/{{ .Values.kafka.tls.certFilename }} \
@@ -70,6 +70,8 @@ spec:
                 -storetype PKCS12 \
                 -storepass "${STORE_PASS}" \
                 -noprompt -alias ca
+          env:
+            {{- include "kafka.tls.storePasswordEnv" . | nindent 12 }}
           {{- with .Values.kafka.controller.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -154,6 +156,9 @@ spec:
               cp /opt/kafka/config/kraft/server.properties /tmp/kafka-config/
 
               sed -i "s/PLACEHOLDER_NODE_ID/${NODE_ID}/g" /tmp/kafka-config/server.properties
+              {{- if .Values.kafka.tls.enabled }}
+              sed -i "s|PLACEHOLDER_STORE_PASSWORD|${KAFKA_TLS_STORE_PASSWORD}|g" /tmp/kafka-config/server.properties
+              {{- end }}
 
               exec /opt/kafka/bin/kafka-server-start.sh /tmp/kafka-config/server.properties
           ports:
@@ -185,6 +190,9 @@ spec:
               value: {{ .Values.kafka.controller.jvm.heapOpts | quote }}
             - name: KAFKA_JVM_PERFORMANCE_OPTS
               value: {{ .Values.kafka.controller.jvm.performanceOpts | quote }}
+            {{- if .Values.kafka.tls.enabled }}
+            {{- include "kafka.tls.storePasswordEnv" . | nindent 12 }}
+            {{- end }}
           {{- with .Values.kafka.controller.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/kafka/templates/kafka-controller-deployment.yaml
+++ b/kafka/templates/kafka-controller-deployment.yaml
@@ -56,7 +56,10 @@ spec:
             - -c
             - |
               set -e
-              STORE_PASS="${KAFKA_TLS_STORE_PASSWORD}"
+              # Ephemeral per-pod store password: generated here, shared with the
+              # main container via the kafka-tls emptyDir, never persisted off-pod.
+              STORE_PASS="$(openssl rand -hex 16)"
+              printf '%s' "${STORE_PASS}" > /opt/kafka/tls/store-pass
 
               openssl pkcs12 -export \
                 -in /opt/kafka/tls-pem/{{ .Values.kafka.tls.certFilename }} \
@@ -70,8 +73,6 @@ spec:
                 -storetype PKCS12 \
                 -storepass "${STORE_PASS}" \
                 -noprompt -alias ca
-          env:
-            {{- include "kafka.tls.storePasswordEnv" . | nindent 12 }}
           {{- with .Values.kafka.controller.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -157,7 +158,8 @@ spec:
 
               sed -i "s/PLACEHOLDER_NODE_ID/${NODE_ID}/g" /tmp/kafka-config/server.properties
               {{- if .Values.kafka.tls.enabled }}
-              sed -i "s|PLACEHOLDER_STORE_PASSWORD|${KAFKA_TLS_STORE_PASSWORD}|g" /tmp/kafka-config/server.properties
+              STORE_PASS="$(cat /opt/kafka/tls/store-pass)"
+              sed -i "s|PLACEHOLDER_STORE_PASSWORD|${STORE_PASS}|g" /tmp/kafka-config/server.properties
               {{- end }}
 
               exec /opt/kafka/bin/kafka-server-start.sh /tmp/kafka-config/server.properties
@@ -190,9 +192,6 @@ spec:
               value: {{ .Values.kafka.controller.jvm.heapOpts | quote }}
             - name: KAFKA_JVM_PERFORMANCE_OPTS
               value: {{ .Values.kafka.controller.jvm.performanceOpts | quote }}
-            {{- if .Values.kafka.tls.enabled }}
-            {{- include "kafka.tls.storePasswordEnv" . | nindent 12 }}
-            {{- end }}
           {{- with .Values.kafka.controller.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/kafka/templates/kafka-secret.yaml
+++ b/kafka/templates/kafka-secret.yaml
@@ -5,7 +5,7 @@
 {{- $chartUsers = append $chartUsers . }}
 {{- end }}
 {{- end }}
-{{- if or $chartUsers .Values.kafka.tls.enabled }}
+{{- if $chartUsers }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,9 +21,6 @@ type: Opaque
 stringData:
   {{- range $u := $chartUsers }}
   {{ $u.username }}-password: {{ include "kafka.auth.userPassword" (dict "ctx" $ "user" $u) | quote }}
-  {{- end }}
-  {{- if .Values.kafka.tls.enabled }}
-  {{ include "kafka.tls.storePasswordKey" . | trim }}: {{ include "kafka.tls.storePasswordValue" . | quote }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/kafka/templates/kafka-secret.yaml
+++ b/kafka/templates/kafka-secret.yaml
@@ -5,7 +5,7 @@
 {{- $chartUsers = append $chartUsers . }}
 {{- end }}
 {{- end }}
-{{- if $chartUsers }}
+{{- if or $chartUsers .Values.kafka.tls.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,6 +21,9 @@ type: Opaque
 stringData:
   {{- range $u := $chartUsers }}
   {{ $u.username }}-password: {{ include "kafka.auth.userPassword" (dict "ctx" $ "user" $u) | quote }}
+  {{- end }}
+  {{- if .Values.kafka.tls.enabled }}
+  {{ include "kafka.tls.storePasswordKey" . | trim }}: {{ include "kafka.tls.storePasswordValue" . | quote }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/kafka/templates/kafka-topic-init-job.yaml
+++ b/kafka/templates/kafka-topic-init-job.yaml
@@ -54,7 +54,7 @@ spec:
         - -c
         - |
           set -e
-          STORE_PASS="{{ include "kafka.tls.storePassword" . }}"
+          STORE_PASS="${KAFKA_TLS_STORE_PASSWORD}"
           openssl pkcs12 -export \
             -in /opt/kafka/tls-pem/{{ .Values.kafka.tls.certFilename }} \
             -inkey /opt/kafka/tls-pem/{{ .Values.kafka.tls.keyFilename }} \
@@ -66,6 +66,8 @@ spec:
             -storetype PKCS12 \
             -storepass "${STORE_PASS}" \
             -noprompt -alias ca
+        env:
+          {{- include "kafka.tls.storePasswordEnv" . | nindent 10 }}
         resources:
           requests:
             cpu: 50m
@@ -91,6 +93,9 @@ spec:
           # and a container with headroom.
           - name: KAFKA_HEAP_OPTS
             value: "-Xmx256m -Xms64m"
+          {{- if $tls }}
+          {{- include "kafka.tls.storePasswordEnv" . | nindent 10 }}
+          {{- end }}
         resources:
           requests:
             cpu: 50m
@@ -115,10 +120,10 @@ spec:
           security.protocol=SSL
           ssl.keystore.type=PKCS12
           ssl.keystore.location=/tmp/kafka-tls/keystore.p12
-          ssl.keystore.password={{ include "kafka.tls.storePassword" . }}
+          ssl.keystore.password=${KAFKA_TLS_STORE_PASSWORD}
           ssl.truststore.type=PKCS12
           ssl.truststore.location=/tmp/kafka-tls/truststore.p12
-          ssl.truststore.password={{ include "kafka.tls.storePassword" . }}
+          ssl.truststore.password=${KAFKA_TLS_STORE_PASSWORD}
           EOF
           {{- else }}
           cat > "$CC" <<EOF

--- a/kafka/templates/kafka-topic-init-job.yaml
+++ b/kafka/templates/kafka-topic-init-job.yaml
@@ -54,7 +54,10 @@ spec:
         - -c
         - |
           set -e
-          STORE_PASS="${KAFKA_TLS_STORE_PASSWORD}"
+          # Ephemeral per-pod store password: generated here, shared with the main
+          # container via the kafka-tls emptyDir, never persisted off-pod.
+          STORE_PASS="$(openssl rand -hex 16)"
+          printf '%s' "${STORE_PASS}" > /tmp/kafka-tls/store-pass
           openssl pkcs12 -export \
             -in /opt/kafka/tls-pem/{{ .Values.kafka.tls.certFilename }} \
             -inkey /opt/kafka/tls-pem/{{ .Values.kafka.tls.keyFilename }} \
@@ -66,8 +69,6 @@ spec:
             -storetype PKCS12 \
             -storepass "${STORE_PASS}" \
             -noprompt -alias ca
-        env:
-          {{- include "kafka.tls.storePasswordEnv" . | nindent 10 }}
         resources:
           requests:
             cpu: 50m
@@ -93,9 +94,6 @@ spec:
           # and a container with headroom.
           - name: KAFKA_HEAP_OPTS
             value: "-Xmx256m -Xms64m"
-          {{- if $tls }}
-          {{- include "kafka.tls.storePasswordEnv" . | nindent 10 }}
-          {{- end }}
         resources:
           requests:
             cpu: 50m
@@ -116,14 +114,15 @@ spec:
           # (ANONYMOUS super-user) in insecure mode. This avoids the SCRAM
           # chicken-and-egg (creating users requires an already-authorized admin).
           {{- if $tls }}
+          STORE_PASS="$(cat /tmp/kafka-tls/store-pass)"
           cat > "$CC" <<EOF
           security.protocol=SSL
           ssl.keystore.type=PKCS12
           ssl.keystore.location=/tmp/kafka-tls/keystore.p12
-          ssl.keystore.password=${KAFKA_TLS_STORE_PASSWORD}
+          ssl.keystore.password=${STORE_PASS}
           ssl.truststore.type=PKCS12
           ssl.truststore.location=/tmp/kafka-tls/truststore.p12
-          ssl.truststore.password=${KAFKA_TLS_STORE_PASSWORD}
+          ssl.truststore.password=${STORE_PASS}
           EOF
           {{- else }}
           cat > "$CC" <<EOF

--- a/kafka/tests/test-full.sh
+++ b/kafka/tests/test-full.sh
@@ -48,8 +48,8 @@ for pod in "${BROKER_0}" "${BROKER_1}"; do
   assert_eq "${pod} is Running" "Running" "${phase}"
 done
 
-# PKCS12 store password is deterministic: sha256("<release>-tls-store")[:32]
-STOREPASS=$(printf '%s' "${RELEASE}-tls-store" | sha256sum | cut -c1-32)
+# PKCS12 store password is a random per-install value persisted in the chart Secret.
+STOREPASS=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o jsonpath="{.data.tls-store-password}" | base64 -d)
 TESTUSER_PW=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o jsonpath='{.data.testuser-password}' | base64 -d)
 APPUSER_PW=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o jsonpath='{.data.appuser-password}' | base64 -d)
 

--- a/kafka/tests/test-full.sh
+++ b/kafka/tests/test-full.sh
@@ -48,20 +48,19 @@ for pod in "${BROKER_0}" "${BROKER_1}"; do
   assert_eq "${pod} is Running" "Running" "${phase}"
 done
 
-# PKCS12 store password is a random per-install value persisted in the chart Secret.
-STOREPASS=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o jsonpath="{.data.tls-store-password}" | base64 -d)
 TESTUSER_PW=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o jsonpath='{.data.testuser-password}' | base64 -d)
 APPUSER_PW=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o jsonpath='{.data.appuser-password}' | base64 -d)
 
-# Write a SASL_SSL/SCRAM client config for a given user inside a pod.
+# Write a SASL_SSL/SCRAM client config for a given user inside a pod. The PKCS12
+# store password is ephemeral and per-pod, so read it from the pod we write into.
 write_client_props() {
   local pod="$1" user="$2" pw="$3"
-  kubectl exec -n "${NAMESPACE}" "${pod}" -- bash -c "cat > /tmp/${user}.properties <<EOF
+  kubectl exec -n "${NAMESPACE}" "${pod}" -- bash -c "SP=\$(cat /opt/kafka/tls/store-pass); cat > /tmp/${user}.properties <<EOF
 security.protocol=SASL_SSL
 sasl.mechanism=SCRAM-SHA-512
 sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${user}\" password=\"${pw}\";
 ssl.truststore.location=/opt/kafka/tls/truststore.p12
-ssl.truststore.password=${STOREPASS}
+ssl.truststore.password=\${SP}
 ssl.truststore.type=PKCS12
 EOF"
 }

--- a/kafka/tests/test-minimal.sh
+++ b/kafka/tests/test-minimal.sh
@@ -65,8 +65,8 @@ assert_contains "cert-manager issued the broker TLS secret" "${tls_secret}" "sec
 # --- SASL_SSL + SCRAM produce/consume as a client user ---
 BROKER_SVC="${BROKER}.${FULLNAME}-kafka-broker.${NAMESPACE}.svc.cluster.local:9092"
 PASSWORD=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o jsonpath="{.data.${USER_NAME}-password}" | base64 -d)
-# PKCS12 store password is deterministic: sha256("<release>-tls-store")[:32]
-STOREPASS=$(printf '%s' "${RELEASE}-tls-store" | sha256sum | cut -c1-32)
+# PKCS12 store password is a random per-install value persisted in the chart Secret.
+STOREPASS=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o jsonpath="{.data.tls-store-password}" | base64 -d)
 
 # Write a SASL_SSL/SCRAM client config inside the broker pod (reuses the pod's
 # mTLS truststore, which trusts the chart CA).

--- a/kafka/tests/test-minimal.sh
+++ b/kafka/tests/test-minimal.sh
@@ -65,8 +65,9 @@ assert_contains "cert-manager issued the broker TLS secret" "${tls_secret}" "sec
 # --- SASL_SSL + SCRAM produce/consume as a client user ---
 BROKER_SVC="${BROKER}.${FULLNAME}-kafka-broker.${NAMESPACE}.svc.cluster.local:9092"
 PASSWORD=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o jsonpath="{.data.${USER_NAME}-password}" | base64 -d)
-# PKCS12 store password is a random per-install value persisted in the chart Secret.
-STOREPASS=$(kubectl get secret -n "${NAMESPACE}" "${FULLNAME}-kafka-secret" -o jsonpath="{.data.tls-store-password}" | base64 -d)
+# PKCS12 store password is an ephemeral per-pod value generated at runtime and
+# shared within the pod; read it from the broker we exec into below.
+STOREPASS=$(kubectl exec -n "${NAMESPACE}" "${BROKER}" -- cat /opt/kafka/tls/store-pass)
 
 # Write a SASL_SSL/SCRAM client config inside the broker pod (reuses the pod's
 # mTLS truststore, which trusts the chart CA).

--- a/kafka/tests/test-template.sh
+++ b/kafka/tests/test-template.sh
@@ -68,6 +68,11 @@ assert_contains "defaults: self-signed Issuer created" "${defaults}" "test-kafka
 assert_contains "defaults: CA Issuer created" "${defaults}" "test-kafka-kafka-ca"
 assert_contains "defaults: leaf Certificate created" "${defaults}" "kind: Certificate"
 assert_contains "defaults: tls-init init container present" "${defaults}" "tls-init"
+# TLS store password: random, in a Secret, never baked into the ConfigMap (#243)
+assert_contains "defaults: store password persisted in Secret" "${defaults}" "tls-store-password:"
+assert_contains "defaults: ConfigMap uses store-password placeholder" "${defaults}" "ssl.keystore.password=PLACEHOLDER_STORE_PASSWORD"
+assert_contains "defaults: store password injected via secretKeyRef env" "${defaults}" "KAFKA_TLS_STORE_PASSWORD"
+assert_not_contains "defaults: no predictable -tls-store password derivation" "${defaults}" "sha256sum"
 
 # --- TLS with an operator-supplied cert-manager issuer ---
 tls_cm=$(helm template test-kafka "${CHART_DIR}" \

--- a/kafka/tests/test-template.sh
+++ b/kafka/tests/test-template.sh
@@ -68,11 +68,16 @@ assert_contains "defaults: self-signed Issuer created" "${defaults}" "test-kafka
 assert_contains "defaults: CA Issuer created" "${defaults}" "test-kafka-kafka-ca"
 assert_contains "defaults: leaf Certificate created" "${defaults}" "kind: Certificate"
 assert_contains "defaults: tls-init init container present" "${defaults}" "tls-init"
-# TLS store password: random, in a Secret, never baked into the ConfigMap (#243)
-assert_contains "defaults: store password persisted in Secret" "${defaults}" "tls-store-password:"
+# TLS store password (#243): ephemeral, generated per-pod at runtime, never baked
+# into a ConfigMap OR a Secret, and no render-time value (so GitOps stays stable).
 assert_contains "defaults: ConfigMap uses store-password placeholder" "${defaults}" "ssl.keystore.password=PLACEHOLDER_STORE_PASSWORD"
-assert_contains "defaults: store password injected via secretKeyRef env" "${defaults}" "KAFKA_TLS_STORE_PASSWORD"
-assert_not_contains "defaults: no predictable -tls-store password derivation" "${defaults}" "sha256sum"
+assert_contains "defaults: store password generated at runtime" "${defaults}" "openssl rand -hex 16"
+assert_contains "defaults: store password shared via emptyDir file" "${defaults}" "/opt/kafka/tls/store-pass"
+assert_not_contains "defaults: store password not in a Secret" "${defaults}" "tls-store-password:"
+assert_not_contains "defaults: no store-password secretKeyRef env" "${defaults}" "KAFKA_TLS_STORE_PASSWORD"
+# No release-name-derived store password anywhere in the rendered output (#243).
+old_derived=$(printf '%s' "test-kafka-tls-store" | sha256sum | cut -c1-32)
+assert_not_contains "defaults: store password is not release-name-derived" "${defaults}" "${old_derived}"
 
 # --- TLS with an operator-supplied cert-manager issuer ---
 tls_cm=$(helm template test-kafka "${CHART_DIR}" \


### PR DESCRIPTION
Closes #243.

The PKCS12 keystore/truststore password was derived deterministically from public input (`sha256("<release>-tls-store")`) and embedded in cleartext in a ConfigMap — anyone knowing the release name (visible in pod names) could compute it, and ConfigMap read access exposed it directly.

**Now — ephemeral, per-pod, generated at runtime:**
- The keystore/truststore are already rebuilt from the mounted PEM on every pod start, so the store password only needs to be consistent *within a single pod*. Each pod's `tls-init` container generates a fresh random password (`openssl rand -hex 16`) and writes it to a shared `emptyDir` file (`store-pass`); the main container reads it and substitutes the `PLACEHOLDER_STORE_PASSWORD` marker into the runtime `server.properties` (same idiom as `PLACEHOLDER_NODE_ID`). `tls-init` builds the PKCS12 stores with the same value.
- The password therefore lives in **no ConfigMap and no Secret**, and there is **no render-time value at all** — so GitOps (ArgoCD/Flux) renders stay stable (no perpetual Secret drift).

Applied to broker, controller, and topic-init workloads. `openssl rand -hex` keeps the value free of sed/JAAS-special characters. Insecure (non-TLS) path is unaffected.

Render tests assert the placeholder is used, the password is generated at runtime and shared via the emptyDir file, and no store password appears in any Secret/ConfigMap or is release-name-derived. The kind e2e (`test` CI job) exercises the full TLS/mTLS produce/consume path; test harness reads each pod's ephemeral password from the pod.