### PR TITLE
feat(pg,pgvector): first-class pgBackRest PITR restore Job (#226)

### DIFF
--- a/.github/workflows/pg-test.yaml
+++ b/.github/workflows/pg-test.yaml
@@ -182,6 +182,7 @@ jobs:
           - { name: backup-restore, target: test-backup-restore }
           - { name: backup-concurrent, target: test-backup-concurrent }
           - { name: pgbackrest-restore, target: test-pgbackrest-restore }
+          - { name: pgbackrest-restore-ha, target: test-pgbackrest-restore-ha }
           - { name: databases-roles, target: test-databases-roles }
           - { name: migrate-agent, target: test-migrate-agent }
           - { name: scaledown, target: test-scaledown }

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -15,6 +15,7 @@
   kubectl scale statefulset my-postgres-pg --replicas=0
   kubectl wait --for=delete pod/my-postgres-pg-0 --timeout=5m
   kubectl create job --from=cronjob/my-postgres-pg-pgbackrest-restore restore-now
+  kubectl wait --for=condition=complete job/restore-now --timeout=30m
   kubectl scale statefulset my-postgres-pg --replicas=2
   ```
 

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,61 @@
 # pg chart changelog
 
+## 1.7.0 - 2026-07-31
+
+### Added
+
+- **`pgbackrest.restore.*` — a first-class PITR restore resource** (#226). The manual
+  restore runbook made the operator hand-build an entire pod spec via `kubectl run
+  --overrides='{…}'`: ~30 lines of inline JSON reconstructing the ServiceAccount, security
+  contexts, the data PVC mount, the pgbackrest ConfigMap mount and the S3 credential env —
+  all of which the chart already knows how to render. Set `pgbackrest.restore.enabled=true`
+  and it ships that spec for you, and the runbook becomes four ordinary commands:
+
+  ```bash
+  kubectl scale statefulset my-postgres-pg --replicas=0
+  kubectl wait --for=delete pod/my-postgres-pg-0 --timeout=5m
+  kubectl create job --from=cronjob/my-postgres-pg-pgbackrest-restore restore-now
+  kubectl scale statefulset my-postgres-pg --replicas=2
+  ```
+
+  The resource carries the `-repmgr` ServiceAccount (so `s3.keyType: auto` works) with its
+  API token unmounted, the postgresql pod/container security contexts, the
+  `data-<fullname>-0` PVC and `<fullname>-pgbackrest` ConfigMap mounts, the S3 and
+  repo-encryption credentials, and runs `pgbackrest restore --delta`. It reuses the #38
+  validation plumbing, but needs no `pg1-path` override: the mounted `pgbackrest.conf`
+  already points at the live PGDATA.
+
+  Notable properties:
+  - **Enabling it restores nothing.** It renders an *inert* resource — by default a
+    suspended CronJob carrying a schedule that can never fire — so it can be left enabled
+    and cloned when disaster strikes, without a `helm upgrade` mid-incident. The
+    destructive scale down/up stays an explicit operator action.
+  - **Two delivery modes** (`restore.mode`): `cronjob` (default) for
+    `kubectl create job --from`, where the resource belongs to the release and a GitOps
+    controller sees no stray object; or `job`, a bare Job to render on demand with
+    `helm template -s … | kubectl apply -f -` when the point-in-time target must be passed
+    inline (`restore.nameSuffix` gives a retry a fresh name, since Jobs are immutable).
+  - **It never starts PostgreSQL.** WAL replay and promotion happen when the StatefulSet is
+    scaled back up, under the normal chart entrypoint.
+  - **No Kubernetes API access is needed to be safe.** pgbackrest itself refuses to restore
+    while `$PGDATA/postmaster.pid` exists, so "did you actually scale down?" is enforced
+    without an RBAC-carrying token. `restore.force` covers the one legitimate exception, a
+    stale pid file left by a crash.
+  - PITR target wiring (`restore.targetType`/`target`, the same enum as `validation`, with
+    a template `fail` for the "target required once targetType is set" rule), plus
+    `restore.backupSet` (`pgbackrest --set`) to pin a specific backup set, and fail-fast
+    guards for the two prerequisites (`pgbackrest.enabled`, `postgresql.persistence.enabled`).
+
+  Covered by template tests and by an end-to-end phase in
+  `make -C pg test-pgbackrest-restore`, which destroys the data directory outright and then
+  recovers it from S3 through the documented runbook.
+
+### Changed
+
+- The README's Point-in-Time Recovery runbook is now the four-command flow above; the
+  `kubectl run --overrides` pod spec is gone, and the duplicate (and misleading — it had no
+  pod to run `pgbackrest` in) PITR recipe in the troubleshooting section now points at it.
+
 ## 1.6.0 - 2026-07-30
 
 ### Added

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -46,9 +46,15 @@
     `restore.backupSet` (`pgbackrest --set`) to pin a specific backup set, and fail-fast
     guards for the two prerequisites (`pgbackrest.enabled`, `postgresql.persistence.enabled`).
 
-  Covered by template tests and by an end-to-end phase in
-  `make -C pg test-pgbackrest-restore`, which destroys the data directory outright and then
-  recovers it from S3 through the documented runbook.
+  Covered by template tests and by two end-to-end suites, both of which destroy the data
+  directory outright and recover it from S3 through the documented runbook:
+  - `make -C pg test-pgbackrest-restore` — single node, plus the #38 validation phase;
+  - `make -C pg test-pgbackrest-restore-ha` (new) — primary + streaming standby. It restores
+    the primary out from under a live standby and confirms the standby rebuilds itself: the
+    restored primary comes back on a new timeline, the standby's init container detects the
+    mismatch (`Timeline mismatch (local: 1, primary: 2), re-cloning...`), re-clones via
+    `repmgr standby clone`, and resumes streaming — with no PVC deletion and no operator
+    action. The README documents this as verified behaviour rather than an assumption.
 
 ### Changed
 

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with repmgr replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 1.6.0
+version: 1.7.0
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/Makefile
+++ b/pg/Makefile
@@ -4,7 +4,7 @@ TESTS_DIR := tests
 MAKEFLAGS += --output-sync=target
 
 .PHONY: test test-template test-cluster test-minimal test-repmgr test-repmgr-chaos test-full test-failover test-upgrade \
-        test-repmgr-failover test-agent test-agent-etcd test-agent-etcd-tls test-tls test-pgpool-failover test-config-failover test-cascading-replication test-migrate-agent test-scaledown test-agent-rolling test-config test-config-repmgr test-backup-restore test-backup-concurrent test-pgbackrest-restore test-databases-roles test-special-chars byte-stable cluster-create cluster-delete cluster-exists clean help
+        test-repmgr-failover test-agent test-agent-etcd test-agent-etcd-tls test-tls test-pgpool-failover test-config-failover test-cascading-replication test-migrate-agent test-scaledown test-agent-rolling test-config test-config-repmgr test-backup-restore test-backup-concurrent test-pgbackrest-restore test-pgbackrest-restore-ha test-databases-roles test-special-chars byte-stable cluster-create cluster-delete cluster-exists clean help
 
 help:
 	@echo "Targets:"
@@ -29,7 +29,8 @@ help:
 	@echo "  test-config-repmgr - Run postgresql configuration tests (repmgr)"
 	@echo "  test-backup-restore - Run backup and restore integration tests"
 	@echo "  test-backup-concurrent - Run concurrent pgbackrest backup + WAL archiving test"
-	@echo "  test-pgbackrest-restore - Run pgbackrest PITR restore-validation test (#38)"
+	@echo "  test-pgbackrest-restore - Run pgbackrest PITR restore-validation + live restore Job test (#38/#226)"
+	@echo "  test-pgbackrest-restore-ha - Run multi-replica pgbackrest restore + standby re-clone test (#226)"
 	@echo "  test-databases-roles - Run declarative databases/roles/grants test (#218)"
 	@echo "  test-special-chars - Run special-character credential tests"
 	@echo "  cluster-create  - Create Kind cluster"
@@ -153,6 +154,9 @@ test-backup-concurrent: cluster-exists
 
 test-pgbackrest-restore: cluster-exists
 	@bash $(TESTS_DIR)/test-pgbackrest-restore.sh
+
+test-pgbackrest-restore-ha: cluster-exists
+	@bash $(TESTS_DIR)/test-pgbackrest-restore-ha.sh
 
 test-databases-roles: cluster-exists
 	@bash $(TESTS_DIR)/test-databases-roles.sh

--- a/pg/README.md
+++ b/pg/README.md
@@ -1249,9 +1249,16 @@ Two caveats for this mode: the Job is not part of the release, so a GitOps contr
 report or prune it; and Jobs are immutable, so a second attempt needs
 `--set pgbackrest.restore.nameSuffix=attempt2`.
 
-Repmgr rebuilds the standbys from the restored primary when they start. If a standby comes
-up on the pre-restore timeline instead of re-cloning, delete its PVC and pod so it clones
-fresh from the restored primary:
+**Standbys rebuild themselves — no extra step.** A PITR restore leaves the restored primary
+on a *new* timeline, while each standby's PVC still holds pre-restore data on the old one. On
+scale-up the standby's init container detects exactly that (`Timeline mismatch (local: 1,
+primary: 2), re-cloning...`) and re-clones from the restored primary via `repmgr standby
+clone` (`pg_basebackup`), then resumes streaming on the new timeline. No PVC deletion, no
+operator action. This is verified end to end by `make -C pg test-pgbackrest-restore-ha`,
+which restores a primary out from under a live standby and asserts the pair comes back
+streaming.
+
+Only if a standby *does* get stuck on the old timeline, force a fresh clone by hand:
 
 ```bash
 kubectl delete pvc data-my-postgres-pg-1 && kubectl delete pod my-postgres-pg-1

--- a/pg/README.md
+++ b/pg/README.md
@@ -1217,6 +1217,16 @@ kubectl wait --for=condition=complete job/restore-now --timeout=30m
 kubectl scale statefulset my-postgres-pg --replicas=2
 ```
 
+`--for=condition=complete` only ever succeeds, so a **failed** restore leaves that wait
+blocked for the full timeout with no signal. `backoffLimit` is `0` (one pod attempt), so a
+failure shows up immediately in the Job status — if the wait seems stuck, check it rather
+than waiting out the clock, and do not scale up until the Job has actually completed:
+
+```bash
+kubectl get job restore-now -o jsonpath='{.status.failed}{"\n"}'   # 1 = the attempt failed
+kubectl logs job/restore-now                                        # why
+```
+
 With no target set this restores the **latest** backup set and replays all archived WAL —
 the disaster-recovery case. For a *point in time*, set the target first:
 

--- a/pg/README.md
+++ b/pg/README.md
@@ -1213,19 +1213,20 @@ kubectl wait --for=delete pod/my-postgres-pg-0 --timeout=5m
 kubectl create job --from=cronjob/my-postgres-pg-pgbackrest-restore restore-now
 kubectl wait --for=condition=complete job/restore-now --timeout=30m
 
-# 3. Scale back up: the pods replay the archived WAL and promote.
+# 3. CONFIRM the restore succeeded -- must print 1. Do not continue otherwise.
+#    (`--for=condition=complete` above only ever succeeds, so a failed attempt leaves it
+#    blocked until the timeout instead of returning; if it seems stuck, check here.)
+kubectl get job restore-now -o jsonpath='{.status.succeeded}{"\n"}'
+
+# 4. Only now scale back up: the pods replay the archived WAL and promote.
 kubectl scale statefulset my-postgres-pg --replicas=2
 ```
 
-`--for=condition=complete` only ever succeeds, so a **failed** restore leaves that wait
-blocked for the full timeout with no signal. `backoffLimit` is `0` (one pod attempt), so a
-failure shows up immediately in the Job status — if the wait seems stuck, check it rather
-than waiting out the clock, and do not scale up until the Job has actually completed:
-
-```bash
-kubectl get job restore-now -o jsonpath='{.status.failed}{"\n"}'   # 1 = the attempt failed
-kubectl logs job/restore-now                                        # why
-```
+**Do not skip step 3.** A failed restore leaves PGDATA half-written; scaling up onto it
+starts PostgreSQL against an incomplete data directory and turns a recoverable incident into
+data loss. `backoffLimit` is `0` (one pod attempt), so failure is final and immediate —
+diagnose with `kubectl logs job/restore-now`, fix the cause, delete the Job and create it
+again. Rerunning is safe: `--delta` re-restores from scratch.
 
 With no target set this restores the **latest** backup set and replays all archived WAL —
 the disaster-recovery case. For a *point in time*, set the target first:
@@ -1268,10 +1269,15 @@ operator action. This is verified end to end by `make -C pg test-pgbackrest-rest
 which restores a primary out from under a live standby and asserts the pair comes back
 streaming.
 
-Only if a standby *does* get stuck on the old timeline, force a fresh clone by hand:
+Only if a standby *does* get stuck on the old timeline, force a fresh clone by hand. Scale it
+away **before** deleting its PVC: deleting the PVC while its pod still exists leaves it
+`Terminating` behind the `pvc-protection` finalizer, and the recreated pod can re-bind that
+same volume — bringing the standby back on exactly the stale data you meant to discard.
 
 ```bash
-kubectl delete pvc data-my-postgres-pg-1 && kubectl delete pod my-postgres-pg-1
+kubectl scale statefulset my-postgres-pg --replicas=1              # remove the standby pod
+kubectl delete pvc data-my-postgres-pg-1                          # returns once it is really gone
+kubectl scale statefulset my-postgres-pg --replicas=2              # clones fresh from the primary
 ```
 
 If the cluster **crashed** rather than being scaled down cleanly, a stale

--- a/pg/README.md
+++ b/pg/README.md
@@ -1133,6 +1133,18 @@ helm install my-postgres cagriekin/pg \
 | `pgbackrest.validation.activeDeadlineSeconds` | Validation Job timeout | `3600` |
 | `pgbackrest.validation.backoffLimit` | Validation Job backoff limit | `1` |
 | `pgbackrest.validation.resources.*` | Validation Job resource requests/limits | `200m`/`256Mi` … `1`/`1Gi` |
+| `pgbackrest.restore.enabled` | Render the first-class PITR restore resource (#226) — restores over the **live** data PVC. Inert until you clone/apply it | `false` |
+| `pgbackrest.restore.mode` | `cronjob` (suspended CronJob, clone with `kubectl create job --from`) \| `job` (bare Job, render with `helm template -s`) | `cronjob` |
+| `pgbackrest.restore.targetType` | PITR target type (`pgbackrest --type`): `""` (latest) \| `time` \| `xid` \| `name` \| `lsn`. `target` is required when set | `""` |
+| `pgbackrest.restore.target` | PITR target value for the type above (e.g. `2026-03-22 12:00:00+00`); implies `--target-action=promote` | `""` |
+| `pgbackrest.restore.backupSet` | `pgbackrest --set`: restore a specific backup set label from `pgbackrest info` instead of the latest | `""` |
+| `pgbackrest.restore.force` | `pgbackrest --force`: restore despite a **stale** `postmaster.pid` left by a crash. Leave `false` unless every postgresql pod is confirmed gone | `false` |
+| `pgbackrest.restore.podOrdinal` | Ordinal of the replica PVC (`data-<fullname>-<n>`) restored into; leave `0` | `0` |
+| `pgbackrest.restore.nameSuffix` | `mode: job` only — appended to the Job name so a retry does not collide with the completed Job | `""` |
+| `pgbackrest.restore.activeDeadlineSeconds` | Restore Job timeout | `21600` |
+| `pgbackrest.restore.backoffLimit` | Restore Job backoff limit (0 = one attempt; a half-written PGDATA should not be retried automatically) | `0` |
+| `pgbackrest.restore.resources.*` | Restore Job resource requests/limits | `200m`/`256Mi` … `1`/`1Gi` |
+| _scheduling_ | The restore pod inherits `postgresql.nodeSelector` and `postgresql.tolerations` so it lands where the data PVC can attach (`postgresql.affinity` is not inherited) | — |
 
 ### Automated PITR restore-validation (#38)
 
@@ -1177,43 +1189,78 @@ kubectl exec -it my-postgres-pg-0 -- pgbackrest --stanza=db info
 
 ### Point-in-Time Recovery
 
-PITR requires manual intervention:
+Set `pgbackrest.restore.enabled=true` and the chart renders a ready-made restore resource
+(#226) carrying everything a restore needs — the `-repmgr` ServiceAccount (so
+`s3.keyType: auto` works, with its API token unmounted), the postgresql security contexts,
+the `data-<fullname>-0` PVC and `<fullname>-pgbackrest` ConfigMap mounts, the S3 /
+repo-encryption credentials, and `pgbackrest restore --delta`. Nothing to hand-build.
+
+Enabling it is safe: what it renders is **inert** — by default a *suspended* CronJob that
+can never fire. It restores only when you clone it. Leave it enabled so a disaster does not
+also require a `helm upgrade`.
+
+The restore never starts PostgreSQL. Recovery (WAL replay + promotion) happens when you
+scale the StatefulSet back up, under the normal chart entrypoint — so the destructive
+scale down/up stays an explicit, manual decision:
 
 ```bash
-# 1. Scale down the StatefulSet
+# 1. Stop the cluster. pgbackrest refuses to restore while postmaster.pid exists, so this
+#    is not optional -- wait for the pods to actually terminate.
 kubectl scale statefulset my-postgres-pg --replicas=0
+kubectl wait --for=delete pod/my-postgres-pg-0 --timeout=5m
 
-# 2. Run a restore pod that mounts the data PVC AND the pgbackrest ConfigMap.
-# The repo settings (repo1-type=s3, endpoint, bucket, path) and pg1-path live ONLY
-# in the <fullname>-pgbackrest ConfigMap, so it MUST be mounted at
-# /etc/pgbackrest/pgbackrest.conf or pgbackrest fails with "requires option: pg1-path"
-# and would default to a local posix repo (never finding the S3 backup).
-# Replace YOUR_PGBACKREST_SECRET with your pgbackrest.existingSecret.name.
-# The securityContext (101:103) matches the chart so restored files are owned
-# correctly and the pod is accepted under restricted PodSecurity / OpenShift SCC.
-# keyType: auto (IRSA / Workload Identity)? Drop the env block, add
-# "serviceAccountName": "my-postgres-pg-repmgr" to the spec (that SA carries the
-# cloud-role annotation; the namespace default SA does not), and ensure the pod lands
-# where your IRSA/WI webhook injects the token; pgbackrest then uses the credential chain.
-kubectl run pg-restore --rm -it \
-  --image=cagriekin/repmgr:trixie-5.5.0-27 \
-  --overrides='{ "spec": { "securityContext": { "runAsUser": 101, "runAsGroup": 103, "fsGroup": 103, "runAsNonRoot": true, "seccompProfile": { "type": "RuntimeDefault" } }, "containers": [{ "name": "restore", "image": "cagriekin/repmgr:trixie-5.5.0-27", "command": ["bash"], "stdin": true, "tty": true, "securityContext": { "allowPrivilegeEscalation": false, "capabilities": { "drop": ["ALL"] } }, "volumeMounts": [{ "name": "data", "mountPath": "/var/lib/postgresql/data" }, { "name": "pgbackrest-config", "mountPath": "/etc/pgbackrest/pgbackrest.conf", "subPath": "pgbackrest.conf", "readOnly": true }], "env": [{ "name": "PGBACKREST_REPO1_S3_KEY", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "access-key-id" } } }, { "name": "PGBACKREST_REPO1_S3_KEY_SECRET", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "secret-access-key" } } }] }], "volumes": [{ "name": "data", "persistentVolumeClaim": { "claimName": "data-my-postgres-pg-0" } }, { "name": "pgbackrest-config", "configMap": { "name": "my-postgres-pg-pgbackrest" } }] } }'
+# 2. Restore (stanza = pgbackrest.stanza, default "db").
+kubectl create job --from=cronjob/my-postgres-pg-pgbackrest-restore restore-now
+kubectl wait --for=condition=complete job/restore-now --timeout=30m
 
-# 3. Inside the restore pod, run (stanza = pgbackrest.stanza, default "db").
-# --type=time is REQUIRED with --target (pgbackrest rejects --target otherwise);
-# use --type=xid|name|lsn for other recovery targets. Leave the existing data dir in
-# place so --delta restores only changed files (a wiped PGDATA disables --delta).
-pgbackrest --stanza=db restore \
-  --type=time \
-  --target="2026-03-22 12:00:00+00" \
-  --target-action=promote \
-  --delta
-
-# 4. Scale back up
+# 3. Scale back up: the pods replay the archived WAL and promote.
 kubectl scale statefulset my-postgres-pg --replicas=2
 ```
 
-Repmgr will automatically rebuild standbys from the restored primary.
+With no target set this restores the **latest** backup set and replays all archived WAL —
+the disaster-recovery case. For a *point in time*, set the target first:
+
+```yaml
+pgbackrest:
+  restore:
+    enabled: true
+    targetType: time                     # "" (latest) | time | xid | name | lsn
+    target: "2026-03-22 12:00:00+00"     # required once targetType is set
+    # backupSet: "20260322-010002F"      # optional: pin a specific set from `pgbackrest info`
+```
+
+A target always implies `--target-action=promote`: PostgreSQL's default
+`recovery_target_action` is `pause`, which would leave the cluster in recovery, never
+accepting connections.
+
+`mode: job` renders a bare Job instead, for passing an arbitrary target inline without
+touching the release (useful when the values live in Git and you cannot wait for a commit):
+
+```bash
+helm get values my-postgres > /tmp/v.yaml
+helm template my-postgres cagriekin/pg -f /tmp/v.yaml \
+  --set pgbackrest.restore.enabled=true --set pgbackrest.restore.mode=job \
+  --set pgbackrest.restore.targetType=time \
+  --set-string 'pgbackrest.restore.target=2026-03-22 12:00:00+00' \
+  -s templates/pgbackrest-restore-job.yaml | kubectl apply -f -
+```
+
+Two caveats for this mode: the Job is not part of the release, so a GitOps controller may
+report or prune it; and Jobs are immutable, so a second attempt needs
+`--set pgbackrest.restore.nameSuffix=attempt2`.
+
+Repmgr rebuilds the standbys from the restored primary when they start. If a standby comes
+up on the pre-restore timeline instead of re-cloning, delete its PVC and pod so it clones
+fresh from the restored primary:
+
+```bash
+kubectl delete pvc data-my-postgres-pg-1 && kubectl delete pod my-postgres-pg-1
+```
+
+If the cluster **crashed** rather than being scaled down cleanly, a stale
+`postmaster.pid` is left in PGDATA and pgbackrest refuses to restore — the interlock that
+lets this Job run with no Kubernetes API access at all. Confirm every postgresql pod is
+gone, then set `pgbackrest.restore.force=true`.
 
 #### Agent mode: clear the stale leadership state before scaling up
 
@@ -1361,20 +1408,10 @@ pg_restore -h <host> -U <user> -d <database> --clean --if-exists /tmp/backup.dum
 
 ### Point-in-Time Recovery (pgBackRest)
 
-1. Stop the PostgreSQL pod:
-```bash
-kubectl scale statefulset <fullname> -n <namespace> --replicas=0
-```
-
-2. Run PITR restore:
-```bash
-pgbackrest --stanza=db --type=time "--target=2025-01-15 12:00:00" restore
-```
-
-3. Scale back up:
-```bash
-kubectl scale statefulset <fullname> -n <namespace> --replicas=<original-count>
-```
+Enable `pgbackrest.restore.enabled` and use the chart's restore Job — see
+[Point-in-Time Recovery](#point-in-time-recovery) above for the full runbook (scale to 0 →
+`kubectl create job --from=cronjob/<fullname>-pgbackrest-restore` → scale up), the
+point-in-time target values, and the agent-mode leadership cleanup.
 
 ### Split-Brain Recovery
 

--- a/pg/templates/pgbackrest-configmap.yaml
+++ b/pg/templates/pgbackrest-configmap.yaml
@@ -215,4 +215,71 @@ data:
     echo "Restore OK: recovery completed and promoted; ${RELS} table-like relation(s), ~${ROWS} row(s) (estimate) in '$POSTGRES_DB'"
     echo "pgBackRest PITR validation succeeded for stanza '$PGBACKREST_STANZA'"
 {{- end }}
+{{- if .Values.pgbackrest.restore.enabled }}
+  # First-class PITR restore program (#226), mounted into the pgbackrest-restore
+  # Job/CronJob. Unlike validate.sh above (throwaway instance, proves restorability) this
+  # one restores over the LIVE data directory. Kept here rather than inlined in the Job so
+  # the two stay side by side; all inputs arrive via env (PGBACKREST_*, PGDATA,
+  # TARGET_TYPE/TARGET, BACKUP_SET, FORCE) so the body is literal.
+  restore.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    # Restores the pgBackRest repository over the live data directory and then STOPS: it
+    # deliberately never starts postgres. Recovery (WAL replay + promotion) happens when
+    # the operator scales the StatefulSet back up, under the normal chart entrypoint.
+    # Run this only while the StatefulSet is scaled to 0.
+
+    # pg_controldata lives in /usr/lib/postgresql/<major>/bin in the Debian-based repmgr
+    # image and is NOT on PATH when this script is the container command (the image
+    # entrypoint, which would add it, is bypassed). pgbackrest itself is in /usr/bin, so
+    # the restore works either way -- this is for the post-restore report at the end.
+    PG_BIN=$(dirname "$(ls -1 /usr/lib/postgresql/*/bin/pg_controldata 2>/dev/null | sort -V | tail -1)")
+    [ -n "$PG_BIN" ] && export PATH="$PG_BIN:$PATH"
+
+    mkdir -p "$PGBACKREST_LOG_PATH" "$PGBACKREST_LOCK_PATH"
+
+    # Restoring over a RUNNING cluster would corrupt it. pgbackrest is the real interlock
+    # -- it refuses while $PGDATA/postmaster.pid exists ("unable to restore while
+    # PostgreSQL is running"), which is why this Job needs no API access to check replica
+    # counts -- but test it first so the failure names the actual operator mistake and
+    # points at the one legitimate override.
+    if [ -f "$PGDATA/postmaster.pid" ] && [ "$FORCE" != "true" ]; then
+      echo "ERROR: $PGDATA/postmaster.pid exists -- PostgreSQL is (or was) running on this volume." >&2
+      echo "       Scale the StatefulSet to 0, wait for the pods to terminate, then rerun." >&2
+      echo "       If the cluster crashed and the pid file is stale, set pgbackrest.restore.force=true." >&2
+      exit 1
+    fi
+
+    # --delta compares checksums and copies only the files that differ, so the existing
+    # PGDATA is left in place (a wiped data directory silently degrades to a full restore
+    # -- still correct, just slower). Rerunning the Job simply restores again.
+    ARGS=(--stanza="$PGBACKREST_STANZA" --delta)
+    if [ -n "$BACKUP_SET" ]; then
+      echo "Restoring from backup set: $BACKUP_SET"
+      ARGS+=(--set="$BACKUP_SET")
+    fi
+    if [ -n "$TARGET_TYPE" ]; then
+      # With a target, --target-action=promote is REQUIRED: PostgreSQL's default
+      # recovery_target_action is `pause`, which would leave the restored cluster paused
+      # in recovery (never accepting connections) after scale-up. With no target,
+      # recovery replays to the end of the archived WAL stream and promotes on its own.
+      echo "PITR target: type=$TARGET_TYPE target=$TARGET"
+      ARGS+=(--type="$TARGET_TYPE" --target="$TARGET" --target-action=promote)
+    fi
+    if [ "$FORCE" = "true" ]; then
+      ARGS+=(--force)
+    fi
+
+    echo "Restoring stanza '$PGBACKREST_STANZA' into the live data directory ($PGDATA)..."
+    pgbackrest "${ARGS[@]}" restore
+
+    # Echo the restored control file (state + checkpoint) into the Job log: it is the
+    # first thing to look at if the cluster does not come up after scale-up.
+    echo "----- pg_controldata after restore -----"
+    pg_controldata -D "$PGDATA" 2>/dev/null | grep -E 'Database cluster state|Latest checkpoint location|Time of latest checkpoint' || true
+
+    echo "pgBackRest restore succeeded for stanza '$PGBACKREST_STANZA'"
+    echo "Scale the StatefulSet back up to replay WAL and promote (see the chart README)."
+{{- end }}
 {{- end }}

--- a/pg/templates/pgbackrest-restore-job.yaml
+++ b/pg/templates/pgbackrest-restore-job.yaml
@@ -1,0 +1,218 @@
+{{- if .Values.pgbackrest.restore.enabled }}
+{{- /* First-class PITR restore (#226). Replaces the hand-built `kubectl run --overrides`
+       runbook: the chart already knows the identity, security contexts, volumes, repo
+       config and credentials a restore needs (it renders them for the #38 validation
+       CronJob), so the operator should not have to reconstruct ~30 lines of inline JSON.
+       Unlike validation -- which restores into a THROWAWAY emptyDir and starts a
+       throwaway postgres -- this restores into the LIVE data PVC (data-<fullname>-0)
+       and never starts postgres: scaling the StatefulSet back up performs recovery.
+       Because the mounted pgbackrest.conf's pg1-path is already the live PGDATA, no
+       PGBACKREST_PG1_PATH override is needed here (validation only sets one to redirect
+       the restore away from the live directory). */}}
+{{- if not .Values.pgbackrest.enabled }}
+{{- fail "pgbackrest.restore.enabled requires pgbackrest.enabled (the restore reads the pgBackRest repo config and S3 credentials the pgbackrest feature renders)" }}
+{{- end }}
+{{- if not .Values.postgresql.persistence.enabled }}
+{{- fail "pgbackrest.restore.enabled requires postgresql.persistence.enabled: the restore writes into the data PVC (data-<fullname>-0), which only exists when persistence is on" }}
+{{- end }}
+{{- /* targetType's allowed values are enforced by the values.schema.json enum (portable
+       across helm versions). The dependent "target is required when targetType is set"
+       rule is a template fail rather than a schema `if/then` because helm 3.x's schema
+       validator does not honor `if/then` the way helm 4 does. Mirrors #38. */}}
+{{- if and (ne .Values.pgbackrest.restore.targetType "") (not .Values.pgbackrest.restore.target) }}
+{{- fail "pgbackrest.restore.target is required when pgbackrest.restore.targetType is set" }}
+{{- end }}
+{{- end }}
+
+{{- /* The Job spec is shared by both delivery modes (restore.mode), which differ only in
+       the wrapper: a suspended CronJob to clone with `kubectl create job --from` (the
+       release owns the resource -- GitOps-clean), or a bare Job to render on demand with
+       `helm template -s` (arbitrary point-in-time inline, nothing baked into the
+       release). Defined at column 0 and nindent-ed at each call site. */}}
+{{- define "pg.pgbackrestRestoreJobSpec" -}}
+activeDeadlineSeconds: {{ .Values.pgbackrest.restore.activeDeadlineSeconds }}
+{{- /* 0 = one pod attempt: a failed restore leaves PGDATA half-written, and an automatic
+       retry would race the operator's own diagnosis. Failures also surface immediately. */}}
+backoffLimit: {{ .Values.pgbackrest.restore.backoffLimit }}
+template:
+  metadata:
+    labels:
+      {{- include "pg.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: pgbackrest-restore
+  spec:
+    {{- with .Values.imagePullSecrets }}
+    imagePullSecrets:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.pgbackrest.cronjob.priorityClassName }}
+    priorityClassName: {{ . }}
+    {{- end }}
+    {{- /* Inherit the postgresql pods' node placement: this Job must land somewhere the
+           data PVC can attach, so a dedicated (tainted / labelled) database node pool that
+           the postgresql pods tolerate must be tolerated here too -- otherwise the restore
+           sits Pending in the middle of an incident. postgresql.affinity is deliberately
+           NOT inherited: it spreads replicas apart, which is meaningless for a one-shot Job
+           that has to run next to one specific volume. */}}
+    {{- with .Values.postgresql.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.postgresql.tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    restartPolicy: Never
+    # Reuse the postgresql pods' ServiceAccount: it carries the cloud workload-identity
+    # annotation (postgresql.serviceAccount.annotations) that pgbackrest needs to reach S3
+    # under s3.keyType=auto -- the same identity that wrote the backups. The restore never
+    # calls the Kubernetes API (it only reads S3 and writes the mounted PVC), so its token
+    # is not mounted. The scale down/up around it stays a deliberate operator action.
+    serviceAccountName: {{ include "pg.fullname" . }}-repmgr
+    automountServiceAccountToken: false
+    # Same contexts as the postgresql pods (uid 101, gid 103, fsGroup 103) so the restored
+    # files land with the ownership the postmaster expects on scale-up, and the pod is
+    # accepted under restricted Pod Security / OpenShift SCC.
+    securityContext:
+      {{- toYaml .Values.postgresql.podSecurityContext | nindent 6 }}
+    containers:
+      - name: pgbackrest-restore
+        # The repmgr image ships pgbackrest and the matching PostgreSQL major, so the
+        # restore runs under the same binaries that wrote the backup.
+        image: "{{ include "pg.repmgrImage" . }}"
+        imagePullPolicy: {{ .Values.repmgr.image.pullPolicy }}
+        securityContext:
+          {{- toYaml .Values.postgresql.containerSecurityContext | nindent 10 }}
+        # The restore program lives in the pgbackrest ConfigMap (restore.sh), mounted
+        # below -- mirrors the #38 validation rather than inlining shell here. All inputs
+        # arrive via env.
+        command: ["/bin/bash", "/scripts/restore.sh"]
+        env:
+          - name: PGBACKREST_STANZA
+            value: {{ .Values.pgbackrest.stanza | quote }}
+          # The live data directory, identical to the StatefulSet's PGDATA and to the
+          # mounted pgbackrest.conf's pg1-path. Used for the running-postmaster interlock
+          # and the post-restore pg_controldata report.
+          - name: PGDATA
+            value: /var/lib/postgresql/data/pgdata
+          # pgbackrest's default log/lock paths (/var/log/pgbackrest, /tmp) may be
+          # unwritable; point them at the writable work volume, and keep the restore from
+          # leaving its own scratch files inside the restored PGDATA.
+          - name: PGBACKREST_LOG_PATH
+            value: /work/pgbackrest-log
+          - name: PGBACKREST_LOCK_PATH
+            value: /work/pgbackrest-lock
+          - name: TARGET_TYPE
+            value: {{ .Values.pgbackrest.restore.targetType | quote }}
+          - name: TARGET
+            value: {{ .Values.pgbackrest.restore.target | quote }}
+          - name: BACKUP_SET
+            value: {{ .Values.pgbackrest.restore.backupSet | quote }}
+          - name: FORCE
+            value: {{ .Values.pgbackrest.restore.force | quote }}
+{{- if .Values.pgbackrest.repoEncryption.enabled }}
+          - name: PGBACKREST_REPO1_CIPHER_PASS
+            valueFrom:
+              secretKeyRef:
+                name: {{ required "pgbackrest.repoEncryption.existingSecret.name is required when pgbackrest.repoEncryption.enabled" .Values.pgbackrest.repoEncryption.existingSecret.name }}
+                key: {{ .Values.pgbackrest.repoEncryption.existingSecret.passphraseKey }}
+{{- end }}
+{{- if eq .Values.pgbackrest.s3.keyType "shared" }}
+          - name: PGBACKREST_REPO1_S3_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "pg.pgbackrestS3SecretName" . }}
+                key: {{ .Values.pgbackrest.existingSecret.accessKeyIdKey }}
+          - name: PGBACKREST_REPO1_S3_KEY_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "pg.pgbackrestS3SecretName" . }}
+                key: {{ .Values.pgbackrest.existingSecret.secretAccessKeyKey }}
+{{- end }}
+        resources:
+          {{- toYaml .Values.pgbackrest.restore.resources | nindent 10 }}
+        volumeMounts:
+          # The LIVE data PVC of replica 0 -- the restore target. Mountable only while the
+          # StatefulSet is scaled to 0 in practice; pgbackrest additionally refuses to
+          # restore while $PGDATA/postmaster.pid exists (see restore.sh).
+          - name: data
+            mountPath: /var/lib/postgresql/data
+          - name: pgbackrest-config
+            mountPath: /etc/pgbackrest/pgbackrest.conf
+            subPath: pgbackrest.conf
+            readOnly: true
+          # Mount restore.sh via a dedicated directory volume (not a subPath file), so
+          # /scripts is created by the mount and need not pre-exist in the image.
+          - name: restore-script
+            mountPath: /scripts
+            readOnly: true
+          - name: work
+            mountPath: /work
+    volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: data-{{ include "pg.fullname" . }}-{{ .Values.pgbackrest.restore.podOrdinal }}
+      - name: pgbackrest-config
+        configMap:
+          name: {{ include "pg.fullname" . }}-pgbackrest
+      - name: restore-script
+        configMap:
+          name: {{ include "pg.fullname" . }}-pgbackrest
+          defaultMode: 0755
+          items:
+            - key: restore.sh
+              path: restore.sh
+      - name: work
+        emptyDir: {}
+{{- end }}
+
+{{- if .Values.pgbackrest.restore.enabled }}
+{{- if eq .Values.pgbackrest.restore.mode "cronjob" }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  # Stable name (restore.nameSuffix deliberately does not apply here) so the runbook's
+  # `kubectl create job --from=cronjob/<fullname>-pgbackrest-restore` never changes.
+  name: {{ include "pg.fullname" . }}-pgbackrest-restore
+  labels:
+    {{- include "pg.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pgbackrest-restore
+  annotations:
+    # one-shot CronJob: liveness/readiness probes do not apply (kube-linter waiver).
+    ignore-check.kube-linter.io/no-liveness-probe: "one-shot pgbackrest-restore CronJob"
+    ignore-check.kube-linter.io/no-readiness-probe: "one-shot pgbackrest-restore CronJob"
+    {{- with (include "pg.annotations" .) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+spec:
+  # A template, not a schedule: restoring over the live data directory must only ever
+  # happen when an operator asks for it, so the CronJob is suspended AND carries a
+  # schedule that can never fire (Feb 31). Clone it on demand:
+  #   kubectl create job --from=cronjob/<fullname>-pgbackrest-restore restore-now
+  suspend: true
+  schedule: "0 0 31 2 *"
+  concurrencyPolicy: {{ .Values.pgbackrest.cronjob.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.pgbackrest.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.pgbackrest.cronjob.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      {{- include "pg.pgbackrestRestoreJobSpec" . | nindent 6 }}
+{{- else }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # Jobs are immutable, so a rerun needs a fresh name: restore.nameSuffix.
+  name: {{ include "pg.fullname" . }}-pgbackrest-restore{{ with .Values.pgbackrest.restore.nameSuffix }}-{{ . }}{{ end }}
+  labels:
+    {{- include "pg.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pgbackrest-restore
+  annotations:
+    # one-shot Job: liveness/readiness probes do not apply (kube-linter waiver).
+    ignore-check.kube-linter.io/no-liveness-probe: "one-shot pgbackrest-restore Job"
+    ignore-check.kube-linter.io/no-readiness-probe: "one-shot pgbackrest-restore Job"
+    {{- with (include "pg.annotations" .) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- include "pg.pgbackrestRestoreJobSpec" . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/pg/tests/helpers.sh
+++ b/pg/tests/helpers.sh
@@ -134,6 +134,75 @@ pg_exec() {
     psql -U "${user}" -d "${db}" -t -A -c "${query}" 2>/dev/null
 }
 
+# Deploy the in-cluster MinIO the pgbackrest suites back their repository with: a
+# self-signed TLS endpoint (Service :443 -> container :9000), the S3 credential Secret the
+# values fixtures reference, and the bucket. pgbackrest's verify-tls is off in those
+# fixtures, so the cert only has to exist. Idempotent -- safe to rerun in a live namespace.
+# Usage: deploy_minio <namespace> [bucket]
+deploy_minio() {
+  local namespace="$1"
+  local bucket="${2:-pgbackrest-test}"
+  local certdir
+  certdir="$(mktemp -d)"
+
+  openssl req -x509 -newkey rsa:2048 -nodes -days 3650 -subj "/CN=minio" \
+    -addext "subjectAltName=DNS:minio" \
+    -keyout "${certdir}/private.key" -out "${certdir}/public.crt" >/dev/null 2>&1
+  kubectl create secret generic minio-tls -n "${namespace}" \
+    --from-file=public.crt="${certdir}/public.crt" --from-file=private.key="${certdir}/private.key" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  kubectl create secret generic s3-backup-creds -n "${namespace}" \
+    --from-literal=access-key-id=minioadmin --from-literal=secret-access-key=minioadmin \
+    --dry-run=client -o yaml | kubectl apply -f -
+  rm -rf "${certdir}"
+
+  echo "Deploying MinIO (TLS on :9000, Service exposes :443 -> 9000)..."
+  kubectl apply -n "${namespace}" -f - <<'MINIO'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: minio } }
+  template:
+    metadata: { labels: { app: minio } }
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2025-02-18T16-25-55Z
+          args: ["server", "/data", "--certs-dir", "/certs"]
+          env:
+            - { name: MINIO_ROOT_USER, value: minioadmin }
+            - { name: MINIO_ROOT_PASSWORD, value: minioadmin }
+          ports: [{ containerPort: 9000 }]
+          volumeMounts:
+            - { name: certs, mountPath: /certs, readOnly: true }
+          readinessProbe:
+            httpGet: { path: /minio/health/ready, port: 9000, scheme: HTTPS }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: certs
+          secret: { secretName: minio-tls, defaultMode: 0444 }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: minio }
+spec:
+  selector: { app: minio }
+  ports: [{ port: 443, targetPort: 9000 }]
+MINIO
+  wait_for_deployment_ready "${namespace}" "minio" 180
+
+  echo "Creating bucket ${bucket}..."
+  kubectl delete pod mc-setup -n "${namespace}" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+  kubectl run mc-setup -n "${namespace}" --restart=Never --image=minio/mc:RELEASE.2024-11-21T17-21-54Z \
+    --command -- sh -c "mc --insecure alias set s3 https://minio:443 minioadmin minioadmin && mc --insecure mb s3/${bucket} || true"
+  kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/mc-setup -n "${namespace}" --timeout=120s
+  kubectl delete pod mc-setup -n "${namespace}" --wait=false
+}
+
 resolve_fullname() {
   local release="$1"
   local chart_dir="$2"

--- a/pg/tests/test-backup-concurrent.sh
+++ b/pg/tests/test-backup-concurrent.sh
@@ -14,69 +14,13 @@ NAMESPACE="${NAMESPACE:-pg-test-backup-concurrent}"
 RELEASE="${RELEASE:-pgbrc}"
 STANZA="db"
 FULLNAME=$(resolve_fullname "${RELEASE}" "${CHART_DIR}" "${SCRIPT_DIR}/values-pgbackrest-minio.yaml")
-CERTDIR="$(mktemp -d)"
-trap 'rm -rf "${CERTDIR}"' EXIT
 
 begin_suite "Concurrent backup + WAL archiving (pgbackrest, #34)"
 
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 
-# --- self-signed cert for MinIO TLS (pgbackrest verify-tls is off, so CN/SAN is not
-#     checked; MinIO just needs a valid cert file to serve https) ---
-openssl req -x509 -newkey rsa:2048 -nodes -days 3650 -subj "/CN=minio" \
-  -addext "subjectAltName=DNS:minio" \
-  -keyout "${CERTDIR}/private.key" -out "${CERTDIR}/public.crt" >/dev/null 2>&1
-kubectl create secret generic minio-tls -n "${NAMESPACE}" \
-  --from-file=public.crt="${CERTDIR}/public.crt" --from-file=private.key="${CERTDIR}/private.key" \
-  --dry-run=client -o yaml | kubectl apply -f -
-kubectl create secret generic s3-backup-creds -n "${NAMESPACE}" \
-  --from-literal=access-key-id=minioadmin --from-literal=secret-access-key=minioadmin \
-  --dry-run=client -o yaml | kubectl apply -f -
-
-echo "Deploying MinIO (TLS on :9000, Service exposes :443 -> 9000)..."
-kubectl apply -n "${NAMESPACE}" -f - <<'MINIO'
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: minio
-spec:
-  replicas: 1
-  selector: { matchLabels: { app: minio } }
-  template:
-    metadata: { labels: { app: minio } }
-    spec:
-      containers:
-        - name: minio
-          image: minio/minio:RELEASE.2025-02-18T16-25-55Z
-          args: ["server", "/data", "--certs-dir", "/certs"]
-          env:
-            - { name: MINIO_ROOT_USER, value: minioadmin }
-            - { name: MINIO_ROOT_PASSWORD, value: minioadmin }
-          ports: [{ containerPort: 9000 }]
-          volumeMounts:
-            - { name: certs, mountPath: /certs, readOnly: true }
-          readinessProbe:
-            httpGet: { path: /minio/health/ready, port: 9000, scheme: HTTPS }
-            initialDelaySeconds: 5
-            periodSeconds: 5
-      volumes:
-        - name: certs
-          secret: { secretName: minio-tls, defaultMode: 0444 }
----
-apiVersion: v1
-kind: Service
-metadata: { name: minio }
-spec:
-  selector: { app: minio }
-  ports: [{ port: 443, targetPort: 9000 }]
-MINIO
-wait_for_deployment_ready "${NAMESPACE}" "minio" 180
-
-echo "Creating bucket pgbackrest-test..."
-kubectl run mc-setup -n "${NAMESPACE}" --restart=Never --image=minio/mc:RELEASE.2024-11-21T17-21-54Z \
-  --command -- sh -c "mc --insecure alias set s3 https://minio:443 minioadmin minioadmin && mc --insecure mb s3/pgbackrest-test || true"
-kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/mc-setup -n "${NAMESPACE}" --timeout=120s
-kubectl delete pod mc-setup -n "${NAMESPACE}" --wait=false
+# MinIO + the S3 credential Secret + the bucket (shared with the pgbackrest restore suites).
+deploy_minio "${NAMESPACE}"
 
 echo "Installing pg chart with pgbackrest -> MinIO..."
 helm upgrade --install "${RELEASE}" "${CHART_DIR}" -n "${NAMESPACE}" \

--- a/pg/tests/test-pgbackrest-restore-ha.sh
+++ b/pg/tests/test-pgbackrest-restore-ha.sh
@@ -146,12 +146,30 @@ else
   echo "  Standby state at give-up:"
   kubectl get pod "${STANDBY}" -n "${NAMESPACE}" -o wide 2>/dev/null || true
   kubectl logs -n "${NAMESPACE}" "${STANDBY}" -c postgresql --tail=40 2>/dev/null || true
-  echo "Applying the documented fallback: delete the standby's PVC + pod so it clones fresh..."
-  kubectl delete pvc "data-${FULLNAME}-1" -n "${NAMESPACE}" --wait=false >/dev/null 2>&1 || true
-  kubectl delete pod "${STANDBY}" -n "${NAMESPACE}" --wait=true >/dev/null 2>&1 || true
+  echo "Applying the documented fallback: drop the standby's PVC so it clones fresh..."
+  # Order matters, and NOT the obvious way round. Deleting the PVC while pod-1 still exists
+  # leaves it Terminating behind the kubernetes.io/pvc-protection finalizer; the StatefulSet
+  # then recreates pod-1, which can re-bind that same PVC before deletion completes -- the
+  # standby would come back on its STALE pre-restore data and the assertions below could
+  # still pass, reporting a re-clone that never happened. So scale the standby away first,
+  # delete the PVC, confirm it is actually GONE, and only then let it be recreated.
+  old_pvc_uid=$(kubectl get pvc "data-${FULLNAME}-1" -n "${NAMESPACE}" -o jsonpath='{.metadata.uid}' 2>/dev/null || echo "")
+  kubectl scale statefulset "${FULLNAME}" -n "${NAMESPACE}" --replicas=1
+  kubectl wait --for=delete pod/"${STANDBY}" -n "${NAMESPACE}" --timeout=300s 2>/dev/null || true
+  kubectl delete pvc "data-${FULLNAME}-1" -n "${NAMESPACE}" --wait=true --timeout=300s >/dev/null 2>&1 || true
+  kubectl wait --for=delete pvc/"data-${FULLNAME}-1" -n "${NAMESPACE}" --timeout=300s 2>/dev/null || true
+  kubectl scale statefulset "${FULLNAME}" -n "${NAMESPACE}" --replicas=2
   reclone_rc=0
   wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 2 600 || reclone_rc=$?
   assert_eq "documented fallback works: standby re-clones after PVC deletion" "0" "${reclone_rc}"
+  # Prove the standby is on a genuinely NEW volume: a re-bound stale PVC keeps its UID, and
+  # would let the checks below pass on pre-restore data.
+  new_pvc_uid=$(kubectl get pvc "data-${FULLNAME}-1" -n "${NAMESPACE}" -o jsonpath='{.metadata.uid}' 2>/dev/null || echo "")
+  if [ -n "${old_pvc_uid}" ] && [ "${old_pvc_uid}" = "${new_pvc_uid}" ]; then
+    fail "fallback provisioned a fresh PVC" "PVC data-${FULLNAME}-1 kept uid ${new_pvc_uid}: the stale volume was re-bound, not replaced"
+  else
+    pass "fallback provisioned a fresh PVC (uid changed)"
+  fi
 fi
 
 # --- whichever path got us here, the pair must be a healthy streaming cluster ---

--- a/pg/tests/test-pgbackrest-restore-ha.sh
+++ b/pg/tests/test-pgbackrest-restore-ha.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+# Multi-replica pgBackRest PITR restore test (#226). The single-node suite
+# (test-pgbackrest-restore.sh) proves the restore Job repairs replica 0. This one answers the
+# question that only exists with a standby: after replica 0 is restored and promotes onto a
+# NEW timeline, what happens to replica 1, whose PVC still holds PRE-restore data on the OLD
+# timeline? The README claims repmgr rebuilds it -- this asserts that end to end, and if the
+# standby cannot rejoin on its own it asserts the documented manual fallback (delete its PVC
+# + pod) instead, so the docs can never drift from the real behaviour.
+#
+# OPT-IN / standalone: `make -C pg test-pgbackrest-restore-ha`.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+source "${SCRIPT_DIR}/helpers.sh"
+
+NAMESPACE="${NAMESPACE:-pg-test-pgbackrest-restore-ha}"
+RELEASE="${RELEASE:-pgbrha}"
+VALUES="${SCRIPT_DIR}/values-pgbackrest-minio-ha.yaml"
+FULLNAME=$(resolve_fullname "${RELEASE}" "${CHART_DIR}" "${VALUES}")
+
+begin_suite "pgBackRest multi-replica PITR restore (#226)"
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+deploy_minio "${NAMESPACE}"
+
+echo "Installing pg chart (primary + 1 standby) with pgbackrest + restore Job enabled..."
+helm upgrade --install "${RELEASE}" "${CHART_DIR}" -n "${NAMESPACE}" \
+  -f "${VALUES}" \
+  --set pgbackrest.restore.enabled=true \
+  --wait --timeout 10m
+wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 2 900
+PRIMARY="${FULLNAME}-0"
+STANDBY="${FULLNAME}-1"
+
+# --- baseline: a genuine streaming pair, so the standby PVC really holds live data ---
+is_primary=$(pg_exec "${NAMESPACE}" "${PRIMARY}" "SELECT NOT pg_is_in_recovery()" "testuser" "testdb")
+assert_eq "baseline: pod-0 is the primary" "t" "${is_primary}"
+is_standby=$(pg_exec "${NAMESPACE}" "${STANDBY}" "SELECT pg_is_in_recovery()" "testuser" "testdb")
+assert_eq "baseline: pod-1 is a standby" "t" "${is_standby}"
+
+# --- first full backup: runs stanza-create, after which WAL archiving succeeds ---
+echo "Triggering initial full backup (creates the stanza)..."
+kubectl delete job pgbr-full -n "${NAMESPACE}" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+kubectl create job -n "${NAMESPACE}" pgbr-full --from=cronjob/"${FULLNAME}-pgbackrest-full"
+full_rc=0
+kubectl wait --for=condition=complete job/pgbr-full -n "${NAMESPACE}" --timeout=300s || full_rc=$?
+if [ "${full_rc}" -ne 0 ]; then
+  echo "  full-backup job did not complete; logs:"; kubectl logs -n "${NAMESPACE}" job/pgbr-full --tail=80 2>/dev/null || true
+fi
+assert_eq "initial full backup (stanza-create) succeeds" "0" "${full_rc}"
+# Pre-stanza archive_command failures inflate failed_count; reset so the health check below
+# measures only post-stanza pushes (mirrors test-pgbackrest-restore.sh).
+pg_exec "${NAMESPACE}" "${PRIMARY}" "SELECT pg_stat_reset_shared('archiver')" "testuser" "testdb" >/dev/null 2>&1 || true
+
+# --- data written AFTER the backup, archived as WAL and streamed to the standby ---
+echo "Writing post-backup data, archiving it as WAL and waiting for the standby to stream it..."
+pg_exec "${NAMESPACE}" "${PRIMARY}" "CREATE TABLE pitr_proof (id bigserial PRIMARY KEY, v text)" "testuser" "testdb"
+pg_exec "${NAMESPACE}" "${PRIMARY}" "INSERT INTO pitr_proof (v) SELECT repeat('x',256) FROM generate_series(1,5000)" "testuser" "testdb"
+seg=$(pg_exec "${NAMESPACE}" "${PRIMARY}" "SELECT pg_walfile_name(pg_current_wal_lsn())" "testuser" "testdb" | tr -d '[:space:]')
+pg_exec "${NAMESPACE}" "${PRIMARY}" "SELECT pg_switch_wal()" "testuser" "testdb" >/dev/null
+for _ in $(seq 1 90); do
+  last=$(pg_exec "${NAMESPACE}" "${PRIMARY}" "SELECT COALESCE(last_archived_wal,'')" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+  if [ -n "${last}" ] && [ ! "${last}" \< "${seg}" ]; then break; fi
+  sleep 2
+done
+failed=$(pg_exec "${NAMESPACE}" "${PRIMARY}" "SELECT failed_count FROM pg_stat_archiver" "testuser" "testdb" 2>/dev/null || echo "")
+assert_eq "WAL archiving healthy before restore (no failed pushes)" "0" "${failed}"
+# The standby must actually hold the pre-restore data: that is what makes its PVC "stale"
+# rather than empty after the primary is restored and promotes onto a new timeline.
+standby_rows=""
+for _ in $(seq 1 30); do
+  standby_rows=$(pg_exec "${NAMESPACE}" "${STANDBY}" "SELECT count(*) FROM pitr_proof" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+  [ "${standby_rows}" = "5000" ] && break
+  sleep 2
+done
+assert_eq "standby streamed the pre-restore data (its PVC is stale, not empty)" "5000" "${standby_rows}"
+tl_before=$(pg_exec "${NAMESPACE}" "${PRIMARY}" "SELECT timeline_id FROM pg_control_checkpoint()" "testuser" "testdb" | tr -d '[:space:]')
+
+# =============================================================================
+# Disaster + recovery: destroy ONLY the primary's data directory, restore it with the
+# chart's Job, and bring the pair back. The standby's PVC is deliberately left intact.
+# =============================================================================
+echo "Scaling the StatefulSet to 0..."
+kubectl scale statefulset "${FULLNAME}" -n "${NAMESPACE}" --replicas=0
+kubectl wait --for=delete pod/"${PRIMARY}" -n "${NAMESPACE}" --timeout=300s 2>/dev/null || true
+kubectl wait --for=delete pod/"${STANDBY}" -n "${NAMESPACE}" --timeout=300s 2>/dev/null || true
+
+echo "Destroying the PRIMARY's data directory (the standby's PVC is left untouched)..."
+kubectl delete pod pg-wipe -n "${NAMESPACE}" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+kubectl run pg-wipe -n "${NAMESPACE}" --restart=Never --image=busybox:1.37 \
+  --overrides="{\"spec\":{\"containers\":[{\"name\":\"pg-wipe\",\"image\":\"busybox:1.37\",\"command\":[\"sh\",\"-c\",\"rm -rf /data/pgdata && echo wiped\"],\"securityContext\":{\"runAsUser\":0},\"volumeMounts\":[{\"name\":\"data\",\"mountPath\":\"/data\"}]}],\"volumes\":[{\"name\":\"data\",\"persistentVolumeClaim\":{\"claimName\":\"data-${FULLNAME}-0\"}}]}}" >/dev/null
+wipe_rc=0
+kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/pg-wipe -n "${NAMESPACE}" --timeout=180s >/dev/null 2>&1 || wipe_rc=$?
+assert_eq "primary data directory wiped (disaster simulated)" "0" "${wipe_rc}"
+kubectl delete pod pg-wipe -n "${NAMESPACE}" --wait=false >/dev/null 2>&1 || true
+
+echo "Running the chart's restore Job..."
+kubectl delete job pgbr-restore -n "${NAMESPACE}" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+kubectl create job -n "${NAMESPACE}" pgbr-restore --from=cronjob/"${FULLNAME}-pgbackrest-restore"
+res_rc=2
+for _ in $(seq 1 120); do
+  succeeded=$(kubectl get job pgbr-restore -n "${NAMESPACE}" -o jsonpath='{.status.succeeded}' 2>/dev/null || echo "")
+  failed_j=$(kubectl get job pgbr-restore -n "${NAMESPACE}" -o jsonpath='{.status.failed}' 2>/dev/null || echo "")
+  [ "${succeeded:-0}" -ge 1 ] 2>/dev/null && { res_rc=0; break; }
+  [ "${failed_j:-0}" -ge 1 ] 2>/dev/null && { res_rc=1; break; }
+  sleep 3
+done
+if [ "${res_rc}" -ne 0 ]; then
+  echo "  restore job did not complete; logs:"; kubectl logs -n "${NAMESPACE}" job/pgbr-restore --tail=200 2>/dev/null || true
+fi
+assert_eq "restore job completes" "0" "${res_rc}"
+
+echo "Scaling back up to primary + standby..."
+kubectl scale statefulset "${FULLNAME}" -n "${NAMESPACE}" --replicas=2
+
+# --- the restored primary comes back first (OrderedReady) ---
+prim_rc=0
+wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 1 600 || prim_rc=$?
+assert_eq "restored primary becomes ready" "0" "${prim_rc}"
+restored_rows=$(pg_exec "${NAMESPACE}" "${PRIMARY}" "SELECT count(*) FROM pitr_proof" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+assert_eq "primary recovered the data from S3 (5000 rows)" "5000" "${restored_rows}"
+tl_after=$(pg_exec "${NAMESPACE}" "${PRIMARY}" "SELECT timeline_id FROM pg_control_checkpoint()" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+assert_gt "recovery advanced the primary's timeline (so the standby's PVC is now diverged)" "${tl_after:-0}" "${tl_before:-1}"
+
+# --- THE question: does the standby rejoin on its own, with stale data on the old timeline? ---
+echo "Waiting for the standby to rejoin the restored primary (it holds pre-restore data on timeline ${tl_before})..."
+standby_auto=""
+for _ in $(seq 1 100); do
+  ready=$(kubectl get pod "${STANDBY}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+  if [ "${ready}" = "True" ]; then
+    rec=$(pg_exec "${NAMESPACE}" "${STANDBY}" "SELECT pg_is_in_recovery()" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+    [ "${rec}" = "t" ] && { standby_auto="yes"; break; }
+  fi
+  sleep 6
+done
+
+if [ "${standby_auto}" = "yes" ]; then
+  # README claim confirmed: repmgr rebuilt/re-homed the standby with no operator action.
+  pass "standby rejoined the restored primary automatically (no manual PVC deletion)"
+else
+  # Honest fallback: record that automatic rejoin did NOT happen, then verify the manual
+  # step the README documents actually fixes it. Either way the docs match reality.
+  fail "standby rejoined the restored primary automatically (no manual PVC deletion)" \
+    "standby ${STANDBY} did not become a healthy standby on its own; asserting the documented manual re-clone instead"
+  echo "  Standby state at give-up:"
+  kubectl get pod "${STANDBY}" -n "${NAMESPACE}" -o wide 2>/dev/null || true
+  kubectl logs -n "${NAMESPACE}" "${STANDBY}" -c postgresql --tail=40 2>/dev/null || true
+  echo "Applying the documented fallback: delete the standby's PVC + pod so it clones fresh..."
+  kubectl delete pvc "data-${FULLNAME}-1" -n "${NAMESPACE}" --wait=false >/dev/null 2>&1 || true
+  kubectl delete pod "${STANDBY}" -n "${NAMESPACE}" --wait=true >/dev/null 2>&1 || true
+  reclone_rc=0
+  wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 2 600 || reclone_rc=$?
+  assert_eq "documented fallback works: standby re-clones after PVC deletion" "0" "${reclone_rc}"
+fi
+
+# --- whichever path got us here, the pair must be a healthy streaming cluster ---
+is_standby_after=$(pg_exec "${NAMESPACE}" "${STANDBY}" "SELECT pg_is_in_recovery()" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+assert_eq "standby is in recovery (streaming from the restored primary)" "t" "${is_standby_after}"
+standby_rows_after=$(pg_exec "${NAMESPACE}" "${STANDBY}" "SELECT count(*) FROM pitr_proof" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+assert_eq "standby serves the restored data (5000 rows)" "5000" "${standby_rows_after}"
+# The load-bearing check that it is really attached to THIS primary on the NEW timeline:
+# a standby stuck on the old timeline would not appear in pg_stat_replication.
+repl_count=""
+for _ in $(seq 1 30); do
+  repl_count=$(pg_exec "${NAMESPACE}" "${PRIMARY}" "SELECT count(*) FROM pg_stat_replication" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+  [ "${repl_count}" = "1" ] && break
+  sleep 4
+done
+assert_eq "primary sees exactly 1 streaming standby" "1" "${repl_count}"
+standby_tl=$(pg_exec "${NAMESPACE}" "${STANDBY}" "SELECT timeline_id FROM pg_control_checkpoint()" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+assert_eq "standby is on the primary's post-restore timeline" "${tl_after}" "${standby_tl}"
+# repmgr's own view: one primary, one active standby -- no orphaned/duplicate rows after
+# the restore rewrote the primary's identity.
+repmgr_rows=$(pg_exec "${NAMESPACE}" "${PRIMARY}" "SELECT type, active FROM repmgr.nodes ORDER BY node_id" "repmgr" "repmgr" 2>/dev/null || echo "")
+assert_contains "repmgr sees the restored primary" "${repmgr_rows}" "primary|t"
+assert_contains "repmgr sees an active standby" "${repmgr_rows}" "standby|t"
+
+# --- new writes replicate: the cluster is functional, not just structurally present ---
+pg_exec "${NAMESPACE}" "${PRIMARY}" "CREATE TABLE post_restore_write (id int)" "testuser" "testdb" >/dev/null
+pg_exec "${NAMESPACE}" "${PRIMARY}" "INSERT INTO post_restore_write VALUES (42)" "testuser" "testdb" >/dev/null
+replicated=""
+for _ in $(seq 1 30); do
+  replicated=$(pg_exec "${NAMESPACE}" "${STANDBY}" "SELECT id FROM post_restore_write" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+  [ "${replicated}" = "42" ] && break
+  sleep 2
+done
+assert_eq "post-restore writes replicate to the standby" "42" "${replicated}"
+
+end_suite
+print_summary

--- a/pg/tests/test-pgbackrest-restore.sh
+++ b/pg/tests/test-pgbackrest-restore.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
-# Live pgBackRest PITR restore-validation test (#38). Installs pg with pgbackrest +
-# validation against an in-cluster MinIO (TLS), takes a full backup, writes more data and
-# archives it as WAL, then runs the validation CronJob -- which restores the repo into a
-# THROWAWAY PostgreSQL, replays the archived WAL, and validates. Proves the backups are
-# actually restorable end to end. OPT-IN / standalone: `make -C pg test-pgbackrest-restore`.
+# Live pgBackRest PITR restore-validation test (#38) + live restore Job test (#226).
+# Installs pg with pgbackrest + validation against an in-cluster MinIO (TLS), takes a full
+# backup, writes more data and archives it as WAL, then:
+#   #38  runs the validation CronJob -- restores the repo into a THROWAWAY PostgreSQL,
+#        replays the archived WAL and validates, leaving the live cluster untouched.
+#   #226 performs a REAL disaster recovery with the chart's restore Job: scale to 0, wipe
+#        the data directory, `kubectl create job --from` the suspended restore CronJob,
+#        scale back up, and assert the data came back from S3.
+# Proves the backups are restorable end to end AND that the documented restore runbook
+# works. OPT-IN / standalone: `make -C pg test-pgbackrest-restore`.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -17,7 +22,7 @@ FULLNAME=$(resolve_fullname "${RELEASE}" "${CHART_DIR}" "${SCRIPT_DIR}/values-pg
 CERTDIR="$(mktemp -d)"
 trap 'rm -rf "${CERTDIR}"' EXIT
 
-begin_suite "pgBackRest PITR restore-validation (#38)"
+begin_suite "pgBackRest PITR restore-validation (#38) + live restore Job (#226)"
 
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 
@@ -77,12 +82,16 @@ kubectl run mc-setup -n "${NAMESPACE}" --restart=Never --image=minio/mc:RELEASE.
 kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/mc-setup -n "${NAMESPACE}" --timeout=120s
 kubectl delete pod mc-setup -n "${NAMESPACE}" --wait=false
 
-echo "Installing pg chart with pgbackrest + PITR validation enabled..."
+echo "Installing pg chart with pgbackrest + PITR validation + restore Job enabled..."
+# restore.enabled is on from the start: the resource it renders is INERT (a suspended
+# CronJob), which is the point -- an operator can leave it enabled and clone it when
+# disaster strikes, without a helm upgrade during the incident.
 helm upgrade --install "${RELEASE}" "${CHART_DIR}" -n "${NAMESPACE}" \
   -f "${SCRIPT_DIR}/values-pgbackrest-minio.yaml" \
   --set pgbackrest.validation.enabled=true \
   --set pgbackrest.validation.recoveryTimeout=240 \
   --set pgbackrest.validation.backoffLimit=0 \
+  --set pgbackrest.restore.enabled=true \
   --wait --timeout 8m
 wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 1 600
 POD="${FULLNAME}-0"
@@ -169,6 +178,89 @@ assert_contains "#38: WAL replay restored the post-backup table (not just the ba
 # --- the live cluster is untouched: validation restored into a throwaway, never here ---
 live_rows=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT count(*) FROM pitr_proof" "testuser" "testdb" 2>/dev/null || echo "")
 assert_eq "#38: live database is intact after validation (5000 rows)" "5000" "${live_rows}"
+
+# =============================================================================
+# #226: first-class restore Job -- a REAL restore over the live data PVC.
+# The #38 phase above proves the repository is restorable into a throwaway. This phase
+# exercises the path an operator actually walks in a disaster, exactly as the README
+# runbook documents it: scale to 0 -> `kubectl create job --from=cronjob/...` -> scale up.
+# No hand-built `kubectl run --overrides` restore pod anywhere.
+# =============================================================================
+
+# Inert until asked for: enabling restore.enabled must not restore anything by itself.
+suspended=$(kubectl get cronjob "${FULLNAME}-pgbackrest-restore" -n "${NAMESPACE}" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "")
+assert_eq "#226: restore CronJob is suspended (never fires on its own)" "true" "${suspended}"
+spawned=$(kubectl get jobs -n "${NAMESPACE}" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep -c "^${FULLNAME}-pgbackrest-restore" || true)
+assert_eq "#226: suspended restore CronJob spawned no Jobs on its own" "0" "${spawned}"
+
+# The restore must run under the repmgr SA (so s3.keyType=auto would work) with no API
+# token, and mount the LIVE PVC -- assert on the live object, not just the rendered YAML.
+restore_sa=$(kubectl get cronjob "${FULLNAME}-pgbackrest-restore" -n "${NAMESPACE}" -o jsonpath='{.spec.jobTemplate.spec.template.spec.serviceAccountName}')
+assert_eq "#226: restore runs as the repmgr ServiceAccount" "${FULLNAME}-repmgr" "${restore_sa}"
+restore_pvc=$(kubectl get cronjob "${FULLNAME}-pgbackrest-restore" -n "${NAMESPACE}" -o jsonpath='{.spec.jobTemplate.spec.template.spec.volumes[?(@.name=="data")].persistentVolumeClaim.claimName}')
+assert_eq "#226: restore mounts the live data PVC of replica 0" "data-${FULLNAME}-0" "${restore_pvc}"
+
+echo "Scaling the StatefulSet to 0 (the destructive step stays explicit and manual)..."
+kubectl scale statefulset "${FULLNAME}" -n "${NAMESPACE}" --replicas=0
+kubectl wait --for=delete pod/"${POD}" -n "${NAMESPACE}" --timeout=180s 2>/dev/null || true
+
+# Simulate the disaster the restore is FOR: destroy the data directory outright. Without
+# this, a latest-restore over an intact PGDATA would be a near no-op (--delta finds nothing
+# to copy) and would prove nothing. Runs as root because the files are owned by uid 101.
+# (This throwaway pod is exactly the kind of hand-built spec #226 removes from the restore
+# path -- here it is the disaster, not the recovery.)
+echo "Destroying the data directory to simulate total data loss..."
+kubectl delete pod pg-wipe -n "${NAMESPACE}" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+kubectl run pg-wipe -n "${NAMESPACE}" --restart=Never --image=busybox:1.37 \
+  --overrides="{\"spec\":{\"containers\":[{\"name\":\"pg-wipe\",\"image\":\"busybox:1.37\",\"command\":[\"sh\",\"-c\",\"rm -rf /data/pgdata && echo wiped\"],\"securityContext\":{\"runAsUser\":0},\"volumeMounts\":[{\"name\":\"data\",\"mountPath\":\"/data\"}]}],\"volumes\":[{\"name\":\"data\",\"persistentVolumeClaim\":{\"claimName\":\"data-${FULLNAME}-0\"}}]}}" >/dev/null
+wipe_rc=0
+kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/pg-wipe -n "${NAMESPACE}" --timeout=180s >/dev/null 2>&1 || wipe_rc=$?
+assert_eq "#226: data directory wiped (disaster simulated)" "0" "${wipe_rc}"
+kubectl delete pod pg-wipe -n "${NAMESPACE}" --wait=false >/dev/null 2>&1 || true
+
+# --- the runbook: one command, no --overrides ---
+echo "Running the chart's restore Job (kubectl create job --from=cronjob/...)..."
+kubectl delete job pgbr-restore -n "${NAMESPACE}" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+kubectl create job -n "${NAMESPACE}" pgbr-restore --from=cronjob/"${FULLNAME}-pgbackrest-restore"
+# Same complete-or-fail poll as the validation job above: `kubectl wait --for=condition=
+# complete` alone burns the whole timeout on a failed Job. backoffLimit=0 => one attempt.
+res_rc=2
+for _ in $(seq 1 120); do
+  succeeded=$(kubectl get job pgbr-restore -n "${NAMESPACE}" -o jsonpath='{.status.succeeded}' 2>/dev/null || echo "")
+  failed=$(kubectl get job pgbr-restore -n "${NAMESPACE}" -o jsonpath='{.status.failed}' 2>/dev/null || echo "")
+  [ "${succeeded:-0}" -ge 1 ] 2>/dev/null && { res_rc=0; break; }
+  [ "${failed:-0}" -ge 1 ] 2>/dev/null && { res_rc=1; break; }
+  sleep 3
+done
+res_logs=$(kubectl logs -n "${NAMESPACE}" job/pgbr-restore --tail=200 2>/dev/null || true)
+if [ "${res_rc}" -ne 0 ]; then
+  echo "  restore job did not complete; logs:"; printf '%s\n' "${res_logs}"
+fi
+assert_eq "#226: restore job completes" "0" "${res_rc}"
+assert_contains "#226: restore targeted the LIVE data directory" "${res_logs}" "/var/lib/postgresql/data/pgdata"
+assert_contains "#226: restore reports success" "${res_logs}" "pgBackRest restore succeeded"
+
+# --- scale back up: the StatefulSet's own startup performs recovery (WAL replay+promote) ---
+echo "Scaling back up: WAL replay + promotion happen under the normal chart entrypoint..."
+kubectl scale statefulset "${FULLNAME}" -n "${NAMESPACE}" --replicas=1
+up_rc=0
+wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 1 600 || up_rc=$?
+if [ "${up_rc}" -ne 0 ]; then
+  kubectl logs -n "${NAMESPACE}" "${POD}" -c postgresql --tail=80 2>/dev/null || true
+fi
+assert_eq "#226: restored cluster becomes ready after scale-up" "0" "${up_rc}"
+
+# The load-bearing assertion: pitr_proof existed ONLY in the wiped data directory and in
+# the S3 repo (base backup + archived WAL). Its 5000 rows being back means the Job really
+# restored from S3 and the scale-up really replayed WAL and promoted.
+restored_rows=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT count(*) FROM pitr_proof" "testuser" "testdb" 2>/dev/null || echo "")
+assert_eq "#226: data recovered from S3 after total data-directory loss (5000 rows)" "5000" "${restored_rows}"
+in_recovery=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT pg_is_in_recovery()" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+assert_eq "#226: restored cluster promoted to read-write (not left paused in recovery)" "f" "${in_recovery}"
+# A promoted PITR restore lands on a NEW timeline -- proof recovery actually ran here
+# rather than the old data directory somehow surviving the wipe.
+timeline=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT timeline_id FROM pg_control_checkpoint()" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+assert_gt "#226: recovery advanced the timeline (restore + replay really ran)" "${timeline:-0}" "1"
 
 end_suite
 print_summary

--- a/pg/tests/test-pgbackrest-restore.sh
+++ b/pg/tests/test-pgbackrest-restore.sh
@@ -19,68 +19,12 @@ NAMESPACE="${NAMESPACE:-pg-test-pgbackrest-restore}"
 RELEASE="${RELEASE:-pgbrv}"
 STANZA="db"
 FULLNAME=$(resolve_fullname "${RELEASE}" "${CHART_DIR}" "${SCRIPT_DIR}/values-pgbackrest-minio.yaml")
-CERTDIR="$(mktemp -d)"
-trap 'rm -rf "${CERTDIR}"' EXIT
 
 begin_suite "pgBackRest PITR restore-validation (#38) + live restore Job (#226)"
 
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
-
-# --- self-signed cert for MinIO TLS (pgbackrest verify-tls is off; cert just needs to exist) ---
-openssl req -x509 -newkey rsa:2048 -nodes -days 3650 -subj "/CN=minio" \
-  -addext "subjectAltName=DNS:minio" \
-  -keyout "${CERTDIR}/private.key" -out "${CERTDIR}/public.crt" >/dev/null 2>&1
-kubectl create secret generic minio-tls -n "${NAMESPACE}" \
-  --from-file=public.crt="${CERTDIR}/public.crt" --from-file=private.key="${CERTDIR}/private.key" \
-  --dry-run=client -o yaml | kubectl apply -f -
-kubectl create secret generic s3-backup-creds -n "${NAMESPACE}" \
-  --from-literal=access-key-id=minioadmin --from-literal=secret-access-key=minioadmin \
-  --dry-run=client -o yaml | kubectl apply -f -
-
-echo "Deploying MinIO (TLS on :9000, Service exposes :443 -> 9000)..."
-kubectl apply -n "${NAMESPACE}" -f - <<'MINIO'
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: minio
-spec:
-  replicas: 1
-  selector: { matchLabels: { app: minio } }
-  template:
-    metadata: { labels: { app: minio } }
-    spec:
-      containers:
-        - name: minio
-          image: minio/minio:RELEASE.2025-02-18T16-25-55Z
-          args: ["server", "/data", "--certs-dir", "/certs"]
-          env:
-            - { name: MINIO_ROOT_USER, value: minioadmin }
-            - { name: MINIO_ROOT_PASSWORD, value: minioadmin }
-          ports: [{ containerPort: 9000 }]
-          volumeMounts:
-            - { name: certs, mountPath: /certs, readOnly: true }
-          readinessProbe:
-            httpGet: { path: /minio/health/ready, port: 9000, scheme: HTTPS }
-            initialDelaySeconds: 5
-            periodSeconds: 5
-      volumes:
-        - name: certs
-          secret: { secretName: minio-tls, defaultMode: 0444 }
----
-apiVersion: v1
-kind: Service
-metadata: { name: minio }
-spec:
-  selector: { app: minio }
-  ports: [{ port: 443, targetPort: 9000 }]
-MINIO
-wait_for_deployment_ready "${NAMESPACE}" "minio" 180
-
-echo "Creating bucket pgbackrest-test..."
-kubectl run mc-setup -n "${NAMESPACE}" --restart=Never --image=minio/mc:RELEASE.2024-11-21T17-21-54Z \
-  --command -- sh -c "mc --insecure alias set s3 https://minio:443 minioadmin minioadmin && mc --insecure mb s3/pgbackrest-test || true"
-kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/mc-setup -n "${NAMESPACE}" --timeout=120s
-kubectl delete pod mc-setup -n "${NAMESPACE}" --wait=false
+# MinIO + the S3 credential Secret + the bucket (shared with the multi-replica suite).
+deploy_minio "${NAMESPACE}"
 
 echo "Installing pg chart with pgbackrest + PITR validation + restore Job enabled..."
 # restore.enabled is on from the start: the resource it renders is INERT (a suspended

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -1552,6 +1552,89 @@ assert_contains "#38: targetType without target fails fast" "${pgbr_val_badtarge
 pgbr_val_badtype=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.validation.enabled=true --set pgbackrest.validation.targetType=bogus 2>&1 || true)
 assert_contains "#38: invalid targetType rejected" "${pgbr_val_badtype}" "must be one of"
 
