### PR TITLE
feat(pg,pgvector): extraVolumes/extraVolumeMounts/extraEnv passthrough (#262)

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,19 @@
 # pg chart changelog
 
+## 1.6.0 - 2026-07-30
+
+### Added
+
+- **`postgresql.extraVolumes` / `postgresql.extraVolumeMounts` / `postgresql.extraEnv`**
+  (#262) — generic pod-spec passthrough for the postgresql container. Lets an operator
+  mount an arbitrary `Secret`/`ConfigMap` as a file that is byte-identical on the primary
+  and every standby, without a per-use-case chart change. The motivating case is the
+  pgsodium server root key (Supabase Vault) read via `pgsodium.getkey_script`: it must be
+  identical across replicas so a promoted standby can still decrypt `supabase_vault` after
+  a failover. `extraVolumes` render into the pod template; `extraVolumeMounts` and
+  `extraEnv` onto the postgresql container. All default to `[]` (no change to rendered
+  output when unset).
+
 ## 1.5.0 - 2026-07-12
 
 Requires the new repmgr image (`trixie-5.5.0-28`), which bundles the `pgaudit`

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -12,7 +12,38 @@
   identical across replicas so a promoted standby can still decrypt `supabase_vault` after
   a failover. `extraVolumes` render into the pod template; `extraVolumeMounts` and
   `extraEnv` onto the postgresql container. All default to `[]` (no change to rendered
-  output when unset).
+  output when unset). See the README, "Mounting an extra file on every replica".
+
+  The three values are validated at render time (`pg.validateExtraPassthrough`), keeping
+  the chart's fail-fast convention — each plausible mistake would otherwise be a silent
+  runtime failure or an apply-time API rejection:
+  - each must be a **list** of objects (a map produced an opaque YAML parse error);
+  - an `extraVolumes` name may not collide with a chart-managed volume — a `data`
+    collision is silently discarded in favour of the volumeClaimTemplate (mount resolves
+    into the PVC, expected file absent → CrashLoopBackOff with nothing to point at), and
+    with persistence off the duplicate name is rejected by the API server;
+  - every `extraVolumeMounts` entry must reference a declared `extraVolumes` entry
+    (catches the `extraVolume:`/`extraVolumes:` typo, which `values.schema.json` cannot —
+    `additionalProperties` is open — and which otherwise fails only at apply, leaving a
+    live release in a failed state);
+  - `extraEnv` may not reuse a chart-set env name (`PGDATA`, `POSTGRES_*`, `REPMGR_*`, …);
+    duplicate env names are last-wins at runtime, so an override would silently shadow the
+    chart/Secret value (wrong data directory, or cluster-wide auth failure).
+
+### Fixed
+
+- **An operator-set `postgresql.configuration.shared_preload_libraries` silently dropped
+  `repmgr` whenever `postgresql.audit.enabled` was false**, disabling failover. The merge
+  that preserves `repmgr` (and the operator's own libraries) previously ran only on the
+  audit path, while `custom.conf` is loaded via `conf.d`'s `include_dir` *after* the repmgr
+  image's own `postgresql.conf` — so a bare value overrode
+  `shared_preload_libraries = 'repmgr'` and the postmaster started without the repmgr
+  library: repmgrd/agent lost their repmgr functions and no standby was ever promoted.
+  The merge is now unconditional in repmgr mode, emitted from an authoritative
+  `repmgr-preload.conf` that sorts after `custom.conf`. Surfaced while reviewing #262,
+  whose pgsodium use case requires exactly this setting. Behaviour is unchanged when audit
+  is enabled, and in standalone mode (nothing to preserve) the operator's value still
+  passes through `custom.conf` untouched.
 
 ## 1.5.0 - 2026-07-12
 

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with repmgr replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 1.5.0
+version: 1.6.0
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/README.md
+++ b/pg/README.md
@@ -162,6 +162,9 @@ Runtime configuration can be injected without rebuilding images. Settings are wr
 |-----------|-------------|---------|
 | `postgresql.configuration` | Map of postgresql.conf parameters | `{}` |
 | `postgresql.pgHba` | List of pg_hba.conf entries injected via postStart | `[]` |
+| `postgresql.extraVolumes` | Extra pod-level volumes (see [Mounting an extra file on every replica](#mounting-an-extra-file-on-every-replica)) | `[]` |
+| `postgresql.extraVolumeMounts` | Extra mounts for the postgresql container; each must reference a `postgresql.extraVolumes` entry | `[]` |
+| `postgresql.extraEnv` | Extra env vars for the postgresql container (supports `value` and `valueFrom`); may not reuse a chart-set name | `[]` |
 | `postgresql.extensions.enabled` | Enable extensions support | `false` |
 | `postgresql.audit.enabled` | Enable pgaudit audit logging (requires repmgr mode; see [Audit logging](#audit-logging-pgaudit)) | `false` |
 | `postgresql.audit.log` | pgaudit session classes: `read,write,function,role,ddl,misc,misc_set,all` (negate with `-`) | `"ddl, role, write"` |
@@ -194,6 +197,42 @@ postgresql:
 ```
 
 When `repmgr.enabled` is true, `additionalCommands` automatically discover the current primary and execute against it, so DDL statements like `CREATE EXTENSION` work correctly regardless of which pod the hook runs on (including standbys after a failover).
+
+### Mounting an extra file on every replica
+
+Some extensions read a key or config file from disk that **must be byte-identical on the primary and every standby** — otherwise a promoted standby behaves differently after a failover. The canonical case is **pgsodium** (the basis of Supabase Vault): its server root key is loaded by `pgsodium.getkey_script`, and if a standby has a different key it cannot decrypt `supabase_vault` secrets once promoted — a silent, post-failover data-availability failure.
+
+Mount the file with `postgresql.extraVolumes` + `postgresql.extraVolumeMounts`. Because these render into the StatefulSet pod template, every replica gets the same file, and it survives failover and a `pg_rewind` rejoin:
+
+```yaml
+postgresql:
+  extraVolumes:
+    - name: pgsodium-key
+      secret:
+        secretName: pgsodium-root-key
+        defaultMode: 0400
+        items:
+          - key: getkey.sh
+            path: getkey.sh
+  extraVolumeMounts:
+    - name: pgsodium-key
+      mountPath: /etc/postgresql/pgsodium
+      readOnly: true
+  configuration:
+    shared_preload_libraries: pgsodium
+    pgsodium.getkey_script: /etc/postgresql/pgsodium/getkey.sh
+```
+
+In repmgr mode the chart merges `repmgr` into `shared_preload_libraries` for you — declare only your own libraries. (A bare value in `configuration` is loaded via `include_dir` *after* the image's own `postgresql.conf`, so without that merge it would override the image's `shared_preload_libraries = 'repmgr'` and silently disable failover.)
+
+`postgresql.extraEnv` does the same for environment variables and accepts both `value` and `valueFrom`.
+
+These three values are validated at render time, so a mistake fails `helm install`/`upgrade` with a clear message instead of at apply time or silently at runtime:
+
+- each must be a **list** of objects (a map is a common slip and would otherwise produce an opaque YAML parse error);
+- an `extraVolumes` name may not collide with a chart-managed volume (`data`, `postgresql-config`, `postgresql-tls`, `ext-lib`, `ext-share`, `repmgr-config`, `etcd-tls`, `pg-run`, `pgbackrest-config`, `service-updater-script`) — a `data` collision is silently dropped in favour of the volumeClaimTemplate;
+- every `extraVolumeMounts` entry must reference a declared `extraVolumes` entry (catches the `extraVolume:`/`extraVolumes:` typo, which the API server would otherwise reject only at apply time);
+- `extraEnv` may not reuse a chart-set env name (`PGDATA`, `POSTGRES_*`, `REPMGR_*`, …) — duplicate env names are last-wins at runtime, so an override would silently shadow the chart/Secret value.
 
 ### Repmgr Parameters
 

--- a/pg/templates/_helpers.tpl
+++ b/pg/templates/_helpers.tpl
@@ -261,17 +261,41 @@ GRANT {{ $privs }} ON DATABASE "{{ $g.database }}" TO "{{ $role }}"
 {{- end -}}
 {{- end }}
 
-{{- /* #219: the authoritative shared_preload_libraries value when audit is enabled.
-       This renders into pgaudit.conf, which sorts after custom.conf under conf.d's
-       include_dir and therefore wins -- so it MUST reassemble the full list, not just
-       pgaudit. repmgr is always kept (replication + repmgr GUCs depend on the preload,
-       and audit is guarded to repmgr mode); any libraries the operator declared in
-       postgresql.configuration.shared_preload_libraries are merged in (comma-split,
-       trimmed, de-duplicated) so enabling audit never silently drops a preload. The
-       operator's key is matched case-insensitively -- PostgreSQL GUC names are
+{{- /* True when the operator declared shared_preload_libraries in
+       postgresql.configuration (matched case-insensitively -- PostgreSQL GUC names are
        case-insensitive, so a value under e.g. `Shared_Preload_Libraries` must still be
-       picked up (and is likewise suppressed in custom.conf) or it would be dropped. */ -}}
-{{- define "pg.auditSharedPreloadLibraries" -}}
+       found or it would be silently dropped from the merge). */ -}}
+{{- define "pg.userSetSharedPreloadLibraries" -}}
+{{- range $k, $v := (.Values.postgresql.configuration | default dict) -}}
+  {{- if eq (lower ($k | toString)) "shared_preload_libraries" -}}true{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- /* True when the chart -- not custom.conf -- owns shared_preload_libraries, i.e. the
+       merged value is emitted from an authoritative conf.d file that sorts after
+       custom.conf. That is the case whenever a library must be preserved across an
+       operator-declared value: repmgr (replication) and/or pgaudit (#219). In standalone
+       mode with audit off there is nothing to preserve, so the operator's value passes
+       through custom.conf untouched. */ -}}
+{{- define "pg.chartOwnsSharedPreloadLibraries" -}}
+{{- if or .Values.postgresql.audit.enabled (and .Values.repmgr.enabled (eq (include "pg.userSetSharedPreloadLibraries" .) "true")) -}}true{{- end -}}
+{{- end -}}
+
+{{- /* The authoritative shared_preload_libraries value. Rendered into a conf.d file that
+       sorts after custom.conf under include_dir and therefore wins -- so it MUST
+       reassemble the FULL list, not just the chart's own libraries.
+         - repmgr is kept whenever repmgr.enabled: replication and the repmgr GUCs depend
+           on the preload, and the repmgr image entrypoint writes
+           `shared_preload_libraries = 'repmgr'` into PGDATA/postgresql.conf, which any
+           conf.d value overrides. Dropping it disables failover (#262 review).
+         - pgaudit is appended when audit.enabled (#219).
+         - Libraries the operator declared in postgresql.configuration are merged in
+           (comma-split, trimmed, de-duplicated) so the chart never silently drops a
+           preload the operator asked for.
+       Originally audit-only (pg.auditSharedPreloadLibraries); generalized because the
+       audit-gated merge meant an operator-set value with audit OFF silently dropped
+       repmgr and broke HA failover. */ -}}
+{{- define "pg.sharedPreloadLibraries" -}}
 {{- $libs := list -}}
 {{- $user := "" -}}
 {{- range $k, $v := (.Values.postgresql.configuration | default dict) -}}
@@ -281,8 +305,8 @@ GRANT {{ $privs }} ON DATABASE "{{ $g.database }}" TO "{{ $role }}"
   {{- $t := trim $l -}}
   {{- if and $t (not (has $t $libs)) -}}{{- $libs = append $libs $t -}}{{- end -}}
 {{- end -}}
-{{- if not (has "repmgr" $libs) -}}{{- $libs = prepend $libs "repmgr" -}}{{- end -}}
-{{- if not (has "pgaudit" $libs) -}}{{- $libs = append $libs "pgaudit" -}}{{- end -}}
+{{- if and .Values.repmgr.enabled (not (has "repmgr" $libs)) -}}{{- $libs = prepend $libs "repmgr" -}}{{- end -}}
+{{- if and .Values.postgresql.audit.enabled (not (has "pgaudit" $libs)) -}}{{- $libs = append $libs "pgaudit" -}}{{- end -}}
 {{- join "," $libs -}}
 {{- end -}}
 
@@ -316,6 +340,85 @@ GRANT {{ $privs }} ON DATABASE "{{ $g.database }}" TO "{{ $role }}"
   {{- if and $role (not (regexMatch "^[A-Za-z_][A-Za-z0-9_]*$" $role)) -}}
     {{- fail (printf "postgresql.audit.role: invalid role name %q (must match ^[A-Za-z_][A-Za-z0-9_]*$)" $role) -}}
   {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{- /* #262: validate the postgresql.extraVolumes / extraVolumeMounts / extraEnv
+       passthrough. These are spliced verbatim into the pod spec, so without guards a
+       plausible mistake becomes a silent runtime failure or an apply-time apiserver
+       rejection instead of a render error -- against the chart's fail-fast convention.
+       Guards:
+        (g1) each value must be a LIST of objects. A map (the shape operators reach for,
+             e.g. `extraEnv: {FOO: bar}`) makes toYaml emit a mapping at the sequence
+             indent, so helm aborts with an opaque "did not find expected '-' indicator"
+             YAML parse error naming neither the value nor the required shape.
+        (g2) every entry needs a name (it is the k8s join key for volume<->mount).
+        (g3) extraVolumes names may not collide with a chart-managed volume. A collision
+             on `data` is the dangerous one: with persistence on, the volumeClaimTemplate
+             wins and the pod-spec volume is silently discarded (the mount then resolves
+             into the PVC and the expected file is simply absent -> CrashLoopBackOff with
+             nothing to point at); with persistence off the pod spec carries a duplicate
+             name and the apiserver rejects the StatefulSet.
+        (g4) extraVolumeMounts must reference a declared extraVolumes entry. Chart-owned
+             volumes are deliberately NOT mountable here -- they are internal, and
+             allowing them would reintroduce the ambiguity g3 exists to prevent. This
+             catches the sibling-key typo (`extraVolume:` for `extraVolumes:`), which
+             values.schema.json cannot (additionalProperties is open) and which otherwise
+             renders cleanly and fails only at apply, leaving a live release failed.
+        (g5) extraEnv may not reuse a chart-managed env name. Duplicate env keys are legal
+             YAML and last-wins in the runtime, so a PGDATA or POSTGRES_PASSWORD override
+             would silently win over the chart/Secret value -- pointing the postmaster at
+             the wrong data directory or breaking auth cluster-wide. */ -}}
+{{- define "pg.validateExtraPassthrough" -}}
+{{- $chartVolumes := list "data" "postgresql-config" "postgresql-tls" "ext-lib" "ext-share" "repmgr-config" "etcd-tls" "pg-run" "pgbackrest-config" "service-updater-script" -}}
+{{- /* Env vars the chart sets on the postgresql container (see statefulset.yaml). Reserved
+       UNCONDITIONALLY -- including the ones only a currently-disabled feature emits -- so a
+       passthrough that works today cannot start silently shadowing a chart value after a
+       later `helm upgrade` enables that feature. */ -}}
+{{- $chartEnv := list
+      "PGDATA" "POSTGRES_USER" "POSTGRES_PASSWORD" "POSTGRES_DB"
+      "REPMGR_USER" "REPMGR_PASSWORD" "REPMGR_DB" "REPMGR_NODE_COUNT" "HEADLESS_SERVICE"
+      "NAMESPACE" "PRIMARY_MARKER" "POD_NAME" "POD_SELECTOR" "POD_CIDR" "MASTER_SERVICE"
+      "LEASE_NAME" "LEASE_DURATION" "RENEW_DEADLINE" "RETRY_PERIOD" "RECONCILE_INTERVAL"
+      "CASCADE_REPLICATION" "POSTGRESQL_PGHBA" "TLS_REQUIRE_SSL" "TLS_CLIENT_CERT_AUTH"
+      "MONITORING_USER" "MIGRATE_LEGACY_MD5_USERS" "SPLIT_BRAIN_ACTION"
+      "DCS_BACKEND" "ETCD_ENDPOINTS" "ETCD_PREFIX" "ETCD_TLS_CERT" "ETCD_TLS_KEY" "ETCD_TLS_CA"
+      "PGBACKREST_ENABLED" "PGBACKREST_STANZA" "PGBACKREST_REPO1_CIPHER_PASS"
+      "PGBACKREST_REPO1_S3_KEY" "PGBACKREST_REPO1_S3_KEY_SECRET" "MONITORING_HISTORY_DAYS" -}}
+{{- /* g1: shape. `with` is not used -- an explicitly-set map must reach the check. */ -}}
+{{- range $key := list "extraVolumes" "extraVolumeMounts" "extraEnv" -}}
+  {{- $val := index $.Values.postgresql $key -}}
+  {{- if and $val (not (kindIs "slice" $val)) -}}
+    {{- fail (printf "postgresql.%s must be a list of objects, got %s. Use a YAML sequence of entries, each with a name (e.g. `postgresql.%s: [{name: my-entry, ...}]`), not a map." $key (kindOf $val) $key) -}}
+  {{- end -}}
+{{- end -}}
+{{- $volNames := list -}}
+{{- range $i, $v := (.Values.postgresql.extraVolumes | default list) -}}
+  {{- $n := ($v.name | default "") | toString -}}
+  {{- if not $n -}}{{- fail (printf "postgresql.extraVolumes[%d]: name is required" $i) -}}{{- end -}}
+  {{- if has $n $chartVolumes -}}
+    {{- fail (printf "postgresql.extraVolumes[%d]: %q is a chart-managed volume name and may not be reused (reserved: %s). With persistence enabled a %q volume is silently discarded in favour of the volumeClaimTemplate; with persistence disabled the duplicate name is rejected by the API server. Pick a distinct name." $i $n (join ", " $chartVolumes) $n) -}}
+  {{- end -}}
+  {{- if has $n $volNames -}}{{- fail (printf "postgresql.extraVolumes[%d]: duplicate volume name %q" $i $n) -}}{{- end -}}
+  {{- $volNames = append $volNames $n -}}
+{{- end -}}
+{{- range $i, $m := (.Values.postgresql.extraVolumeMounts | default list) -}}
+  {{- $n := ($m.name | default "") | toString -}}
+  {{- if not $n -}}{{- fail (printf "postgresql.extraVolumeMounts[%d]: name is required" $i) -}}{{- end -}}
+  {{- if not ($m.mountPath | default "") -}}{{- fail (printf "postgresql.extraVolumeMounts[%d] (%s): mountPath is required" $i $n) -}}{{- end -}}
+  {{- if not (has $n $volNames) -}}
+    {{- fail (printf "postgresql.extraVolumeMounts[%d]: no postgresql.extraVolumes entry named %q (declared: %s). Every extra mount needs a matching extra volume -- otherwise the API server rejects the StatefulSet at apply time with `volumeMounts[..].name: Not found`. Check for a typo, or that you set extraVolumes (plural). Chart-managed volumes cannot be mounted here." $i $n (ternary "none" (join ", " $volNames) (empty $volNames))) -}}
+  {{- end -}}
+{{- end -}}
+{{- $envNames := list -}}
+{{- range $i, $e := (.Values.postgresql.extraEnv | default list) -}}
+  {{- $n := ($e.name | default "") | toString -}}
+  {{- if not $n -}}{{- fail (printf "postgresql.extraEnv[%d]: name is required" $i) -}}{{- end -}}
+  {{- if has $n $chartEnv -}}
+    {{- fail (printf "postgresql.extraEnv[%d]: %q is set by the chart on the postgresql container and may not be overridden -- a duplicate env name is last-wins at runtime, so this would silently shadow the chart/Secret value (e.g. pointing the postmaster at the wrong PGDATA, or breaking cluster-wide auth). Use the chart's own value for this setting instead." $i $n) -}}
+  {{- end -}}
+  {{- if has $n $envNames -}}{{- fail (printf "postgresql.extraEnv[%d]: duplicate env name %q" $i $n) -}}{{- end -}}
+  {{- $envNames = append $envNames $n -}}
 {{- end -}}
 {{- end }}
 

--- a/pg/templates/postgresql-configmap.yaml
+++ b/pg/templates/postgresql-configmap.yaml
@@ -11,19 +11,38 @@ metadata:
     {{- . | nindent 4 }}
   {{- end }}
 data:
-{{- if .Values.postgresql.configuration }}
+{{- /* When the chart owns shared_preload_libraries (repmgr and/or pgaudit must be
+       preserved), the merged value is emitted from an authoritative file below that sorts
+       after custom.conf under conf.d's include_dir; emitting it here too would be a dead
+       duplicate that file overrides, so skip it. Matched case-insensitively -- PostgreSQL
+       GUC names are case-insensitive, and the merge helper reads the key the same way, so
+       both must agree or a non-canonically cased key would be emitted here yet dropped
+       from the merged preload list. Keys are collected first so custom.conf is omitted
+       entirely (rather than emitted empty) when the preload key was its only entry. */}}
+{{- $ownsPreload := eq (include "pg.chartOwnsSharedPreloadLibraries" .) "true" }}
+{{- $customKeys := list }}
+{{- range $key, $value := (.Values.postgresql.configuration | default dict) }}
+{{- if not (and $ownsPreload (eq (lower ($key | toString)) "shared_preload_libraries")) }}
+{{- $customKeys = append $customKeys $key }}
+{{- end }}
+{{- end }}
+{{- if $customKeys }}
   custom.conf: |
-    {{- range $key, $value := .Values.postgresql.configuration }}
-    {{- /* When audit is on, shared_preload_libraries is owned by pgaudit.conf (which
-           merges this value with repmgr + pgaudit); emitting it here too would be a
-           dead duplicate that pgaudit.conf overrides, so skip it. Matched case-
-           insensitively -- PostgreSQL GUC names are case-insensitive, and the merge
-           helper reads the key the same way, so both must agree or a non-canonically
-           cased key would be emitted here yet dropped from the merged preload list. */}}
-    {{- if not (and $.Values.postgresql.audit.enabled (eq (lower ($key | toString)) "shared_preload_libraries")) }}
-    {{ $key }} = '{{ $value | toString | replace "'" "''" }}'
+    {{- range $key := $customKeys }}
+    {{ $key }} = '{{ index $.Values.postgresql.configuration $key | toString | replace "'" "''" }}'
     {{- end }}
-    {{- end }}
+{{- end }}
+{{- if and (not .Values.postgresql.audit.enabled) (eq (include "pg.chartOwnsSharedPreloadLibraries" .) "true") }}
+  # repmgr mode with an operator-declared shared_preload_libraries. custom.conf is loaded
+  # via conf.d's include_dir at the END of PGDATA/postgresql.conf, so a bare operator value
+  # there would override the repmgr image entrypoint's `shared_preload_libraries = 'repmgr'`
+  # and start the postmaster WITHOUT the repmgr library -- replication and the repmgr GUCs
+  # lose their functions and failover silently stops working (#262 review). This file sorts
+  # after custom.conf, so its merged value (repmgr + the operator's libraries) wins.
+  # shared_preload_libraries is a postmaster parameter: a change here rolls the pods via the
+  # StatefulSet's checksum/postgresql-config annotation.
+  repmgr-preload.conf: |
+    shared_preload_libraries = '{{ include "pg.sharedPreloadLibraries" . }}'
 {{- end }}
 {{- if .Values.pgbackrest.enabled }}
   # Required for pgbackrest WAL archiving. archive_mode is a postmaster
@@ -55,7 +74,7 @@ data:
   # conf.d's include_dir, so its shared_preload_libraries is authoritative; the helper
   # keeps repmgr (replication) and any operator-declared libraries and adds pgaudit.
   pgaudit.conf: |
-    shared_preload_libraries = '{{ include "pg.auditSharedPreloadLibraries" . }}'
+    shared_preload_libraries = '{{ include "pg.sharedPreloadLibraries" . }}'
     pgaudit.log = '{{ .Values.postgresql.audit.log | toString | replace "'" "''" }}'
     pgaudit.log_catalog = {{ ternary "on" "off" .Values.postgresql.audit.logCatalog }}
     pgaudit.log_parameter = {{ ternary "on" "off" .Values.postgresql.audit.logParameter }}

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -1,5 +1,6 @@
 {{- include "pg.validateResourceNames" . }}
 {{- include "pg.validateAudit" . }}
+{{- include "pg.validateExtraPassthrough" . }}
 {{- if and (not .Values.repmgr.enabled) (gt (int .Values.postgresql.replicaCount) 0) }}
 {{- fail "postgresql.replicaCount > 0 requires repmgr.enabled=true: with repmgr disabled the chart would run replicaCount+1 independent PostgreSQL instances with no replication between them. Set postgresql.replicaCount=0 for standalone mode or enable repmgr" }}
 {{- end }}

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -514,6 +514,9 @@ spec:
                   key: {{ .Values.pgbackrest.existingSecret.secretAccessKeyKey }}
 {{- end }}
 {{- end }}
+{{- with .Values.postgresql.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+{{- end }}
 {{- if not .Values.repmgr.enabled }}
           lifecycle:
             postStart:
@@ -849,6 +852,9 @@ spec:
               mountPath: /etc/etcd-tls
               readOnly: true
 {{- end }}
+{{- with .Values.postgresql.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+{{- end }}
 {{- if eq (include "pg.repmgrdMode" .) "true" }}
         - name: repmgrd
           image: "{{ include "pg.repmgrImage" . }}"
@@ -1082,7 +1088,7 @@ spec:
           resources:
             {{- toYaml .Values.pgbackrest.resources | nindent 12 }}
 {{- end }}
-{{- if or .Values.postgresql.configuration .Values.postgresql.extensions.enabled .Values.repmgr.enabled .Values.pgbackrest.enabled .Values.postgresql.tls.enabled (not .Values.postgresql.persistence.enabled) }}
+{{- if or .Values.postgresql.configuration .Values.postgresql.extensions.enabled .Values.repmgr.enabled .Values.pgbackrest.enabled .Values.postgresql.tls.enabled .Values.postgresql.extraVolumes (not .Values.postgresql.persistence.enabled) }}
       volumes:
 {{- if or .Values.postgresql.configuration .Values.pgbackrest.enabled .Values.postgresql.tls.enabled .Values.postgresql.audit.enabled }}
         - name: postgresql-config
@@ -1130,6 +1136,9 @@ spec:
         - name: pgbackrest-config
           configMap:
             name: {{ include "pg.fullname" . }}-pgbackrest
+{{- end }}
+{{- with .Values.postgresql.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
 {{- end }}
 {{- if not .Values.postgresql.persistence.enabled }}
         - name: data

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -2888,5 +2888,87 @@ casc_repmgrd=$(helm template test-pg "${CHART_DIR}" \
   --show-only templates/statefulset.yaml 2>&1)
 assert_not_contains "#29: repmgrd mode never gets CASCADE_REPLICATION (agent-only)" "${casc_repmgrd}" "CASCADE_REPLICATION"
 
+# ======================================================================
+# #262: postgresql.extraVolumes / extraVolumeMounts / extraEnv passthrough,
+# its render-time guards, and the repmgr shared_preload_libraries merge that
+# the review surfaced (previously audit-gated -> silently dropped repmgr).
+# ======================================================================
+xv_args=(--set-json 'postgresql.extraVolumes=[{"name":"pgsodium-key","secret":{"secretName":"pgsodium-root-key","defaultMode":256}}]'
+         --set-json 'postgresql.extraVolumeMounts=[{"name":"pgsodium-key","mountPath":"/etc/postgresql/pgsodium","readOnly":true}]'
+         --set-json 'postgresql.extraEnv=[{"name":"SOME_FLAG","value":"1"},{"name":"KEY_REF","valueFrom":{"secretKeyRef":{"name":"s","key":"k"}}}]')
+
+# Agent mode (the HA path the pgsodium failover case depends on)
+xv_agent=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  "${xv_args[@]}" --show-only templates/statefulset.yaml 2>&1)
+assert_contains "#262 agent: extra volume renders on the pod" "${xv_agent}" "secretName: pgsodium-root-key"
+assert_contains "#262 agent: extra mount renders on the container" "${xv_agent}" "mountPath: /etc/postgresql/pgsodium"
+assert_contains "#262 agent: extraEnv value form renders" "${xv_agent}" 'name: SOME_FLAG'
+assert_contains "#262 agent: extraEnv valueFrom form renders" "${xv_agent}" 'secretKeyRef:'
+
+# Default render must be byte-stable: nothing extra when the values are unset
+xv_default=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-agent.yaml" \
+  --show-only templates/statefulset.yaml 2>&1)
+assert_not_contains "#262 off: no extra volume by default" "${xv_default}" "pgsodium-key"
+
+# extraVolumes alone must open the volumes block with persistence ON (the new gate
+# clause): with repmgr/tls/pgbackrest/extensions/configuration all off and persistence
+# on, no other condition renders a `volumes:` block.
+xv_gate=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-minimal.yaml" \
+  --set postgresql.persistence.enabled=true \
+  --set-json 'postgresql.extraVolumes=[{"name":"pgsodium-key","emptyDir":{}}]' \
+  --show-only templates/statefulset.yaml 2>&1)
+assert_contains "#262 gate: extraVolumes alone opens the volumes block" "${xv_gate}" "pgsodium-key"
+
+# --- guards: each plausible mistake must fail the render, not apply/runtime ---
+guard_fails() { # name, extra helm args...
+  local name="$1"; shift
+  local rc=0
+  helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-minimal.yaml" "$@" >/dev/null 2>&1 || rc=$?
+  assert_eq "${name}" "1" "$([ "${rc}" -ne 0 ] && echo 1 || echo 0)"
+}
+guard_fails "#262 guard: extraEnv as a map fails fast"          --set-json 'postgresql.extraEnv={"FOO":"bar"}'
+guard_fails "#262 guard: extraVolumes as a map fails fast"      --set-json 'postgresql.extraVolumes={"name":"x"}'
+guard_fails "#262 guard: extraVolumes without a name fails"     --set-json 'postgresql.extraVolumes=[{"emptyDir":{}}]'
+guard_fails "#262 guard: extraVolumes colliding with data fails" --set-json 'postgresql.extraVolumes=[{"name":"data","emptyDir":{}}]'
+guard_fails "#262 guard: extraVolumes colliding with repmgr-config fails" --set-json 'postgresql.extraVolumes=[{"name":"repmgr-config","emptyDir":{}}]'
+guard_fails "#262 guard: duplicate extraVolumes name fails"     --set-json 'postgresql.extraVolumes=[{"name":"a","emptyDir":{}},{"name":"a","emptyDir":{}}]'
+guard_fails "#262 guard: dangling extraVolumeMounts fails"      --set-json 'postgresql.extraVolumeMounts=[{"name":"typo","mountPath":"/x"}]'
+guard_fails "#262 guard: extraVolumeMounts without mountPath fails" --set-json 'postgresql.extraVolumes=[{"name":"a","emptyDir":{}}]' --set-json 'postgresql.extraVolumeMounts=[{"name":"a"}]'
+guard_fails "#262 guard: extraEnv reusing PGDATA fails"         --set-json 'postgresql.extraEnv=[{"name":"PGDATA","value":"/x"}]'
+guard_fails "#262 guard: extraEnv reusing POSTGRES_PASSWORD fails" --set-json 'postgresql.extraEnv=[{"name":"POSTGRES_PASSWORD","value":"x"}]'
+guard_fails "#262 guard: extraEnv reusing a disabled-feature name (REPMGR_DB) fails" --set-json 'postgresql.extraEnv=[{"name":"REPMGR_DB","value":"x"}]'
+guard_fails "#262 guard: duplicate extraEnv name fails"         --set-json 'postgresql.extraEnv=[{"name":"A","value":"1"},{"name":"A","value":"2"}]'
+
+# --- shared_preload_libraries: repmgr must survive an operator-set value with audit OFF ---
+spl_repmgr=$(helm template test-pg "${CHART_DIR}" \
+  --set repmgr.enabled=true --set repmgr.image.majorVersion=18 --set postgresql.majorVersion=18 \
+  --set-string postgresql.configuration.shared_preload_libraries=pgsodium \
+  --show-only templates/postgresql-configmap.yaml 2>&1)
+assert_contains "#262 preload: audit off keeps repmgr (merged)" "${spl_repmgr}" "shared_preload_libraries = 'repmgr,pgsodium'"
+assert_not_contains "#262 preload: bare operator value is not left in custom.conf" "${spl_repmgr}" "shared_preload_libraries = 'pgsodium'"
+# audit ON: unchanged behaviour (pgaudit.conf stays authoritative)
+spl_audit=$(helm template test-pg "${CHART_DIR}" \
+  --set repmgr.enabled=true --set repmgr.image.majorVersion=18 --set postgresql.majorVersion=18 \
+  --set postgresql.audit.enabled=true \
+  --set-string postgresql.configuration.shared_preload_libraries=pgsodium \
+  --show-only templates/postgresql-configmap.yaml 2>&1)
+assert_contains "#262 preload: audit on merges repmgr + operator + pgaudit" "${spl_audit}" "shared_preload_libraries = 'repmgr,pgsodium,pgaudit'"
+# standalone: nothing to preserve, operator value passes through untouched
+spl_standalone=$(helm template test-pg "${CHART_DIR}" \
+  --set repmgr.enabled=false --set postgresql.replicaCount=0 \
+  --set-string postgresql.configuration.shared_preload_libraries=pgsodium \
+  --show-only templates/postgresql-configmap.yaml 2>&1)
+assert_contains "#262 preload: standalone passes the value through" "${spl_standalone}" "shared_preload_libraries = 'pgsodium'"
+assert_not_contains "#262 preload: standalone adds no repmgr" "${spl_standalone}" "repmgr,pgsodium"
+
+# --- pgvector parity (symlinked templates + its own values defaults) ---
+pgv_xv=$(helm template test-pgv "${PGVECTOR_DIR}" "${xv_args[@]}" \
+  --show-only templates/statefulset.yaml 2>&1)
+assert_contains "#262 pgvector: extra volume renders" "${pgv_xv}" "secretName: pgsodium-root-key"
+assert_contains "#262 pgvector: extra mount renders" "${pgv_xv}" "mountPath: /etc/postgresql/pgsodium"
+pgv_guard_rc=0
+helm template test-pgv "${PGVECTOR_DIR}" --set-json 'postgresql.extraEnv=[{"name":"PGDATA","value":"/x"}]' >/dev/null 2>&1 || pgv_guard_rc=$?
+assert_eq "#262 pgvector: guards apply too" "1" "$([ "${pgv_guard_rc}" -ne 0 ] && echo 1 || echo 0)"
+
 end_suite
 print_summary

--- a/pg/tests/unit/audit_test.yaml
+++ b/pg/tests/unit/audit_test.yaml
@@ -197,3 +197,103 @@ tests:
     asserts:
       - exists:
           path: spec.template.metadata.annotations["checksum/postgresql-config"]
+
+  # --- #262 review: the repmgr merge must NOT be audit-gated ---
+  # custom.conf is loaded via conf.d's include_dir AFTER the repmgr image's own
+  # postgresql.conf, so a bare operator value there overrides
+  # `shared_preload_libraries = 'repmgr'` and starts the postmaster without the repmgr
+  # library -- failover silently stops working. Previously the preserving merge ran only
+  # on the audit path.
+  - it: audit OFF - operator shared_preload_libraries keeps repmgr in an authoritative file
+    template: templates/postgresql-configmap.yaml
+    set:
+      postgresql.audit.enabled: false
+      postgresql.configuration:
+        shared_preload_libraries: pgsodium
+    asserts:
+      - equal:
+          path: data["repmgr-preload.conf"]
+          value: |
+            shared_preload_libraries = 'repmgr,pgsodium'
+      # custom.conf is omitted entirely -- the preload key was its only entry, and an
+      # empty conf.d file would be pointless
+      - notExists:
+          path: data["custom.conf"]
+      # audit off must not smuggle pgaudit into the preload list
+      - notExists:
+          path: data["pgaudit.conf"]
+
+  - it: audit OFF - other configuration keys still render in custom.conf alongside the merge
+    template: templates/postgresql-configmap.yaml
+    set:
+      postgresql.audit.enabled: false
+      postgresql.configuration:
+        shared_preload_libraries: pgsodium
+        work_mem: 32MB
+    asserts:
+      - matchRegex:
+          path: data["repmgr-preload.conf"]
+          pattern: "shared_preload_libraries = 'repmgr,pgsodium'"
+      - matchRegex:
+          path: data["custom.conf"]
+          pattern: "work_mem = '32MB'"
+      # still suppressed in custom.conf -- repmgr-preload.conf owns it
+      - notMatchRegex:
+          path: data["custom.conf"]
+          pattern: shared_preload_libraries
+
+  - it: audit OFF - non-canonically-cased key is merged and suppressed
+    template: templates/postgresql-configmap.yaml
+    set:
+      postgresql.audit.enabled: false
+      postgresql.configuration:
+        Shared_Preload_Libraries: pgsodium
+        work_mem: 32MB
+    asserts:
+      - matchRegex:
+          path: data["repmgr-preload.conf"]
+          pattern: "shared_preload_libraries = 'repmgr,pgsodium'"
+      - notMatchRegex:
+          path: data["custom.conf"]
+          pattern: (?i)shared_preload_libraries
+
+  - it: audit OFF - an explicit repmgr in the operator list is not duplicated
+    template: templates/postgresql-configmap.yaml
+    set:
+      postgresql.audit.enabled: false
+      postgresql.configuration:
+        shared_preload_libraries: "pgsodium, repmgr"
+    asserts:
+      - equal:
+          path: data["repmgr-preload.conf"]
+          value: |
+            shared_preload_libraries = 'pgsodium,repmgr'
+
+  - it: repmgr mode without an operator preload renders no authoritative preload file
+    template: templates/postgresql-configmap.yaml
+    set:
+      postgresql.audit.enabled: false
+      postgresql.configuration:
+        work_mem: 32MB
+    asserts:
+      - notExists:
+          path: data["repmgr-preload.conf"]
+      - matchRegex:
+          path: data["custom.conf"]
+          pattern: "work_mem = '32MB'"
+
+  # Standalone has no repmgr library to preserve, so the operator's value passes through.
+  - it: standalone - operator shared_preload_libraries passes through custom.conf untouched
+    template: templates/postgresql-configmap.yaml
+    set:
+      repmgr.enabled: false
+      postgresql.replicaCount: 0
+      postgresql.audit.enabled: false
+      postgresql.configuration:
+        shared_preload_libraries: pgsodium
+    asserts:
+      - matchRegex:
+          path: data["custom.conf"]
+          pattern: "shared_preload_libraries = 'pgsodium'"
+      - notExists:
+          path: data["repmgr-preload.conf"]

--- a/pg/tests/unit/guards_test.yaml
+++ b/pg/tests/unit/guards_test.yaml
@@ -65,3 +65,151 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "pgbackrest.existingSecret.name is required (pgbackrest.s3.keyType=shared); use keyType=auto for cloud workload identity"
+
+  # --- Scenario 13: extra passthrough validation (#262) ---
+  - it: extraEnv as a map (not a list) fails render with a shape message
+    templates:
+      - templates/statefulset.yaml
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.extraEnv:
+        FOO: bar
+    asserts:
+      - failedTemplate:
+          errorMessage: "postgresql.extraEnv must be a list of objects, got map. Use a YAML sequence of entries, each with a name (e.g. `postgresql.extraEnv: [{name: my-entry, ...}]`), not a map."
+
+  - it: extraVolumes as a map (not a list) fails render
+    templates:
+      - templates/statefulset.yaml
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.extraVolumes:
+        name: pgsodium-key
+    asserts:
+      - failedTemplate: {}
+
+  - it: extraVolumes entry without a name fails render
+    templates:
+      - templates/statefulset.yaml
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.extraVolumes:
+        - emptyDir: {}
+    asserts:
+      - failedTemplate:
+          errorMessage: "postgresql.extraVolumes[0]: name is required"
+
+  - it: extraVolumes colliding with the chart data volume fails render
+    templates:
+      - templates/statefulset.yaml
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.extraVolumes:
+        - name: data
+          emptyDir: {}
+    asserts:
+      - failedTemplate:
+          errorMessage: 'postgresql.extraVolumes[0]: "data" is a chart-managed volume name and may not be reused (reserved: data, postgresql-config, postgresql-tls, ext-lib, ext-share, repmgr-config, etcd-tls, pg-run, pgbackrest-config, service-updater-script). With persistence enabled a "data" volume is silently discarded in favour of the volumeClaimTemplate; with persistence disabled the duplicate name is rejected by the API server. Pick a distinct name.'
+
+  - it: extraVolumes colliding with an internal volume (repmgr-config) fails render
+    templates:
+      - templates/statefulset.yaml
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.extraVolumes:
+        - name: repmgr-config
+          emptyDir: {}
+    asserts:
+      - failedTemplate: {}
+
+  - it: duplicate extraVolumes names fail render
+    templates:
+      - templates/statefulset.yaml
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.extraVolumes:
+        - name: dup
+          emptyDir: {}
+        - name: dup
+          emptyDir: {}
+    asserts:
+      - failedTemplate:
+          errorMessage: 'postgresql.extraVolumes[1]: duplicate volume name "dup"'
+
+  # The sibling-key typo the schema cannot catch (additionalProperties is open):
+  # a mount with no matching volume renders cleanly and is rejected only at apply.
+  - it: extraVolumeMounts with no matching extraVolumes entry fails render
+    templates:
+      - templates/statefulset.yaml
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.extraVolumeMounts:
+        - name: pgsodium-key
+          mountPath: /etc/postgresql/pgsodium
+    asserts:
+      - failedTemplate:
+          errorMessage: 'postgresql.extraVolumeMounts[0]: no postgresql.extraVolumes entry named "pgsodium-key" (declared: none). Every extra mount needs a matching extra volume -- otherwise the API server rejects the StatefulSet at apply time with `volumeMounts[..].name: Not found`. Check for a typo, or that you set extraVolumes (plural). Chart-managed volumes cannot be mounted here.'
+
+  - it: extraVolumeMounts without mountPath fails render
+    templates:
+      - templates/statefulset.yaml
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.extraVolumes:
+        - name: k
+          emptyDir: {}
+      postgresql.extraVolumeMounts:
+        - name: k
+    asserts:
+      - failedTemplate:
+          errorMessage: "postgresql.extraVolumeMounts[0] (k): mountPath is required"
+
+  - it: extraEnv reusing a chart-set env name (PGDATA) fails render
+    templates:
+      - templates/statefulset.yaml
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.extraEnv:
+        - name: PGDATA
+          value: /wrong
+    asserts:
+      - failedTemplate:
+          errorMessage: 'postgresql.extraEnv[0]: "PGDATA" is set by the chart on the postgresql container and may not be overridden -- a duplicate env name is last-wins at runtime, so this would silently shadow the chart/Secret value (e.g. pointing the postmaster at the wrong PGDATA, or breaking cluster-wide auth). Use the chart''s own value for this setting instead.'
+
+  # Reserved unconditionally: repmgr is disabled in values-minimal, but a value that
+  # works today must not start shadowing the chart once an upgrade enables repmgr.
+  - it: extraEnv reusing a disabled-feature env name (REPMGR_PASSWORD) still fails
+    templates:
+      - templates/statefulset.yaml
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.extraEnv:
+        - name: REPMGR_PASSWORD
+          value: x
+    asserts:
+      - failedTemplate: {}
+
+  - it: duplicate extraEnv names fail render
+    templates:
+      - templates/statefulset.yaml
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.extraEnv:
+        - name: A
+          value: "1"
+        - name: A
+          value: "2"
+    asserts:
+      - failedTemplate:
+          errorMessage: 'postgresql.extraEnv[1]: duplicate env name "A"'

--- a/pg/tests/unit/render_test.yaml
+++ b/pg/tests/unit/render_test.yaml
@@ -123,3 +123,44 @@ tests:
       - equal:
           path: spec.ports[0].targetPort
           value: postgresql
+
+  # --- Scenario 9: extraVolumes/extraVolumeMounts/extraEnv passthrough (#262) ---
+  - it: extra passthrough renders volume, mount on postgresql container, and env
+    values:
+      - ../values-minimal.yaml
+    set:
+      postgresql.extraVolumes:
+        - name: pgsodium-key
+          secret:
+            secretName: pgsodium-root-key
+            defaultMode: 0400
+      postgresql.extraVolumeMounts:
+        - name: pgsodium-key
+          mountPath: /etc/postgresql/pgsodium
+          readOnly: true
+      postgresql.extraEnv:
+        - name: SOME_FLAG
+          value: "1"
+    template: templates/statefulset.yaml
+    asserts:
+      # Pod-level volume present (block renders even with persistence off + repmgr off)
+      - equal:
+          path: spec.template.spec.volumes[?(@.name=="pgsodium-key")].secret.secretName
+          value: pgsodium-root-key
+      # Mounted on the postgresql container
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="postgresql")].volumeMounts[?(@.name=="pgsodium-key")].mountPath
+          value: /etc/postgresql/pgsodium
+      # Env injected onto the postgresql container
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="postgresql")].env[?(@.name=="SOME_FLAG")].value
+          value: "1"
+
+  - it: no extra passthrough renders nothing extra by default (minimal has no volumes block)
+    values:
+      - ../values-minimal.yaml
+    template: templates/statefulset.yaml
+    asserts:
+      # minimal (persistence off) still renders the ephemeral data volume, but no stray extras
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name=="pgsodium-key")]

--- a/pg/tests/unit/render_test.yaml
+++ b/pg/tests/unit/render_test.yaml
@@ -125,10 +125,16 @@ tests:
           value: postgresql
 
   # --- Scenario 9: extraVolumes/extraVolumeMounts/extraEnv passthrough (#262) ---
+  # persistence.enabled=true ON PURPOSE: values-minimal disables persistence, and
+  # `(not persistence.enabled)` already renders a `volumes:` block on its own. With
+  # persistence ON (and repmgr/tls/pgbackrest/extensions/configuration all off in
+  # minimal), extraVolumes is the ONLY reason the block renders -- so this actually
+  # exercises the new render gate instead of passing tautologically.
   - it: extra passthrough renders volume, mount on postgresql container, and env
     values:
       - ../values-minimal.yaml
     set:
+      postgresql.persistence.enabled: true
       postgresql.extraVolumes:
         - name: pgsodium-key
           secret:
@@ -141,26 +147,51 @@ tests:
       postgresql.extraEnv:
         - name: SOME_FLAG
           value: "1"
+        - name: PGSODIUM_KEY_REF
+          valueFrom:
+            secretKeyRef:
+              name: pgsodium-root-key
+              key: pgsodium.key
     template: templates/statefulset.yaml
     asserts:
-      # Pod-level volume present (block renders even with persistence off + repmgr off)
+      # extraVolumes alone opens the volumes block (persistence on, no other volume feature)
       - equal:
           path: spec.template.spec.volumes[?(@.name=="pgsodium-key")].secret.secretName
           value: pgsodium-root-key
+      - equal:
+          path: spec.template.spec.volumes[?(@.name=="pgsodium-key")].secret.defaultMode
+          value: 256 # 0400 octal
+      # The ephemeral data volume must NOT be there -- persistence is on (PVC template)
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name=="data")]
       # Mounted on the postgresql container
       - equal:
           path: spec.template.spec.containers[?(@.name=="postgresql")].volumeMounts[?(@.name=="pgsodium-key")].mountPath
           value: /etc/postgresql/pgsodium
-      # Env injected onto the postgresql container
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="postgresql")].volumeMounts[?(@.name=="pgsodium-key")].readOnly
+          value: true
+      # Env injected onto the postgresql container -- both value and valueFrom forms
       - equal:
           path: spec.template.spec.containers[?(@.name=="postgresql")].env[?(@.name=="SOME_FLAG")].value
           value: "1"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="postgresql")].env[?(@.name=="PGSODIUM_KEY_REF")].valueFrom.secretKeyRef.name
+          value: pgsodium-root-key
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="postgresql")].env[?(@.name=="PGSODIUM_KEY_REF")].valueFrom.secretKeyRef.key
+          value: pgsodium.key
 
-  - it: no extra passthrough renders nothing extra by default (minimal has no volumes block)
+  - it: no extra volumes, mounts or env by default
     values:
       - ../values-minimal.yaml
     template: templates/statefulset.yaml
     asserts:
-      # minimal (persistence off) still renders the ephemeral data volume, but no stray extras
+      # minimal (persistence off) still renders the ephemeral `data` volume, so assert
+      # on the absence of the extras specifically, not on the volumes block as a whole.
       - notExists:
           path: spec.template.spec.volumes[?(@.name=="pgsodium-key")]
+      - notExists:
+          path: spec.template.spec.containers[?(@.name=="postgresql")].volumeMounts[?(@.name=="pgsodium-key")]
+      - notExists:
+          path: spec.template.spec.containers[?(@.name=="postgresql")].env[?(@.name=="SOME_FLAG")]

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -154,9 +154,26 @@ postgresql:
   # passthrough for mounting an operator-supplied file that must be byte-identical on
   # every replica -- e.g. the pgsodium server root key (Supabase Vault) read via
   # pgsodium.getkey_script, which a promoted standby needs to decrypt supabase_vault
-  # after failover. Mount a Secret/ConfigMap here and reference it from
-  # postgresql.configuration; the same volume lands on the primary and every standby.
-  # extraVolumes are pod-level; extraVolumeMounts land on the postgresql container.
+  # after failover. The same volume lands on the primary and every standby, and
+  # survives failover and a pg_rewind rejoin.
+  #
+  # extraVolumes are pod-level; extraVolumeMounts and extraEnv land on the postgresql
+  # container. Validated at render time (see pg.validateExtraPassthrough): each must be
+  # a LIST of objects, extraVolumes names may not collide with a chart-managed volume
+  # (data, postgresql-config, postgresql-tls, ext-lib, ext-share, repmgr-config,
+  # etcd-tls, pg-run, pgbackrest-config, service-updater-script), every
+  # extraVolumeMounts entry must reference a declared extraVolumes entry, and extraEnv
+  # may not reuse a chart-set env name (PGDATA, POSTGRES_*, REPMGR_*, ...) -- each of
+  # those is a silent-shadowing or apply-time failure, so the chart fails the render.
+  #
+  # To actually load an extension from a mounted key, pair this with
+  # postgresql.configuration, e.g. for pgsodium:
+  #   postgresql.configuration:
+  #     shared_preload_libraries: pgsodium
+  #     pgsodium.getkey_script: /etc/postgresql/pgsodium/getkey.sh
+  # In repmgr mode the chart merges `repmgr` into shared_preload_libraries for you (a
+  # bare value there would otherwise override the image's preload and silently disable
+  # failover), so declare only your own libraries.
   extraVolumes: []
     # - name: pgsodium-key
     #   secret:

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -150,6 +150,30 @@ postgresql:
     # - "host all all 10.0.0.0/8 md5"
     # - "host replication repmgr 10.0.0.0/8 trust"
 
+  # Extra volumes/mounts/env for the postgresql container (#262). Generic pod-spec
+  # passthrough for mounting an operator-supplied file that must be byte-identical on
+  # every replica -- e.g. the pgsodium server root key (Supabase Vault) read via
+  # pgsodium.getkey_script, which a promoted standby needs to decrypt supabase_vault
+  # after failover. Mount a Secret/ConfigMap here and reference it from
+  # postgresql.configuration; the same volume lands on the primary and every standby.
+  # extraVolumes are pod-level; extraVolumeMounts land on the postgresql container.
+  extraVolumes: []
+    # - name: pgsodium-key
+    #   secret:
+    #     secretName: pgsodium-root-key
+    #     defaultMode: 0400
+    #     items:
+    #       - key: pgsodium.key
+    #         path: pgsodium.key
+  extraVolumeMounts: []
+    # - name: pgsodium-key
+    #   mountPath: /etc/postgresql/pgsodium
+    #   readOnly: true
+  # Extra env vars for the postgresql container (supports value and valueFrom).
+  extraEnv: []
+    # - name: SOME_FLAG
+    #   value: "1"
+
   # Client-connection TLS (#110). Off by default (no change to rendered manifests unless
   # enabled). When enabled, PostgreSQL serves ssl=on from the cert Secret (BYO, like the
   # etcd TLS block).

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,28 @@
 # pgvector chart changelog
 
+## 1.6.0 - 2026-07-30
+
+Inherited from pg's symlinked templates (`statefulset.yaml`, `postgresql-configmap.yaml`,
+`_helpers.tpl`). See the [pg 1.6.0 changelog](../pg/CHANGELOG.md) for the full detail.
+
+### Added
+
+- **`postgresql.extraVolumes` / `postgresql.extraVolumeMounts` / `postgresql.extraEnv`**
+  (#262) — generic pod-spec passthrough for the postgresql container, for mounting a file
+  that must be byte-identical on the primary and every standby (e.g. the pgsodium server
+  root key behind Supabase Vault, which a promoted standby needs to decrypt
+  `supabase_vault` after a failover). All default to `[]`, so rendered output is unchanged
+  when unset, and all three are validated at render time (list shape, no chart-managed
+  volume-name collision, every mount must reference a declared volume, no reuse of a
+  chart-set env name).
+
+### Fixed
+
+- **An operator-set `postgresql.configuration.shared_preload_libraries` silently dropped
+  `repmgr` whenever `postgresql.audit.enabled` was false**, disabling failover. The merge
+  preserving `repmgr` now runs unconditionally in repmgr mode. This matters more here than
+  in pg: pgvector operators commonly set `shared_preload_libraries` to load extensions.
+
 ## 1.5.0 - 2026-07-12
 
 Inherited from pg's symlinked templates. Requires the new repmgr image

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus repmgr replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 1.5.0
+version: 1.6.0
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -177,6 +177,9 @@ Runtime configuration can be injected without rebuilding images. Settings are wr
 |-----------|-------------|---------|
 | `postgresql.configuration` | Map of postgresql.conf parameters | `{}` |
 | `postgresql.pgHba` | List of pg_hba.conf entries injected via postStart | `[]` |
+| `postgresql.extraVolumes` | Extra pod-level volumes — mount a file identically on every replica (e.g. a pgsodium key); see the [pg chart README](../pg/README.md#mounting-an-extra-file-on-every-replica) | `[]` |
+| `postgresql.extraVolumeMounts` | Extra mounts for the postgresql container; each must reference a `postgresql.extraVolumes` entry | `[]` |
+| `postgresql.extraEnv` | Extra env vars for the postgresql container (supports `value` and `valueFrom`); may not reuse a chart-set name | `[]` |
 | `postgresql.extensions.enabled` | Enable extensions support | `true` |
 | `postgresql.audit.enabled` | Enable pgaudit audit logging (requires repmgr mode; see [Audit logging](#audit-logging-pgaudit)) | `false` |
 | `postgresql.audit.log` | pgaudit session classes: `read,write,function,role,ddl,misc,misc_set,all` (negate with `-`) | `"ddl, role, write"` |

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -149,6 +149,32 @@ postgresql:
     # - "host all all 10.0.0.0/8 md5"
     # - "host replication repmgr 10.0.0.0/8 trust"
 
+  # Extra volumes/mounts/env for the postgresql container (#262). Generic pod-spec
+  # passthrough for mounting an operator-supplied file that must be byte-identical on
+  # every replica -- e.g. the pgsodium server root key (Supabase Vault) read via
+  # pgsodium.getkey_script, which a promoted standby needs to decrypt supabase_vault
+  # after failover. The same volume lands on the primary and every standby, and survives
+  # failover and a pg_rewind rejoin.
+  #
+  # extraVolumes are pod-level; extraVolumeMounts and extraEnv land on the postgresql
+  # container. All three are validated at render time (list shape, no collision with a
+  # chart-managed volume name, every mount must reference a declared extraVolumes entry,
+  # no reuse of a chart-set env name). See the pg chart README, "Mounting an extra file
+  # on every replica", for the full notes and the pgsodium example.
+  extraVolumes: []
+    # - name: pgsodium-key
+    #   secret:
+    #     secretName: pgsodium-root-key
+    #     defaultMode: 0400
+  extraVolumeMounts: []
+    # - name: pgsodium-key
+    #   mountPath: /etc/postgresql/pgsodium
+    #   readOnly: true
+  # Extra env vars for the postgresql container (supports value and valueFrom).
+  extraEnv: []
+    # - name: SOME_FLAG
+    #   value: "1"
+
   # Client-connection TLS (#110). Off by default (no change to rendered manifests unless
   # enabled). See the pg chart README for the full TLS notes (cert SANs, require/mTLS,
   # internal-user exemptions, replication-stays-plaintext).


### PR DESCRIPTION
Closes #262.

Adds generic pod-spec passthrough for the postgresql container:

- `postgresql.extraVolumes` — rendered into the pod template
- `postgresql.extraVolumeMounts` — rendered onto the postgresql container
- `postgresql.extraEnv` — extra env (`value` / `valueFrom`) on the postgresql container

All default to `[]`; with them unset the rendered output is unchanged (only the chart version label moves).

### Why
Lets an operator mount an arbitrary `Secret`/`ConfigMap` as a file that is byte-identical on the primary and every standby without a per-use-case chart change. Motivating case: the **pgsodium** server root key (Supabase Vault) loaded via `pgsodium.getkey_script` must be identical across replicas so a promoted standby can still decrypt `supabase_vault` after a failover.

### Render-time validation
The values are spliced into the pod spec, so each plausible mistake is guarded (`pg.validateExtraPassthrough`) rather than left to fail silently at runtime or at apply:

| Mistake | Without a guard |
|---|---|
| map instead of list | opaque `did not find expected '-' indicator` YAML error |
| `extraVolumes` name `data` | silently discarded for the volumeClaimTemplate → mount resolves into the PVC, file absent, CrashLoopBackOff with nothing to point at (persistence off: API server rejects the duplicate name) |
| mount with no matching volume (e.g. `extraVolume:` typo — schema is open) | renders clean, rejected only at apply, leaving a live release failed |
| `extraEnv: PGDATA` / `POSTGRES_PASSWORD` | duplicate env is last-wins → wrong data directory, or cluster-wide auth break |

Chart-set env names are reserved *unconditionally* (including ones only a disabled feature emits) so a value that works today can't start shadowing the chart after an upgrade enables that feature.

### Also fixed: `shared_preload_libraries` dropped `repmgr` (HA-breaking)
Surfaced while reviewing this PR, since the pgsodium case needs exactly that setting. An operator-set `postgresql.configuration.shared_preload_libraries` **silently dropped `repmgr` whenever `postgresql.audit.enabled` was false** — the preserving merge only ran on the audit path, while `custom.conf` loads via `include_dir` *after* the image's `postgresql.conf` and so overrode `shared_preload_libraries = 'repmgr'`. The postmaster then started without the repmgr library and no standby was ever promoted.

The merge is now unconditional in repmgr mode, emitted from an authoritative `repmgr-preload.conf` that sorts after `custom.conf`. Audit-on behaviour is unchanged; standalone (nothing to preserve) still passes the operator's value through untouched.

### pgvector
`pgvector/templates/{statefulset,postgresql-configmap,_helpers}` are symlinks to pg's, so pgvector already renders both changes. Brought to parity per repo convention: version bump to 1.6.0, values defaults, CHANGELOG, README rows.

### Tests
- `guards_test.yaml`: 11 new cases, one per guard (exact error messages asserted)
- `audit_test.yaml`: 6 new cases covering the preload merge across audit-off / audit-on / standalone / no-operator-value / already-lists-repmgr
- `render_test.yaml`: volume + mount + env (both `value` and `valueFrom`) render; nothing extra by default. The positive test sets `persistence.enabled=true` on purpose so `extraVolumes` is genuinely the reason the `volumes:` block renders
- `test-template.sh`: +26 assertions incl. agent mode and pgvector parity
- Mutation-checked: reverting the gate clause or re-gating the preload merge makes the suites fail, so none of it passes vacuously
- **pg 74/74 unit, pgvector 34/34 unit, 886/886 render** 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `postgresql.extraVolumes`, `postgresql.extraVolumeMounts`, and `postgresql.extraEnv` to mount and inject Secret/ConfigMap-based content into PostgreSQL pods across replicas.
  * Added fail-fast validation to catch invalid shapes, name collisions, and mismatched volume/mount definitions during Helm rendering.
* **Bug Fixes**
  * Fixed `repmgr` failover-related `shared_preload_libraries` behavior when audit is disabled.
* **Documentation**
  * Updated README and changelogs with usage examples and validation rules.
* **Tests**
  * Extended render/guard tests to cover new passthrough values and the preload merge fix.
* **Chores**
  * Bumped chart versions to **1.6.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->