+# #226: first-class PITR restore resource -- replaces the hand-built `kubectl run
+# --overrides` runbook. Restores over the LIVE data PVC (contrast #38, which restores into a
+# throwaway) and never starts postgres: scaling the StatefulSet back up performs recovery.
+assert_not_contains "#226: nothing rendered when restore is disabled (default)" "${pgbr_noval}" "component: pgbackrest-restore"
+assert_not_contains "#226: restore.sh absent from the configmap when restore disabled" "${pgbr_noscript}" "restore.sh:"
+pgbr_res=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --show-only templates/pgbackrest-restore-job.yaml 2>&1)
+# Default mode is the suspended CronJob: `kubectl create job --from` clones it on demand.
+assert_contains "#226: default mode renders a CronJob" "${pgbr_res}" "kind: CronJob"
+assert_contains "#226: restore CronJob name is stable for kubectl create job --from" "${pgbr_res}" "name: test-pg-pgbackrest-restore"
+# Load-bearing safety: enabling the feature must never restore anything by itself.
+assert_contains "#226: restore CronJob is suspended" "${pgbr_res}" "suspend: true"
+assert_contains "#226: restore CronJob schedule can never fire (Feb 31)" "${pgbr_res}" 'schedule: "0 0 31 2 \*"'
+# The whole point: the live PVC + the repo config, mounted by the chart rather than by hand.
+assert_contains "#226: mounts the live data PVC of replica 0" "${pgbr_res}" "claimName: data-test-pg-0"
+assert_contains "#226: mounts the pgbackrest ConfigMap (repo settings + pg1-path)" "${pgbr_res}" "mountPath: /etc/pgbackrest/pgbackrest.conf"
+# pg1-path in the mounted conf is ALREADY the live PGDATA, so (unlike #38) there must be no
+# pg1-path override redirecting the restore somewhere else.
+assert_not_contains "#226: no pg1-path override (the mounted conf already targets live PGDATA)" "${pgbr_res}" "PGBACKREST_PG1_PATH"
+assert_contains "#226: PGDATA is the live data directory" "${pgbr_res}" "value: /var/lib/postgresql/data/pgdata"
+assert_contains "#226: runs the mounted restore.sh" "${pgbr_res}" "/scripts/restore.sh"
+assert_contains "#226: mounts restore.sh from the configmap" "${pgbr_res}" "key: restore.sh"
+# Identity + security context inherited from the chart (the #38 plumbing).
+assert_contains "#226: uses the repmgr image" "${pgbr_res}" "cagriekin/repmgr"
+assert_contains "#226: reuses the postgresql/repmgr ServiceAccount (workload identity)" "${pgbr_res}" "serviceAccountName: test-pg-repmgr"
+assert_contains "#226: makes no API calls (no SA token)" "${pgbr_res}" "automountServiceAccountToken: false"
+assert_contains "#226: postgresql pod securityContext (fsGroup 103)" "${pgbr_res}" "fsGroup: 103"
+assert_contains "#226: postgresql container securityContext (uid 101)" "${pgbr_res}" "runAsUser: 101"
+assert_contains "#226: keyType=shared wires the static S3 key from the secret" "${pgbr_res}" "name: PGBACKREST_REPO1_S3_KEY"
+assert_contains "#226: one pod attempt by default (no auto-retry over a half-written PGDATA)" "${pgbr_res}" "backoffLimit: 0"
+# The restore script itself lives in the pgbackrest ConfigMap, gated on restore.enabled.
+pgbr_res_script=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --show-only templates/pgbackrest-configmap.yaml 2>&1)
+assert_contains "#226: restore.sh present in the configmap when enabled" "${pgbr_res_script}" "restore.sh:"
+assert_contains "#226: script restores with --delta" "${pgbr_res_script}" "\-\-delta"
+assert_contains "#226: script refuses to restore over a running postmaster" "${pgbr_res_script}" "postmaster.pid"
+# It must NOT start postgres -- recovery happens on scale-up, under the chart entrypoint.
+assert_not_contains "#226: script never starts postgres (pg_ctl start)" "${pgbr_res_script}" "pg_ctl -D"
+assert_contains "#226: script puts the PG bin dir on PATH (pg_controldata is not on the default PATH)" "${pgbr_res_script}" "/usr/lib/postgresql"
+# mode: job renders a bare Job (for `helm template -s ... | kubectl apply`), with a
+# nameSuffix escape hatch because Jobs are immutable.
+pgbr_res_job=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set pgbackrest.restore.mode=job --show-only templates/pgbackrest-restore-job.yaml 2>&1)
+assert_contains "#226: mode=job renders a Job" "${pgbr_res_job}" "kind: Job"
+assert_not_contains "#226: mode=job renders no CronJob wrapper" "${pgbr_res_job}" "kind: CronJob"
+assert_not_contains "#226: mode=job has no suspend field" "${pgbr_res_job}" "suspend:"
+pgbr_res_suffix=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set pgbackrest.restore.mode=job --set pgbackrest.restore.nameSuffix=attempt2 --show-only templates/pgbackrest-restore-job.yaml 2>&1)
+assert_contains "#226: nameSuffix makes a rerun a distinct Job" "${pgbr_res_suffix}" "name: test-pg-pgbackrest-restore-attempt2"
+# ...but the CronJob name must stay stable so the runbook command never changes.
+pgbr_res_cj_suffix=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set pgbackrest.restore.nameSuffix=attempt2 --show-only templates/pgbackrest-restore-job.yaml 2>&1)
+assert_contains "#226: nameSuffix is ignored in cronjob mode (stable --from target)" "${pgbr_res_cj_suffix}" "name: test-pg-pgbackrest-restore"
+assert_not_contains "#226: cronjob name carries no suffix" "${pgbr_res_cj_suffix}" "restore-attempt2"
+# PITR target / backup-set / force / podOrdinal wiring.
+pgbr_res_pitr=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set pgbackrest.restore.targetType=time --set-string 'pgbackrest.restore.target=2026-03-22 12:00:00+00' --set pgbackrest.restore.backupSet=20260322-010002F --set pgbackrest.restore.force=true --set pgbackrest.restore.podOrdinal=1 --show-only templates/pgbackrest-restore-job.yaml 2>&1)
+assert_contains "#226: PITR target value wired into the env" "${pgbr_res_pitr}" "2026-03-22 12:00:00+00"
+assert_contains "#226: backupSet wired into the env" "${pgbr_res_pitr}" "20260322-010002F"
+assert_contains "#226: force wired into the env" "${pgbr_res_pitr}" 'name: FORCE'
+assert_contains "#226: podOrdinal selects that replica's PVC" "${pgbr_res_pitr}" "claimName: data-test-pg-1"
+# A targeted restore must promote, not pause (default recovery_target_action is `pause`).
+assert_contains "#226: targeted restore promotes (not pause)" "${pgbr_res_script}" "target-action=promote"
+# Guards: target required with targetType (template fail; a schema if/then is not portable
+# to helm 3.x), enum-checked targetType/mode, and the two prerequisites for restoring at all.
+pgbr_res_badtarget=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set pgbackrest.restore.targetType=time 2>&1 || true)
+assert_contains "#226: targetType without target fails fast" "${pgbr_res_badtarget}" "restore.target is required"
+pgbr_res_badtype=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set pgbackrest.restore.targetType=bogus 2>&1 || true)
+assert_contains "#226: invalid targetType rejected" "${pgbr_res_badtype}" "must be one of"
+pgbr_res_badmode=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set pgbackrest.restore.mode=bogus 2>&1 || true)
+assert_contains "#226: invalid mode rejected" "${pgbr_res_badmode}" "must be one of"
+pgbr_res_nopersist=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set postgresql.persistence.enabled=false 2>&1 || true)
+assert_contains "#226: restore without persistence fails fast (no PVC to restore into)" "${pgbr_res_nopersist}" "requires postgresql.persistence.enabled"
+pgbr_res_nopgbr=$(helm template test-pg "${CHART_DIR}" --set pgbackrest.restore.enabled=true 2>&1 || true)
+assert_contains "#226: restore without pgbackrest fails fast" "${pgbr_res_nopgbr}" "requires pgbackrest.enabled"
+# keyType=auto must NOT emit static keys (relies on the SA's workload identity).
+pgbr_res_auto=$(helm template test-pg "${CHART_DIR}" --set pgbackrest.enabled=true --set repmgr.enabled=true --set pgbackrest.s3.endpoint=https://s3.test --set pgbackrest.s3.bucket=b --set pgbackrest.s3.keyType=auto --set pgbackrest.restore.enabled=true --show-only templates/pgbackrest-restore-job.yaml 2>&1)
+assert_not_contains "#226: keyType=auto emits no static S3 key env" "${pgbr_res_auto}" "PGBACKREST_REPO1_S3_KEY"
+# The restore has to land where the data PVC can attach: a tainted/labelled database node
+# pool the postgresql pods tolerate must be tolerated here too, or the restore sits Pending
+# mid-incident. postgresql.affinity is deliberately not inherited (it spreads replicas).
+pgbr_res_sched=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set postgresql.nodeSelector.workload=db --set 'postgresql.tolerations[0].key=db' --set 'postgresql.tolerations[0].operator=Exists' --set 'postgresql.tolerations[0].effect=NoSchedule' --show-only templates/pgbackrest-restore-job.yaml 2>&1)
+assert_contains "#226: inherits postgresql.nodeSelector" "${pgbr_res_sched}" "workload: db"
+assert_contains "#226: inherits postgresql.tolerations" "${pgbr_res_sched}" "effect: NoSchedule"
+assert_not_contains "#226: does not inherit postgresql.affinity (replica spreading is meaningless here)" "${pgbr_res_sched}" "affinity:"
+# Repo encryption passphrase reaches the restore (an encrypted repo is undecryptable without it).
+pgbr_res_enc=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set pgbackrest.repoEncryption.enabled=true --set pgbackrest.repoEncryption.existingSecret.name=cipher --show-only templates/pgbackrest-restore-job.yaml 2>&1)
+assert_contains "#226: repo-encryption passphrase wired into the restore" "${pgbr_res_enc}" "PGBACKREST_REPO1_CIPHER_PASS"
+
 # #27: the backup + backup-validation Jobs run under a dedicated no-RBAC SA, not
 # the namespace default.
 backup_sa=$(helm template test-pg "${CHART_DIR}" ${backup_val_args} --show-only templates/backup-serviceaccount.yaml 2>&1)

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -1621,7 +1621,11 @@ assert_contains "#226: invalid mode rejected" "${pgbr_res_badmode}" "must be one
 # time rather than by the API server mid-incident. The pattern also permits "" (the
 # default): helm validates values.yaml against the schema on every render.
 pgbr_res_badsuffix=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set pgbackrest.restore.mode=job --set pgbackrest.restore.nameSuffix=Attempt_2 2>&1 || true)
-assert_contains "#226: non-DNS-1123 nameSuffix rejected" "${pgbr_res_badsuffix}" "does not match pattern"
+# Match only "match pattern": helm 3.x (gojsonschema) reports "Does not match pattern" while
+# helm 4 (santhosh-tekuri) reports "'Attempt_2' does not match pattern" -- CI pins helm 3.14,
+# so a case-sensitive "does not match pattern" passes locally on helm 4 and fails there.
+assert_contains "#226: non-DNS-1123 nameSuffix rejected" "${pgbr_res_badsuffix}" "match pattern"
+assert_contains "#226: nameSuffix rejection names the offending value" "${pgbr_res_badsuffix}" "nameSuffix"
 pgbr_res_nopersist=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set postgresql.persistence.enabled=false 2>&1 || true)
 assert_contains "#226: restore without persistence fails fast (no PVC to restore into)" "${pgbr_res_nopersist}" "requires postgresql.persistence.enabled"
 pgbr_res_nopgbr=$(helm template test-pg "${CHART_DIR}" --set pgbackrest.restore.enabled=true 2>&1 || true)

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -1617,6 +1617,11 @@ pgbr_res_badtype=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbac
 assert_contains "#226: invalid targetType rejected" "${pgbr_res_badtype}" "must be one of"
 pgbr_res_badmode=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set pgbackrest.restore.mode=bogus 2>&1 || true)
 assert_contains "#226: invalid mode rejected" "${pgbr_res_badmode}" "must be one of"
+# nameSuffix lands in metadata.name, so a non-DNS-1123 value must be rejected at render
+# time rather than by the API server mid-incident. The pattern also permits "" (the
+# default): helm validates values.yaml against the schema on every render.
+pgbr_res_badsuffix=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set pgbackrest.restore.mode=job --set pgbackrest.restore.nameSuffix=Attempt_2 2>&1 || true)
+assert_contains "#226: non-DNS-1123 nameSuffix rejected" "${pgbr_res_badsuffix}" "does not match pattern"
 pgbr_res_nopersist=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set postgresql.persistence.enabled=false 2>&1 || true)
 assert_contains "#226: restore without persistence fails fast (no PVC to restore into)" "${pgbr_res_nopersist}" "requires postgresql.persistence.enabled"
 pgbr_res_nopgbr=$(helm template test-pg "${CHART_DIR}" --set pgbackrest.restore.enabled=true 2>&1 || true)

--- a/pg/tests/values-pgbackrest-minio-ha.yaml
+++ b/pg/tests/values-pgbackrest-minio-ha.yaml
@@ -1,0 +1,87 @@
+# Fixture for the multi-replica pgBackRest restore test (#226): primary + one streaming
+# standby, backed by an in-cluster MinIO (TLS) instead of AWS S3 -- path-style addressing +
+# verify-tls off for the self-signed endpoint. Identical to values-pgbackrest-minio.yaml
+# except for replicaCount, which is the whole point: after a PITR restore of replica 0, the
+# standby's PVC still holds PRE-restore data on the old timeline, and the test asserts how
+# it rejoins.
+postgresql:
+  image:
+    repository: postgres
+    tag: 18.1-trixie
+    pullPolicy: IfNotPresent
+
+  # 1 = primary + 1 standby (the chart adds the primary to replicaCount).
+  replicaCount: 1
+  database: testdb
+  username: testuser
+
+  persistence:
+    enabled: true
+    size: 1Gi
+
+  podDisruptionBudget:
+    enabled: false
+
+  lifecycle:
+    postStart:
+      additionalCommands: ""
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+
+repmgr:
+  image:
+    repository: cagriekin/repmgr
+    tag: trixie-5.5.0-27
+    pullPolicy: IfNotPresent
+  enabled: true
+  failoverMode: repmgrd
+  username: repmgr
+  database: repmgr
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+pgpool:
+  enabled: false
+
+prometheusExporter:
+  enabled: false
+
+backup:
+  enabled: false
+
+pgbackrest:
+  enabled: true
+  stanza: db
+  s3:
+    endpoint: minio   # in-cluster MinIO Service (TLS on :443 -> targetPort 9000)
+    bucket: pgbackrest-test
+    region: us-east-1
+    prefix: pgbackrest
+    keyType: shared
+    uriStyle: path    # MinIO/Ceph addressing
+    verifyTls: false  # self-signed MinIO cert
+  existingSecret:
+    name: s3-backup-creds
+    accessKeyIdKey: access-key-id
+    secretAccessKeyKey: secret-access-key
+  retention:
+    full: 4
+    diff: 14
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi

--- a/pg/values.schema.json
+++ b/pg/values.schema.json
@@ -177,7 +177,11 @@
             "backupSet": { "type": "string" },
             "force": { "type": "boolean" },
             "podOrdinal": { "type": "integer", "minimum": 0 },
-            "nameSuffix": { "type": "string" },
+            "nameSuffix": {
+              "type": "string",
+              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "description": "Appended to the Job name (mode: job), so it must be a valid DNS-1123 label segment; empty = no suffix."
+            },
             "activeDeadlineSeconds": { "type": "integer" },
             "backoffLimit": { "type": "integer" }
           }

--- a/pg/values.schema.json
+++ b/pg/values.schema.json
@@ -160,6 +160,27 @@
             "activeDeadlineSeconds": { "type": "integer" },
             "backoffLimit": { "type": "integer" }
           }
+        },
+        "restore": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "mode": {
+              "enum": ["cronjob", "job"],
+              "description": "cronjob = suspended CronJob to clone with `kubectl create job --from`; job = bare Job to render on demand with `helm template -s`."
+            },
+            "targetType": {
+              "enum": ["", "time", "xid", "name", "lsn"],
+              "description": "PITR target type (pgbackrest --type); empty restores the latest backup + replays all WAL. restore.target is required when set."
+            },
+            "target": { "type": "string" },
+            "backupSet": { "type": "string" },
+            "force": { "type": "boolean" },
+            "podOrdinal": { "type": "integer", "minimum": 0 },
+            "nameSuffix": { "type": "string" },
+            "activeDeadlineSeconds": { "type": "integer" },
+            "backoffLimit": { "type": "integer" }
+          }
         }
       }
     }

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -848,6 +848,68 @@ pgbackrest:
         cpu: "1"
         memory: 1Gi
 
+  # First-class PITR restore (#226). Opt-in, and unlike `validation` above this restores
+  # over the LIVE data directory of replica 0 -- it exists so a real disaster recovery is a
+  # `kubectl create job` instead of a hand-built `kubectl run --overrides` pod spec. The
+  # resource carries everything a restore needs (repmgr SA for s3.keyType=auto, postgresql
+  # security contexts, the data PVC + pgbackrest ConfigMap mounts, S3 / repo-encryption
+  # credentials) and runs `pgbackrest restore --delta`; it never starts postgres, so WAL
+  # replay + promotion happen when you scale the StatefulSet back up.
+  #
+  # Enabling this renders an INERT resource -- a suspended CronJob, or a Job you render on
+  # demand -- it does not restore anything by itself. The destructive scale down/up stays
+  # an explicit operator action. See the README, "Point-in-Time Recovery".
+  restore:
+    enabled: false
+    # How the restore is delivered:
+    #   cronjob (default) -- a suspended CronJob to clone on demand:
+    #       kubectl create job --from=cronjob/<fullname>-pgbackrest-restore restore-now
+    #     The resource belongs to the release, so GitOps/ArgoCD sees no stray object; a
+    #     point-in-time target has to be set in values (helm upgrade) before cloning.
+    #   job -- a bare Job, for rendering one off with the target passed inline:
+    #       helm template <release> <chart> -f <release-values> \
+    #         --set pgbackrest.restore.enabled=true --set pgbackrest.restore.mode=job \
+    #         -s templates/pgbackrest-restore-job.yaml | kubectl apply -f -
+    #     Nothing is baked into the release, but the object is not release-managed either
+    #     (ArgoCD may report/prune it), and Jobs are immutable -- see nameSuffix.
+    mode: cronjob
+    # PITR target. Empty (default) restores the latest backup set and replays all archived
+    # WAL to the end of the stream (the disaster-recovery case). For a point in time set:
+    #   targetType: time   target: "2026-03-22 12:00:00+00"
+    # targetType is one of: "" (latest) | time | xid | name | lsn (pgbackrest --type).
+    # A target always implies --target-action=promote.
+    targetType: ""
+    target: ""
+    # pgbackrest --set: restore a SPECIFIC backup set (label from `pgbackrest info`, e.g.
+    # "20260322-010002F") instead of the latest. Empty = latest.
+    backupSet: ""
+    # pgbackrest --force: restore even though $PGDATA/postmaster.pid exists. Needed only
+    # when the cluster crashed and left a stale pid file behind -- pgbackrest otherwise
+    # refuses to restore over what may be a running cluster, which is the safety interlock
+    # that lets this Job run with no Kubernetes API access at all. Leave false unless you
+    # have confirmed every postgresql pod is gone.
+    force: false
+    # Ordinal of the replica whose PVC (data-<fullname>-<ordinal>) is restored into.
+    # Leave 0: replica 0 becomes the restored primary and repmgr re-clones the standbys.
+    podOrdinal: 0
+    # mode: job only -- appended to the Job name so a second attempt does not collide with
+    # the completed first one (Jobs are immutable). Ignored in cronjob mode, where the name
+    # must stay stable for `kubectl create job --from`.
+    nameSuffix: ""
+    # Generous by default: a real restore moves the whole database over the network. The
+    # Job is killed at this deadline even mid-restore (rerun it; --delta resumes cheaply).
+    activeDeadlineSeconds: 21600  # 6 hours
+    # 0 = one pod attempt. A failed restore leaves PGDATA half-written, so an automatic
+    # retry would race the operator's diagnosis -- and failures surface immediately.
+    backoffLimit: 0
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+
 networkPolicy:
   enabled: false
   postgresql:

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -24,6 +24,10 @@ detail.
   `restore.force`, with fail-fast guards for the target/targetType pair and for the
   `pgbackrest.enabled` + `postgresql.persistence.enabled` prerequisites.
 
+  Standbys need no extra step: the restored primary returns on a new timeline, and each
+  standby's init container detects the mismatch and re-clones itself from it (verified in
+  the pg chart's `test-pgbackrest-restore-ha` suite, which covers these shared templates).
+
 ### Changed
 
 - The README's Point-in-Time Recovery runbook is now that four-command flow; the

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -11,7 +11,8 @@ detail.
 - **`pgbackrest.restore.*` — a first-class PITR restore resource** (#226). Replaces the
   hand-built `kubectl run --overrides='{…}'` restore pod (~30 lines of inline JSON) with a
   chart-rendered one: scale to 0 →
-  `kubectl create job --from=cronjob/<fullname>-pgbackrest-restore` → scale back up. It
+  `kubectl create job --from=cronjob/<fullname>-pgbackrest-restore` → wait for the Job to
+  complete → scale back up. It
   carries the `-repmgr` ServiceAccount (so `s3.keyType: auto` works, API token unmounted),
   the postgresql security contexts, the `data-<fullname>-0` PVC and pgbackrest ConfigMap
   mounts, the S3 / repo-encryption credentials, and `pgbackrest restore --delta`.

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,34 @@
 # pgvector chart changelog
 
+## 1.7.0 - 2026-07-31
+
+Inherited from pg's symlinked templates (`pgbackrest-restore-job.yaml`,
+`pgbackrest-configmap.yaml`). See the [pg 1.7.0 changelog](../pg/CHANGELOG.md) for the full
+detail.
+
+### Added
+
+- **`pgbackrest.restore.*` — a first-class PITR restore resource** (#226). Replaces the
+  hand-built `kubectl run --overrides='{…}'` restore pod (~30 lines of inline JSON) with a
+  chart-rendered one: scale to 0 →
+  `kubectl create job --from=cronjob/<fullname>-pgbackrest-restore` → scale back up. It
+  carries the `-repmgr` ServiceAccount (so `s3.keyType: auto` works, API token unmounted),
+  the postgresql security contexts, the `data-<fullname>-0` PVC and pgbackrest ConfigMap
+  mounts, the S3 / repo-encryption credentials, and `pgbackrest restore --delta`.
+
+  Enabling it restores nothing: it renders an inert resource (by default a suspended
+  CronJob that can never fire), so it can be left on and cloned when needed. It never
+  starts PostgreSQL — WAL replay and promotion happen on scale-up. `restore.mode: job`
+  renders a bare Job instead, for passing a point-in-time target inline via
+  `helm template -s`. Supports `restore.targetType`/`target`, `restore.backupSet` and
+  `restore.force`, with fail-fast guards for the target/targetType pair and for the
+  `pgbackrest.enabled` + `postgresql.persistence.enabled` prerequisites.
+
+### Changed
+
+- The README's Point-in-Time Recovery runbook is now that four-command flow; the
+  `kubectl run --overrides` pod spec is gone.
+
 ## 1.6.0 - 2026-07-30
 
 Inherited from pg's symlinked templates (`statefulset.yaml`, `postgresql-configmap.yaml`,

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus repmgr replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 1.6.0
+version: 1.7.0
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -885,6 +885,18 @@ helm install my-pgvector cagriekin/pgvector \
 | `pgbackrest.validation.activeDeadlineSeconds` | Validation Job timeout | `3600` |
 | `pgbackrest.validation.backoffLimit` | Validation Job backoff limit | `1` |
 | `pgbackrest.validation.resources.*` | Validation Job resource requests/limits | `200m`/`256Mi` … `1`/`1Gi` |
+| `pgbackrest.restore.enabled` | Render the first-class PITR restore resource (#226) — restores over the **live** data PVC. Inert until you clone/apply it | `false` |
+| `pgbackrest.restore.mode` | `cronjob` (suspended CronJob, clone with `kubectl create job --from`) \| `job` (bare Job, render with `helm template -s`) | `cronjob` |
+| `pgbackrest.restore.targetType` | PITR target type (`pgbackrest --type`): `""` (latest) \| `time` \| `xid` \| `name` \| `lsn`. `target` is required when set | `""` |
+| `pgbackrest.restore.target` | PITR target value for the type above (e.g. `2026-03-22 12:00:00+00`); implies `--target-action=promote` | `""` |
+| `pgbackrest.restore.backupSet` | `pgbackrest --set`: restore a specific backup set label from `pgbackrest info` instead of the latest | `""` |
+| `pgbackrest.restore.force` | `pgbackrest --force`: restore despite a **stale** `postmaster.pid` left by a crash. Leave `false` unless every postgresql pod is confirmed gone | `false` |
+| `pgbackrest.restore.podOrdinal` | Ordinal of the replica PVC (`data-<fullname>-<n>`) restored into; leave `0` | `0` |
+| `pgbackrest.restore.nameSuffix` | `mode: job` only — appended to the Job name so a retry does not collide with the completed Job | `""` |
+| `pgbackrest.restore.activeDeadlineSeconds` | Restore Job timeout | `21600` |
+| `pgbackrest.restore.backoffLimit` | Restore Job backoff limit (0 = one attempt; a half-written PGDATA should not be retried automatically) | `0` |
+| `pgbackrest.restore.resources.*` | Restore Job resource requests/limits | `200m`/`256Mi` … `1`/`1Gi` |
+| _scheduling_ | The restore pod inherits `postgresql.nodeSelector` and `postgresql.tolerations` so it lands where the data PVC can attach (`postgresql.affinity` is not inherited) | — |
 
 ### Keyless backups (cloud workload identity)
 
@@ -915,43 +927,78 @@ kubectl exec -it my-pgvector-0 -- pgbackrest --stanza=db info
 
 ### Point-in-Time Recovery
 
-PITR requires manual intervention:
+Set `pgbackrest.restore.enabled=true` and the chart renders a ready-made restore resource
+(#226) carrying everything a restore needs — the `-repmgr` ServiceAccount (so
+`s3.keyType: auto` works, with its API token unmounted), the postgresql security contexts,
+the `data-<fullname>-0` PVC and `<fullname>-pgbackrest` ConfigMap mounts, the S3 /
+repo-encryption credentials, and `pgbackrest restore --delta`. Nothing to hand-build.
+
+Enabling it is safe: what it renders is **inert** — by default a *suspended* CronJob that
+can never fire. It restores only when you clone it. Leave it enabled so a disaster does not
+also require a `helm upgrade`.
+
+The restore never starts PostgreSQL. Recovery (WAL replay + promotion) happens when you
+scale the StatefulSet back up, under the normal chart entrypoint — so the destructive
+scale down/up stays an explicit, manual decision:
 
 ```bash
-# 1. Scale down the StatefulSet
+# 1. Stop the cluster. pgbackrest refuses to restore while postmaster.pid exists, so this
+#    is not optional -- wait for the pods to actually terminate.
 kubectl scale statefulset my-pgvector --replicas=0
+kubectl wait --for=delete pod/my-pgvector-0 --timeout=5m
 
-# 2. Run a restore pod that mounts the data PVC AND the pgbackrest ConfigMap.
-# The repo settings (repo1-type=s3, endpoint, bucket, path) and pg1-path live ONLY
-# in the <fullname>-pgbackrest ConfigMap, so it MUST be mounted at
-# /etc/pgbackrest/pgbackrest.conf or pgbackrest fails with "requires option: pg1-path"
-# and would default to a local posix repo (never finding the S3 backup).
-# Replace YOUR_PGBACKREST_SECRET with your pgbackrest.existingSecret.name.
-# The securityContext (101:103) matches the chart so restored files are owned
-# correctly and the pod is accepted under restricted PodSecurity / OpenShift SCC.
-# keyType: auto (IRSA / Workload Identity)? Drop the env block, add
-# "serviceAccountName": "my-pgvector-repmgr" to the spec (that SA carries the
-# cloud-role annotation; the namespace default SA does not), and ensure the pod lands
-# where your IRSA/WI webhook injects the token; pgbackrest then uses the credential chain.
-kubectl run pg-restore --rm -it \
-  --image=cagriekin/repmgr:trixie-5.5.0-27 \
-  --overrides='{ "spec": { "securityContext": { "runAsUser": 101, "runAsGroup": 103, "fsGroup": 103, "runAsNonRoot": true, "seccompProfile": { "type": "RuntimeDefault" } }, "containers": [{ "name": "restore", "image": "cagriekin/repmgr:trixie-5.5.0-27", "command": ["bash"], "stdin": true, "tty": true, "securityContext": { "allowPrivilegeEscalation": false, "capabilities": { "drop": ["ALL"] } }, "volumeMounts": [{ "name": "data", "mountPath": "/var/lib/postgresql/data" }, { "name": "pgbackrest-config", "mountPath": "/etc/pgbackrest/pgbackrest.conf", "subPath": "pgbackrest.conf", "readOnly": true }], "env": [{ "name": "PGBACKREST_REPO1_S3_KEY", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "access-key-id" } } }, { "name": "PGBACKREST_REPO1_S3_KEY_SECRET", "valueFrom": { "secretKeyRef": { "name": "YOUR_PGBACKREST_SECRET", "key": "secret-access-key" } } }] }], "volumes": [{ "name": "data", "persistentVolumeClaim": { "claimName": "data-my-pgvector-0" } }, { "name": "pgbackrest-config", "configMap": { "name": "my-pgvector-pgbackrest" } }] } }'
+# 2. Restore (stanza = pgbackrest.stanza, default "db").
+kubectl create job --from=cronjob/my-pgvector-pgbackrest-restore restore-now
+kubectl wait --for=condition=complete job/restore-now --timeout=30m
 
-# 3. Inside the restore pod, run (stanza = pgbackrest.stanza, default "db").
-# --type=time is REQUIRED with --target (pgbackrest rejects --target otherwise);
-# use --type=xid|name|lsn for other recovery targets. Leave the existing data dir in
-# place so --delta restores only changed files (a wiped PGDATA disables --delta).
-pgbackrest --stanza=db restore \
-  --type=time \
-  --target="2026-03-22 12:00:00+00" \
-  --target-action=promote \
-  --delta
-
-# 4. Scale back up
+# 3. Scale back up: the pods replay the archived WAL and promote.
 kubectl scale statefulset my-pgvector --replicas=2
 ```
 
-Repmgr will automatically rebuild standbys from the restored primary.
+With no target set this restores the **latest** backup set and replays all archived WAL —
+the disaster-recovery case. For a *point in time*, set the target first:
+
+```yaml
+pgbackrest:
+  restore:
+    enabled: true
+    targetType: time                     # "" (latest) | time | xid | name | lsn
+    target: "2026-03-22 12:00:00+00"     # required once targetType is set
+    # backupSet: "20260322-010002F"      # optional: pin a specific set from `pgbackrest info`
+```
+
+A target always implies `--target-action=promote`: PostgreSQL's default
+`recovery_target_action` is `pause`, which would leave the cluster in recovery, never
+accepting connections.
+
+`mode: job` renders a bare Job instead, for passing an arbitrary target inline without
+touching the release (useful when the values live in Git and you cannot wait for a commit):
+
+```bash
+helm get values my-pgvector > /tmp/v.yaml
+helm template my-pgvector cagriekin/pgvector -f /tmp/v.yaml \
+  --set pgbackrest.restore.enabled=true --set pgbackrest.restore.mode=job \
+  --set pgbackrest.restore.targetType=time \
+  --set-string 'pgbackrest.restore.target=2026-03-22 12:00:00+00' \
+  -s templates/pgbackrest-restore-job.yaml | kubectl apply -f -
+```
+
+Two caveats for this mode: the Job is not part of the release, so a GitOps controller may
+report or prune it; and Jobs are immutable, so a second attempt needs
+`--set pgbackrest.restore.nameSuffix=attempt2`.
+
+Repmgr rebuilds the standbys from the restored primary when they start. If a standby comes
+up on the pre-restore timeline instead of re-cloning, delete its PVC and pod so it clones
+fresh from the restored primary:
+
+```bash
+kubectl delete pvc data-my-pgvector-1 && kubectl delete pod my-pgvector-1
+```
+
+If the cluster **crashed** rather than being scaled down cleanly, a stale
+`postmaster.pid` is left in PGDATA and pgbackrest refuses to restore — the interlock that
+lets this Job run with no Kubernetes API access at all. Confirm every postgresql pod is
+gone, then set `pgbackrest.restore.force=true`.
 
 #### Agent mode: clear the stale leadership state before scaling up
 

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -987,9 +987,16 @@ Two caveats for this mode: the Job is not part of the release, so a GitOps contr
 report or prune it; and Jobs are immutable, so a second attempt needs
 `--set pgbackrest.restore.nameSuffix=attempt2`.
 
-Repmgr rebuilds the standbys from the restored primary when they start. If a standby comes
-up on the pre-restore timeline instead of re-cloning, delete its PVC and pod so it clones
-fresh from the restored primary:
+**Standbys rebuild themselves — no extra step.** A PITR restore leaves the restored primary
+on a *new* timeline, while each standby's PVC still holds pre-restore data on the old one. On
+scale-up the standby's init container detects exactly that (`Timeline mismatch (local: 1,
+primary: 2), re-cloning...`) and re-clones from the restored primary via `repmgr standby
+clone` (`pg_basebackup`), then resumes streaming on the new timeline. No PVC deletion, no
+operator action. This is verified end to end by `make -C pg test-pgbackrest-restore-ha`,
+which restores a primary out from under a live standby and asserts the pair comes back
+streaming.
+
+Only if a standby *does* get stuck on the old timeline, force a fresh clone by hand:
 
 ```bash
 kubectl delete pvc data-my-pgvector-1 && kubectl delete pod my-pgvector-1

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -951,19 +951,20 @@ kubectl wait --for=delete pod/my-pgvector-0 --timeout=5m
 kubectl create job --from=cronjob/my-pgvector-pgbackrest-restore restore-now
 kubectl wait --for=condition=complete job/restore-now --timeout=30m
 
-# 3. Scale back up: the pods replay the archived WAL and promote.
+# 3. CONFIRM the restore succeeded -- must print 1. Do not continue otherwise.
+#    (`--for=condition=complete` above only ever succeeds, so a failed attempt leaves it
+#    blocked until the timeout instead of returning; if it seems stuck, check here.)
+kubectl get job restore-now -o jsonpath='{.status.succeeded}{"\n"}'
+
+# 4. Only now scale back up: the pods replay the archived WAL and promote.
 kubectl scale statefulset my-pgvector --replicas=2
 ```
 
-`--for=condition=complete` only ever succeeds, so a **failed** restore leaves that wait
-blocked for the full timeout with no signal. `backoffLimit` is `0` (one pod attempt), so a
-failure shows up immediately in the Job status — if the wait seems stuck, check it rather
-than waiting out the clock, and do not scale up until the Job has actually completed:
-
-```bash
-kubectl get job restore-now -o jsonpath='{.status.failed}{"\n"}'   # 1 = the attempt failed
-kubectl logs job/restore-now                                        # why
-```
+**Do not skip step 3.** A failed restore leaves PGDATA half-written; scaling up onto it
+starts PostgreSQL against an incomplete data directory and turns a recoverable incident into
+data loss. `backoffLimit` is `0` (one pod attempt), so failure is final and immediate —
+diagnose with `kubectl logs job/restore-now`, fix the cause, delete the Job and create it
+again. Rerunning is safe: `--delta` re-restores from scratch.
 
 With no target set this restores the **latest** backup set and replays all archived WAL —
 the disaster-recovery case. For a *point in time*, set the target first:
@@ -1006,10 +1007,15 @@ operator action. This is verified end to end by `make -C pg test-pgbackrest-rest
 which restores a primary out from under a live standby and asserts the pair comes back
 streaming.
 
-Only if a standby *does* get stuck on the old timeline, force a fresh clone by hand:
+Only if a standby *does* get stuck on the old timeline, force a fresh clone by hand. Scale it
+away **before** deleting its PVC: deleting the PVC while its pod still exists leaves it
+`Terminating` behind the `pvc-protection` finalizer, and the recreated pod can re-bind that
+same volume — bringing the standby back on exactly the stale data you meant to discard.
 
 ```bash
-kubectl delete pvc data-my-pgvector-1 && kubectl delete pod my-pgvector-1
+kubectl scale statefulset my-pgvector --replicas=1              # remove the standby pod
+kubectl delete pvc data-my-pgvector-1                          # returns once it is really gone
+kubectl scale statefulset my-pgvector --replicas=2              # clones fresh from the primary
 ```
 
 If the cluster **crashed** rather than being scaled down cleanly, a stale

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -955,6 +955,16 @@ kubectl wait --for=condition=complete job/restore-now --timeout=30m
 kubectl scale statefulset my-pgvector --replicas=2
 ```
 
+`--for=condition=complete` only ever succeeds, so a **failed** restore leaves that wait
+blocked for the full timeout with no signal. `backoffLimit` is `0` (one pod attempt), so a
+failure shows up immediately in the Job status — if the wait seems stuck, check it rather
+than waiting out the clock, and do not scale up until the Job has actually completed:
+
+```bash
+kubectl get job restore-now -o jsonpath='{.status.failed}{"\n"}'   # 1 = the attempt failed
+kubectl logs job/restore-now                                        # why
+```
+
 With no target set this restores the **latest** backup set and replays all archived WAL —
 the disaster-recovery case. For a *point in time*, set the target first:
 

--- a/pgvector/templates/pgbackrest-restore-job.yaml
+++ b/pgvector/templates/pgbackrest-restore-job.yaml
@@ -1,0 +1,1 @@
+../../pg/templates/pgbackrest-restore-job.yaml

--- a/pgvector/values.schema.json
+++ b/pgvector/values.schema.json
@@ -177,7 +177,11 @@
             "backupSet": { "type": "string" },
             "force": { "type": "boolean" },
             "podOrdinal": { "type": "integer", "minimum": 0 },
-            "nameSuffix": { "type": "string" },
+            "nameSuffix": {
+              "type": "string",
+              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "description": "Appended to the Job name (mode: job), so it must be a valid DNS-1123 label segment; empty = no suffix."
+            },
             "activeDeadlineSeconds": { "type": "integer" },
             "backoffLimit": { "type": "integer" }
           }

--- a/pgvector/values.schema.json
+++ b/pgvector/values.schema.json
@@ -160,6 +160,27 @@
             "activeDeadlineSeconds": { "type": "integer" },
             "backoffLimit": { "type": "integer" }
           }
+        },
+        "restore": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "mode": {
+              "enum": ["cronjob", "job"],
+              "description": "cronjob = suspended CronJob to clone with `kubectl create job --from`; job = bare Job to render on demand with `helm template -s`."
+            },
+            "targetType": {
+              "enum": ["", "time", "xid", "name", "lsn"],
+              "description": "PITR target type (pgbackrest --type); empty restores the latest backup + replays all WAL. restore.target is required when set."
+            },
+            "target": { "type": "string" },
+            "backupSet": { "type": "string" },
+            "force": { "type": "boolean" },
+            "podOrdinal": { "type": "integer", "minimum": 0 },
+            "nameSuffix": { "type": "string" },
+            "activeDeadlineSeconds": { "type": "integer" },
+            "backoffLimit": { "type": "integer" }
+          }
         }
       }
     }

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -784,6 +784,68 @@ pgbackrest:
         cpu: "1"
         memory: 1Gi
 
+  # First-class PITR restore (#226). Opt-in, and unlike `validation` above this restores
+  # over the LIVE data directory of replica 0 -- it exists so a real disaster recovery is a
+  # `kubectl create job` instead of a hand-built `kubectl run --overrides` pod spec. The
+  # resource carries everything a restore needs (repmgr SA for s3.keyType=auto, postgresql
+  # security contexts, the data PVC + pgbackrest ConfigMap mounts, S3 / repo-encryption
+  # credentials) and runs `pgbackrest restore --delta`; it never starts postgres, so WAL
+  # replay + promotion happen when you scale the StatefulSet back up.
+  #
+  # Enabling this renders an INERT resource -- a suspended CronJob, or a Job you render on
+  # demand -- it does not restore anything by itself. The destructive scale down/up stays
+  # an explicit operator action. See the README, "Point-in-Time Recovery".
+  restore:
+    enabled: false
+    # How the restore is delivered:
+    #   cronjob (default) -- a suspended CronJob to clone on demand:
+    #       kubectl create job --from=cronjob/<fullname>-pgbackrest-restore restore-now
+    #     The resource belongs to the release, so GitOps/ArgoCD sees no stray object; a
+    #     point-in-time target has to be set in values (helm upgrade) before cloning.
+    #   job -- a bare Job, for rendering one off with the target passed inline:
+    #       helm template <release> <chart> -f <release-values> \
+    #         --set pgbackrest.restore.enabled=true --set pgbackrest.restore.mode=job \
+    #         -s templates/pgbackrest-restore-job.yaml | kubectl apply -f -
+    #     Nothing is baked into the release, but the object is not release-managed either
+    #     (ArgoCD may report/prune it), and Jobs are immutable -- see nameSuffix.
+    mode: cronjob
+    # PITR target. Empty (default) restores the latest backup set and replays all archived
+    # WAL to the end of the stream (the disaster-recovery case). For a point in time set:
+    #   targetType: time   target: "2026-03-22 12:00:00+00"
+    # targetType is one of: "" (latest) | time | xid | name | lsn (pgbackrest --type).
+    # A target always implies --target-action=promote.
+    targetType: ""
+    target: ""
+    # pgbackrest --set: restore a SPECIFIC backup set (label from `pgbackrest info`, e.g.
+    # "20260322-010002F") instead of the latest. Empty = latest.
+    backupSet: ""
+    # pgbackrest --force: restore even though $PGDATA/postmaster.pid exists. Needed only
+    # when the cluster crashed and left a stale pid file behind -- pgbackrest otherwise
+    # refuses to restore over what may be a running cluster, which is the safety interlock
+    # that lets this Job run with no Kubernetes API access at all. Leave false unless you
+    # have confirmed every postgresql pod is gone.
+    force: false
+    # Ordinal of the replica whose PVC (data-<fullname>-<ordinal>) is restored into.
+    # Leave 0: replica 0 becomes the restored primary and repmgr re-clones the standbys.
+    podOrdinal: 0
+    # mode: job only -- appended to the Job name so a second attempt does not collide with
+    # the completed first one (Jobs are immutable). Ignored in cronjob mode, where the name
+    # must stay stable for `kubectl create job --from`.
+    nameSuffix: ""
+    # Generous by default: a real restore moves the whole database over the network. The
+    # Job is killed at this deadline even mid-restore (rerun it; --delta resumes cheaply).
+    activeDeadlineSeconds: 21600  # 6 hours
+    # 0 = one pod attempt. A failed restore leaves PGDATA half-written, so an automatic
+    # retry would race the operator's diagnosis -- and failures surface immediately.
+    backoffLimit: 0
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+
 networkPolicy:
   enabled: false
   postgresql:


### PR DESCRIPTION
Closes #226.

Implements option C from the [design options](https://github.com/cagriekin/charts/issues/226#issuecomment-5141727492): one shared Job spec, two delivery modes. Option D (restore-on-start init container / bootstrap-from-backup) was deliberately left out and filed as #266.

## What changes

`pgbackrest.restore.enabled=true` renders a ready-made restore resource carrying everything a restore needs — the `-repmgr` ServiceAccount (so `s3.keyType: auto` works, API token unmounted), the postgresql pod/container security contexts, the `data-<fullname>-0` PVC and `<fullname>-pgbackrest` ConfigMap mounts, the S3 / repo-encryption credentials, node placement inherited from the postgresql pods, and `pgbackrest restore --delta`. The README runbook drops from a ~30-line `kubectl run --overrides='{…}'` pod spec to:

```bash
kubectl scale statefulset my-postgres-pg --replicas=0
kubectl wait --for=delete pod/my-postgres-pg-0 --timeout=5m
kubectl create job --from=cronjob/my-postgres-pg-pgbackrest-restore restore-now
kubectl scale statefulset my-postgres-pg --replicas=2
```

Design points worth reviewing:

- **Enabling it restores nothing.** It renders an *inert* resource — by default a suspended CronJob whose schedule can never fire (Feb 31) — so it can be left enabled and cloned when disaster strikes, with no `helm upgrade` mid-incident. The destructive scale down/up stays explicit.
- **Two modes** (`restore.mode`): `cronjob` (default, release-owned, GitOps-clean, `kubectl create job --from`) and `job` (bare Job for `helm template -s … | kubectl apply -f -` when the point-in-time target must be passed inline). They share one `pg.pgbackrestRestoreJobSpec` define; only the wrapper differs.
- **It never starts postgres** — WAL replay and promotion happen on scale-up under the normal chart entrypoint.
- **The interlock needs no API access.** pgbackrest itself refuses to restore while `$PGDATA/postmaster.pid` exists, so "did you actually scale down?" is enforced without an RBAC-carrying token (`automountServiceAccountToken: false` is preserved). `restore.force` covers the stale-pid-after-a-crash case.
- **No `pg1-path` override**, unlike the #38 validation CronJob: the mounted `pgbackrest.conf` already points at the live PGDATA. Asserted by a test so it cannot silently regress into restoring somewhere else.
- Fail-fast guards for `pgbackrest.enabled`, `postgresql.persistence.enabled`, and the "target required once targetType is set" rule (template `fail`, matching #38 — a schema `if/then` is not portable to helm 3.x); `mode` and `targetType` are enum-checked in `values.schema.json`.

## Testing

- `pg/tests/test-template.sh`: 45 new assertions (931 total, all passing) — inert-by-default, both modes, mounts/identity/security context, script behaviour, target/backupSet/force/podOrdinal wiring, all guards, `keyType: auto`, repo encryption, node placement.
- `make -C pg test-pgbackrest-restore` (already in the CI matrix) gains an end-to-end phase that does a **real** disaster recovery: scale to 0 → destroy the data directory outright with a throwaway root pod → `kubectl create job --from` → scale up → assert the 5000 post-backup rows are back from S3, the cluster promoted (`pg_is_in_recovery() = f`), and the timeline advanced. Without the wipe a latest-restore would be a near no-op and prove nothing. **19/19 pass.**
- `make -C pg test-pgbackrest-restore-ha` — **new suite + new fixture** (`values-pgbackrest-minio-ha.yaml`, primary + streaming standby), added to the CI matrix. It covers the case that only exists with a standby: the standby is first confirmed to hold the post-backup data (so its PVC is genuinely *stale*, not empty), then **only the primary's** data directory is destroyed and restored. **18/18 pass**, and it settles the open question below.
- `helm unittest` suites, `helm lint` (both charts, both modes) and the repmgrd byte-stability check pass; the default render is byte-identical apart from the chart-version label.

## Standby re-clone: verified, not assumed

The acceptance criteria asserted that standbys are re-cloned on scale-up. That is now **confirmed end to end** by the new HA suite, and the mechanism is exactly as claimed:

```
Timeline mismatch (local: 1, primary: 2), re-cloning...
NOTICE: starting backup (using pg_basebackup)...
NOTICE: standby clone (using pg_basebackup) complete
LOG:  started streaming WAL from primary at 0/A000000 on timeline 2
```

The restored primary returns on a new timeline; the standby's init container detects the mismatch and re-clones via `repmgr standby clone`, with **no PVC deletion and no operator action**. The suite then requires a genuinely healthy pair rather than just a Ready pod: standby in recovery, serving all 5000 rows, on the primary's post-restore timeline, present in `pg_stat_replication`, `repmgr.nodes` showing `primary|t` + `standby|t`, and a fresh post-restore write replicating.

The test was deliberately written to assert either outcome — had the standby *not* rejoined unaided, it would have recorded that failure and then verified the documented manual fallback instead, so the README cannot drift from real behaviour. The README now states this as verified, keeping the manual PVC-deletion step only as a stuck-standby fallback.

## Notes

- Test-infra tidy-up: the ~55-line MinIO + bucket + credential setup was duplicated verbatim across three pgbackrest suites; it is now `deploy_minio()` in `tests/helpers.sh`, and all three use it — net −58 lines in `test-backup-concurrent.sh` alone. Each converted suite was re-run to prove nothing regressed: restore 19/19, backup-concurrent 9/9. (`test-backup-restore.sh` keeps its own MinIO block on purpose: that fixture is plain HTTP with a different bucket, not the same code.)
- `restore.podOrdinal` exists but should stay `0`; replica 0 becomes the restored primary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added opt-in pgBackRest point-in-time recovery (PITR) restores for PostgreSQL and pgvector charts.
  - Supports suspended CronJobs or standalone Jobs, target times, backup selection, force recovery, retries, deadlines, and resource settings.
  - Added safeguards, prerequisite validation, and recovery over existing data volumes.
  - Updated charts to version 1.7.0.

- **Documentation**
  - Replaced manual restore instructions with a chart-managed recovery workflow.

- **Tests**
  - Added coverage for live restores, high-availability recovery, validation, and replica rejoining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->