### PR TITLE
feat(pg,pgvector): bootstrap-from-backup init container (#266)

### DIFF
--- a/.github/workflows/pg-test.yaml
+++ b/.github/workflows/pg-test.yaml
@@ -183,6 +183,7 @@ jobs:
           - { name: backup-concurrent, target: test-backup-concurrent }
           - { name: pgbackrest-restore, target: test-pgbackrest-restore }
           - { name: pgbackrest-restore-ha, target: test-pgbackrest-restore-ha }
+          - { name: pgbackrest-bootstrap, target: test-pgbackrest-bootstrap }
           - { name: databases-roles, target: test-databases-roles }
           - { name: migrate-agent, target: test-migrate-agent }
           - { name: scaledown, target: test-scaledown }

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,51 @@
 # pg chart changelog
 
+## 1.8.0 - 2026-07-31
+
+### Added
+
+- **`pgbackrest.bootstrap.*` — automatic recovery from a lost PVC** (#266). Losing replica 0's
+  volume was quietly the worst kind of outage: the pod came back, the entrypoint found an empty
+  data directory, and it `initdb`'d a **brand new empty cluster**. The backups were intact in S3,
+  the live database was empty, and nothing failed loudly. Set `pgbackrest.bootstrap.enabled=true`
+  and an init container (before `repmgr-init`) seeds an *empty* PGDATA from this release's own
+  repository; PostgreSQL then replays the archived WAL on startup and promotes. A lost volume
+  self-heals with no operator action.
+
+  It needs no changes to the repmgr image: once PGDATA is populated, `init-repmgr.sh` defers the
+  start decision and the entrypoint skips `initdb`, so recovery follows the same path as a
+  scale-up after the #226 restore Job.
+
+  **Safe to leave enabled** — it only ever writes into an *empty* data directory:
+  - empty + repository has backups → restore, write a completion marker, replay WAL on startup;
+  - empty + repository has **no backup yet** → do nothing, so a normal first install proceeds
+    (`restore` exits non-zero with no backup, and Kubernetes retries a failed init container
+    forever, so this case is the difference between "works" and "no pod ever starts");
+  - empty + repository **unreachable** → **fail loudly**, pod stays in `Init`. The backup state
+    is unknown, and initializing an empty cluster then would destroy a probably-recoverable
+    database. Reached only when PGDATA is empty, so a pod rescheduled with an intact volume
+    never depends on S3 being reachable;
+  - already initialized → refuse to touch it, marker or not. An ordinary restart, rollout or
+    re-schedule can therefore never re-restore over a running cluster;
+  - partially restored (an attempt that died mid-flight) → resume with `--delta`, which is what
+    makes the init container safe for Kubernetes to retry;
+  - any replica other than 0 → nothing; standbys are cloned from the primary by repmgr.
+
+  The marker at `$PGDATA/.pgbackrest-bootstrap-complete` records the stanza, backup set, target
+  and system identifier. It lives inside PGDATA on purpose: it shares the volume's lifecycle, so
+  losing the volume clears it exactly when a fresh bootstrap becomes correct again.
+
+  Orthogonal to `pgbackrest.restore` (#226) and combinable with it — `bootstrap` populates an
+  empty directory automatically, `restore` overwrites a live one under operator control. Also
+  supports `bootstrap.targetType`/`target` and `bootstrap.backupSet`, with fail-fast guards for
+  the target pair and for the `pgbackrest.enabled` + `postgresql.persistence.enabled`
+  prerequisites.
+
+  Verified by `make -C pg test-pgbackrest-bootstrap`, which deletes replica 0's PVC outright and
+  asserts the **same** cluster returns — the PostgreSQL system identifier is unchanged, which a
+  fresh `initdb` could not produce — then restarts the pod and asserts the bootstrap does not run
+  a second time.
+
 ## 1.7.0 - 2026-07-31
 
 ### Added

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with repmgr replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 1.7.0
+version: 1.8.0
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/Makefile
+++ b/pg/Makefile
@@ -4,7 +4,7 @@ TESTS_DIR := tests
 MAKEFLAGS += --output-sync=target
 
 .PHONY: test test-template test-cluster test-minimal test-repmgr test-repmgr-chaos test-full test-failover test-upgrade \
-        test-repmgr-failover test-agent test-agent-etcd test-agent-etcd-tls test-tls test-pgpool-failover test-config-failover test-cascading-replication test-migrate-agent test-scaledown test-agent-rolling test-config test-config-repmgr test-backup-restore test-backup-concurrent test-pgbackrest-restore test-pgbackrest-restore-ha test-databases-roles test-special-chars byte-stable cluster-create cluster-delete cluster-exists clean help
+        test-repmgr-failover test-agent test-agent-etcd test-agent-etcd-tls test-tls test-pgpool-failover test-config-failover test-cascading-replication test-migrate-agent test-scaledown test-agent-rolling test-config test-config-repmgr test-backup-restore test-backup-concurrent test-pgbackrest-restore test-pgbackrest-restore-ha test-pgbackrest-bootstrap test-databases-roles test-special-chars byte-stable cluster-create cluster-delete cluster-exists clean help
 
 help:
 	@echo "Targets:"
@@ -31,6 +31,7 @@ help:
 	@echo "  test-backup-concurrent - Run concurrent pgbackrest backup + WAL archiving test"
 	@echo "  test-pgbackrest-restore - Run pgbackrest PITR restore-validation + live restore Job test (#38/#226)"
 	@echo "  test-pgbackrest-restore-ha - Run multi-replica pgbackrest restore + standby re-clone test (#226)"
+	@echo "  test-pgbackrest-bootstrap - Run bootstrap-from-backup PVC-loss recovery test (#266)"
 	@echo "  test-databases-roles - Run declarative databases/roles/grants test (#218)"
 	@echo "  test-special-chars - Run special-character credential tests"
 	@echo "  cluster-create  - Create Kind cluster"
@@ -157,6 +158,9 @@ test-pgbackrest-restore: cluster-exists
 
 test-pgbackrest-restore-ha: cluster-exists
 	@bash $(TESTS_DIR)/test-pgbackrest-restore-ha.sh
+
+test-pgbackrest-bootstrap: cluster-exists
+	@bash $(TESTS_DIR)/test-pgbackrest-bootstrap.sh
 
 test-databases-roles: cluster-exists
 	@bash $(TESTS_DIR)/test-databases-roles.sh

--- a/pg/README.md
+++ b/pg/README.md
@@ -1145,6 +1145,67 @@ helm install my-postgres cagriekin/pg \
 | `pgbackrest.restore.backoffLimit` | Restore Job backoff limit (0 = one attempt; a half-written PGDATA should not be retried automatically) | `0` |
 | `pgbackrest.restore.resources.*` | Restore Job resource requests/limits | `200m`/`256Mi` … `1`/`1Gi` |
 | _scheduling_ | The restore pod inherits `postgresql.nodeSelector` and `postgresql.tolerations` so it lands where the data PVC can attach (`postgresql.affinity` is not inherited) | — |
+| `pgbackrest.bootstrap.enabled` | Seed an **empty** PGDATA on replica 0 from this release's repo via an init container (#266) — a lost PVC recovers instead of initdb-ing an empty cluster | `false` |
+| `pgbackrest.bootstrap.targetType` | PITR target type for the bootstrap: `""` (latest) \| `time` \| `xid` \| `name` \| `lsn`. `target` required when set. Applies to **every** fresh bootstrap, not once | `""` |
+| `pgbackrest.bootstrap.target` | PITR target value for the type above | `""` |
+| `pgbackrest.bootstrap.backupSet` | `pgbackrest --set`: bootstrap from a specific backup set label instead of the latest | `""` |
+| `pgbackrest.bootstrap.resources.*` | Bootstrap init-container resource requests/limits | `200m`/`256Mi` … `1`/`1Gi` |
+
+### Bootstrap from backup: automatic recovery from a lost PVC (#266)
+
+Without this, losing replica 0's PVC is quietly the worst kind of outage. The pod comes back,
+the entrypoint finds an empty data directory, and it **`initdb`s a brand new empty cluster** —
+your backups are safe in S3, but the live database is empty and nothing has failed loudly.
+
+`pgbackrest.bootstrap.enabled=true` adds an init container that runs before `repmgr-init` and
+seeds an *empty* PGDATA from this release's own repository. PostgreSQL then replays the archived
+WAL on startup and promotes, so a lost volume self-heals with no operator action:
+
+```yaml
+pgbackrest:
+  enabled: true
+  bootstrap:
+    enabled: true
+```
+
+**It is safe to leave enabled.** It only ever writes into an *empty* data directory:
+
+| Data directory state | What the bootstrap does |
+|---|---|
+| Empty, repository has backups | Restores, writes a completion marker, lets postgres replay WAL |
+| Empty, repository has **no** backup yet | Nothing — a normal first install proceeds and `initdb` runs |
+| Empty, repository **unreachable** | **Fails loudly** and the pod stays in `Init` |
+| Already initialized | Nothing — refuses to touch it, whatever the marker says |
+| Partially restored (aborted attempt) | Resumes the restore (`--delta`) |
+| Any replica other than 0 | Nothing — standbys are cloned from the primary by repmgr |
+
+That third row is deliberate: if the repository cannot be reached, the state of the backups is
+*unknown*, and initializing an empty cluster then would destroy a database that is probably
+still recoverable. Failing to start is the safe outcome. (Reached only when PGDATA is empty, so
+a pod rescheduled with an intact volume never depends on S3 being up.)
+
+The completion marker lives at `$PGDATA/.pgbackrest-bootstrap-complete` and records the stanza,
+backup set, target and system identifier used. Because it lives inside PGDATA it shares the
+volume's lifecycle — losing the volume clears it exactly when a fresh bootstrap becomes correct
+again, with no external state to drift.
+
+This is the automatic counterpart to the restore Job above; they are orthogonal and can both be
+enabled:
+
+| | `bootstrap` | `restore` |
+|---|---|---|
+| Writes into | An **empty** PGDATA only | A **live** PGDATA (destructive) |
+| Triggered by | Pod startup, automatically | An operator (`kubectl create job`) |
+| Use it for | A lost or replaced PVC | Rolling the database back to a point in time |
+
+Setting `bootstrap.targetType`/`target` pins the bootstrap to a point in time — but note it
+applies to **every** fresh bootstrap of this release, not just the next one, so leave both empty
+unless you really want every rebuilt replica 0 to land on that same target.
+
+Verified end to end by `make -C pg test-pgbackrest-bootstrap`, which deletes replica 0's PVC
+outright and asserts the *same* cluster returns — the PostgreSQL system identifier is unchanged,
+which a fresh `initdb` could not produce — then restarts the pod and asserts the bootstrap does
+**not** run a second time.
 
 ### Automated PITR restore-validation (#38)
 

--- a/pg/templates/pgbackrest-configmap.yaml
+++ b/pg/templates/pgbackrest-configmap.yaml
@@ -282,4 +282,133 @@ data:
     echo "pgBackRest restore succeeded for stanza '$PGBACKREST_STANZA'"
     echo "Scale the StatefulSet back up to replay WAL and promote (see the chart README)."
 {{- end }}
+{{- if .Values.pgbackrest.bootstrap.enabled }}
+  # Bootstrap-from-backup program (#266), run as an init container on replica 0 before
+  # repmgr-init. Where restore.sh (#226) deliberately restores OVER a live data directory
+  # under operator control, this one only ever populates an EMPTY one -- so an ordinary pod
+  # restart or rollout can never re-restore over a running cluster. All inputs arrive via env.
+  bootstrap.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    # Seeds an EMPTY data directory from the pgBackRest repository so a replica that lost its
+    # PVC recovers its data instead of initdb-ing an empty cluster. Runs before repmgr-init:
+    # once PGDATA is populated, init-repmgr.sh defers ("Primary-state data directory present")
+    # and the entrypoint skips initdb, so postgres starts, replays the archived WAL via
+    # restore_command and promotes -- the same recovery path as a scale-up after #226's Job.
+
+    # pg_controldata lives in /usr/lib/postgresql/<major>/bin and is NOT on PATH when this
+    # script is the container command (the image entrypoint, which would add it, is bypassed).
+    PG_BIN=$(dirname "$(ls -1 /usr/lib/postgresql/*/bin/pg_controldata 2>/dev/null | sort -V | tail -1)")
+    [ -n "$PG_BIN" ] && export PATH="$PG_BIN:$PATH"
+
+    mkdir -p "$PGBACKREST_LOG_PATH" "$PGBACKREST_LOCK_PATH"
+
+    # The marker records a COMPLETED bootstrap. It lives inside PGDATA on purpose: it shares
+    # the volume's lifecycle, so a wiped/lost PVC clears it exactly when a fresh bootstrap
+    # becomes correct again -- no external state to get out of sync.
+    MARKER="$PGDATA/.pgbackrest-bootstrap-complete"
+    RESUMING=""
+
+    ORDINAL="${HOSTNAME##*-}"
+    # Only replica 0 bootstraps. Standbys must clone from the restored primary (repmgr
+    # standby clone), not each restore their own copy: independent restores of the same repo
+    # would land on divergent recovery points and could not stream from one another.
+    if [ "$ORDINAL" != "0" ]; then
+      echo "Not replica 0 (ordinal $ORDINAL): standbys clone from the primary; nothing to bootstrap."
+      exit 0
+    fi
+
+    if [ -s "$PGDATA/PG_VERSION" ]; then
+      if [ -f "$MARKER" ]; then
+        echo "Bootstrap already completed on this volume:"
+        cat "$MARKER"
+        exit 0
+      fi
+      # PG_VERSION present but no marker. Either a pre-existing cluster (this feature was
+      # enabled on a running release) or an aborted bootstrap. pgbackrest restores
+      # global/pg_control LAST precisely so an interrupted restore cannot be started, so a
+      # READABLE control file means a real cluster -- never touch it. An unreadable one means
+      # the previous attempt died mid-restore, and Kubernetes is retrying this init container.
+      if pg_controldata -D "$PGDATA" >/dev/null 2>&1; then
+        echo "PGDATA already holds an initialized cluster; leaving it untouched."
+        echo "(To restore OVER existing data, use the operator-driven restore Job: pgbackrest.restore.enabled -- see the README.)"
+        exit 0
+      fi
+      echo "WARNING: PGDATA is partially populated and its control file is unreadable -- resuming an aborted bootstrap." >&2
+      RESUMING=yes
+    fi
+
+    # Is there anything to bootstrap FROM? This must be answered before restoring, because a
+    # `restore` with no backup exits non-zero, which under `set -e` would fail this init
+    # container -- and Kubernetes retries init containers forever, so a FIRST install (empty
+    # repo by definition) would never start a pod at all.
+    #
+    # `pgbackrest info` exits 0 even for a missing stanza AND for an unreachable repository, so
+    # the exit code cannot be used; the JSON status code is what distinguishes them:
+    #   1 = missing stanza path/data, 2 = no valid backups  -> benign, nothing to restore yet
+    #   anything else (e.g. 99 HostConnectError)             -> the repo state is UNKNOWN
+    # The distinction is the whole safety story here: "no backup yet" means initialize normally,
+    # while "cannot reach the repo" must NOT fall through to initdb -- that would create an
+    # empty cluster over a database that is probably still recoverable, which is precisely the
+    # silent data loss this feature exists to prevent.
+    #
+    # Reached only when PGDATA is empty (the checks above returned early otherwise), so a pod
+    # rescheduled with an intact volume never depends on the repository being reachable.
+    INFO=$(pgbackrest info --stanza="$PGBACKREST_STANZA" --output=json 2>/dev/null || echo '[]')
+    NBACKUPS=$(printf '%s' "$INFO" | jq -r '[.[].backup[]?] | length' 2>/dev/null || echo 0)
+    REPO_CODE=$(printf '%s' "$INFO" | jq -r '.[0].status.code // 99' 2>/dev/null || echo 99)
+    REPO_MSG=$(printf '%s' "$INFO" | jq -r '.[0].status.message // "unreadable"' 2>/dev/null || echo unreadable)
+    case "${NBACKUPS:-0}" in ''|*[!0-9]*) NBACKUPS=0 ;; esac
+
+    if [ "$NBACKUPS" -eq 0 ]; then
+      if [ "$REPO_CODE" = "1" ] || [ "$REPO_CODE" = "2" ]; then
+        echo "Repository holds no backup for stanza '$PGBACKREST_STANZA' yet (pgbackrest: ${REPO_MSG})."
+        echo "Leaving the data directory empty so this node initializes normally -- the expected path on a first install."
+        exit 0
+      fi
+      echo "FATAL: cannot determine the state of the pgBackRest repository for stanza '$PGBACKREST_STANZA' (status ${REPO_CODE}: ${REPO_MSG})." >&2
+      echo "       Refusing to continue: initializing an empty cluster now would silently discard a database that is probably still recoverable." >&2
+      echo "       Fix repository access (endpoint, credentials, network), or set pgbackrest.bootstrap.enabled=false to initialize an empty cluster deliberately." >&2
+      exit 1
+    fi
+    echo "Repository has ${NBACKUPS} backup(s) for stanza '$PGBACKREST_STANZA'."
+
+    # --delta unconditionally: on a genuinely empty directory pgbackrest just warns and does a
+    # full restore, and on a resumed attempt it copies only what is missing or differs. Without
+    # it, a retry into the partially-restored directory would abort ("directory not empty").
+    ARGS=(--stanza="$PGBACKREST_STANZA" --delta)
+    if [ -n "$BACKUP_SET" ]; then
+      echo "Bootstrapping from backup set: $BACKUP_SET"
+      ARGS+=(--set="$BACKUP_SET")
+    fi
+    if [ -n "$TARGET_TYPE" ]; then
+      # --target-action=promote is REQUIRED with a target: the default recovery_target_action
+      # is `pause`, which would leave the bootstrapped node in recovery, never becoming ready.
+      echo "PITR target: type=$TARGET_TYPE target=$TARGET"
+      ARGS+=(--type="$TARGET_TYPE" --target="$TARGET" --target-action=promote)
+    fi
+
+    if [ -n "$RESUMING" ]; then
+      echo "Resuming bootstrap of stanza '$PGBACKREST_STANZA' into the partially-restored data directory ($PGDATA)..."
+    else
+      echo "Bootstrapping stanza '$PGBACKREST_STANZA' into the empty data directory ($PGDATA)..."
+    fi
+    pgbackrest "${ARGS[@]}" restore
+
+    # Only now is the bootstrap complete: pg_control has been restored, so the cluster is
+    # startable. Record what produced this volume -- the first thing to check if the node
+    # later comes up with unexpected contents.
+    SYSID=$(pg_controldata -D "$PGDATA" 2>/dev/null | awk -F: '/Database system identifier/{gsub(/ /,"",$2); print $2}')
+    {
+      echo "stanza=$PGBACKREST_STANZA"
+      echo "backupSet=${BACKUP_SET:-<latest>}"
+      echo "targetType=${TARGET_TYPE:-<latest-wal>}"
+      echo "target=${TARGET:-}"
+      echo "systemIdentifier=${SYSID:-unknown}"
+      echo "completedAt=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } > "$MARKER"
+
+    echo "Bootstrap succeeded; PostgreSQL will replay the archived WAL and promote on startup."
+{{- end }}
 {{- end }}

--- a/pg/templates/pgbackrest-configmap.yaml
+++ b/pg/templates/pgbackrest-configmap.yaml
@@ -355,6 +355,19 @@ data:
     #
     # Reached only when PGDATA is empty (the checks above returned early otherwise), so a pod
     # rescheduled with an intact volume never depends on the repository being reachable.
+    #
+    # jq parses that JSON. It ships in the repmgr image, but repmgr.image is a values-configurable
+    # input, so check explicitly: without this, a missing jq makes the fallbacks below yield
+    # code 99 and the failure reads "cannot determine the state of the repository", sending an
+    # operator to debug S3 during a perfectly healthy first install. Checked HERE rather than at
+    # the top of the script on purpose -- the early-exit paths above need no jq, so a pod with an
+    # intact data directory must still start on an image that lacks it.
+    if ! command -v jq >/dev/null 2>&1; then
+      echo "FATAL: jq is required to read 'pgbackrest info' output but was not found on PATH." >&2
+      echo "       The repmgr image ships it; a custom repmgr.image must provide it too." >&2
+      echo "       (Refusing to guess the repository state: initializing an empty cluster now could discard a recoverable database.)" >&2
+      exit 1
+    fi
     INFO=$(pgbackrest info --stanza="$PGBACKREST_STANZA" --output=json 2>/dev/null || echo '[]')
     NBACKUPS=$(printf '%s' "$INFO" | jq -r '[.[].backup[]?] | length' 2>/dev/null || echo 0)
     REPO_CODE=$(printf '%s' "$INFO" | jq -r '.[0].status.code // 99' 2>/dev/null || echo 99)

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -46,6 +46,19 @@
 {{- if and .Values.pgbackrest.enabled (not .Values.repmgr.enabled) }}
 {{- fail "pgbackrest.enabled requires repmgr.enabled=true: the pgbackrest binary and the archive_command run inside the postgresql container, which in standalone mode is the official postgres image without pgbackrest. WAL archiving would fail on every segment (unbounded WAL growth) and backups would time out. Enable repmgr, or disable pgbackrest" }}
 {{- end }}
+{{- /* Bootstrap-from-backup (#266) prerequisites. Fail fast rather than rendering an init
+       container that could never work. */}}
+{{- if .Values.pgbackrest.bootstrap.enabled }}
+{{- if not .Values.pgbackrest.enabled }}
+{{- fail "pgbackrest.bootstrap.enabled requires pgbackrest.enabled (the bootstrap init container reads the pgBackRest repo config and S3 credentials the pgbackrest feature renders)" }}
+{{- end }}
+{{- if not .Values.postgresql.persistence.enabled }}
+{{- fail "pgbackrest.bootstrap.enabled requires postgresql.persistence.enabled: with an emptyDir PGDATA every pod restart loses the data directory, so the bootstrap would re-restore the entire database on each start instead of once" }}
+{{- end }}
+{{- if and (ne .Values.pgbackrest.bootstrap.targetType "") (not .Values.pgbackrest.bootstrap.target) }}
+{{- fail "pgbackrest.bootstrap.target is required when pgbackrest.bootstrap.targetType is set" }}
+{{- end }}
+{{- end }}
 {{- /* Bundled etcd consistency: the subchart deploys 3 stateful pods, so reject the
        contradictory inputs that would silently orphan them (fail-fast, CLAUDE.md). */}}
 {{- if (.Values.etcd).enabled }}
@@ -205,6 +218,71 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
+{{- end }}
+{{- if .Values.pgbackrest.bootstrap.enabled }}
+        # Bootstrap-from-backup (#266). Seeds an EMPTY data directory from the pgBackRest
+        # repository, so a replica-0 that lost its PVC recovers its data instead of silently
+        # initdb-ing an empty cluster. Ordered BEFORE repmgr-init on purpose: once PGDATA is
+        # populated, init-repmgr.sh defers the start decision and the entrypoint skips initdb,
+        # so postgres starts, replays the archived WAL via restore_command and promotes.
+        # It refuses to touch an already-initialized directory (see bootstrap.sh), which is
+        # what makes it safe to leave enabled across ordinary restarts and rollouts.
+        - name: pgbackrest-bootstrap
+          image: "{{ include "pg.repmgrImage" . }}"
+          imagePullPolicy: {{ .Values.repmgr.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.postgresql.containerSecurityContext | nindent 12 }}
+          command: ["/bin/bash", "/scripts/bootstrap.sh"]
+          env:
+            - name: PGBACKREST_STANZA
+              value: {{ .Values.pgbackrest.stanza | quote }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            # pgbackrest's default log/lock paths may be unwritable, and neither belongs on
+            # the data volume; /tmp is this container's own writable layer.
+            - name: PGBACKREST_LOG_PATH
+              value: /tmp/pgbackrest-log
+            - name: PGBACKREST_LOCK_PATH
+              value: /tmp/pgbackrest-lock
+            - name: TARGET_TYPE
+              value: {{ .Values.pgbackrest.bootstrap.targetType | quote }}
+            - name: TARGET
+              value: {{ .Values.pgbackrest.bootstrap.target | quote }}
+            - name: BACKUP_SET
+              value: {{ .Values.pgbackrest.bootstrap.backupSet | quote }}
+{{- if .Values.pgbackrest.repoEncryption.enabled }}
+            - name: PGBACKREST_REPO1_CIPHER_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "pgbackrest.repoEncryption.existingSecret.name is required when pgbackrest.repoEncryption.enabled" .Values.pgbackrest.repoEncryption.existingSecret.name }}
+                  key: {{ .Values.pgbackrest.repoEncryption.existingSecret.passphraseKey }}
+{{- end }}
+{{- if eq .Values.pgbackrest.s3.keyType "shared" }}
+            - name: PGBACKREST_REPO1_S3_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pg.pgbackrestS3SecretName" . }}
+                  key: {{ .Values.pgbackrest.existingSecret.accessKeyIdKey }}
+            - name: PGBACKREST_REPO1_S3_KEY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pg.pgbackrestS3SecretName" . }}
+                  key: {{ .Values.pgbackrest.existingSecret.secretAccessKeyKey }}
+{{- end }}
+          resources:
+            {{- toYaml .Values.pgbackrest.bootstrap.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: pgbackrest-config
+              mountPath: /etc/pgbackrest/pgbackrest.conf
+              subPath: pgbackrest.conf
+              readOnly: true
+            # Dedicated directory volume (not a subPath file) so /scripts is created by the
+            # mount and need not pre-exist in the image.
+            - name: pgbackrest-bootstrap-script
+              mountPath: /scripts
+              readOnly: true
 {{- end }}
 {{- if and .Values.postgresql.extensions.enabled .Values.repmgr.enabled }}
 {{- $pgMajor := required "postgresql.majorVersion is required when postgresql.extensions.enabled is true" .Values.postgresql.majorVersion }}
@@ -1137,6 +1215,15 @@ spec:
         - name: pgbackrest-config
           configMap:
             name: {{ include "pg.fullname" . }}-pgbackrest
+{{- if .Values.pgbackrest.bootstrap.enabled }}
+        - name: pgbackrest-bootstrap-script
+          configMap:
+            name: {{ include "pg.fullname" . }}-pgbackrest
+            defaultMode: 0755
+            items:
+              - key: bootstrap.sh
+                path: bootstrap.sh
+{{- end }}
 {{- end }}
 {{- with .Values.postgresql.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/pg/tests/test-pgbackrest-bootstrap.sh
+++ b/pg/tests/test-pgbackrest-bootstrap.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Live bootstrap-from-backup test (#266). Proves the failure this feature exists for:
+# replica 0 loses its PVC entirely, and instead of the entrypoint initdb-ing a BRAND NEW EMPTY
+# cluster (backups intact in S3, live database silently empty), the bootstrap init container
+# restores from the repository and PostgreSQL replays the archived WAL on startup.
+#
+# The load-bearing assertion is the PostgreSQL *system identifier*: a fresh initdb mints a new
+# one, so an unchanged identifier proves the original cluster came back rather than an empty
+# look-alike. The PVC uid is checked too, so the test cannot pass because the volume survived.
+#
+# Also asserts the idempotency AC: a subsequent pod restart with the PVC intact must NOT
+# re-restore -- it must see the completion marker and leave the data directory alone.
+#
+# OPT-IN / standalone: `make -C pg test-pgbackrest-bootstrap`.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+source "${SCRIPT_DIR}/helpers.sh"
+
+NAMESPACE="${NAMESPACE:-pg-test-pgbackrest-bootstrap}"
+RELEASE="${RELEASE:-pgbrbs}"
+VALUES="${SCRIPT_DIR}/values-pgbackrest-minio.yaml"
+FULLNAME=$(resolve_fullname "${RELEASE}" "${CHART_DIR}" "${VALUES}")
+POD="${FULLNAME}-0"
+PVC="data-${FULLNAME}-0"
+
+begin_suite "pgBackRest bootstrap-from-backup (#266)"
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+deploy_minio "${NAMESPACE}"
+
+echo "Installing pg chart with pgbackrest + bootstrap-from-backup enabled..."
+helm upgrade --install "${RELEASE}" "${CHART_DIR}" -n "${NAMESPACE}" \
+  -f "${VALUES}" \
+  --set pgbackrest.bootstrap.enabled=true \
+  --wait --timeout 8m
+wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 1 600
+
+# On a FIRST install the data directory is empty but the repository has no stanza yet, so the
+# bootstrap must be a clean no-op that does not block startup -- if it hard-failed here, the
+# pod would never come up at all (which the readiness wait above already proves).
+# (`restore` with no backup exits non-zero, and Kubernetes retries a failed init container
+# forever -- so getting this wrong would mean no pod EVER starts on a fresh install.)
+first_boot_logs=$(kubectl logs -n "${NAMESPACE}" "${POD}" -c pgbackrest-bootstrap 2>/dev/null || true)
+assert_contains "#266: first install detects the empty repository" "${first_boot_logs}" "no backup for stanza"
+assert_contains "#266: first install falls through to a normal initialization" "${first_boot_logs}" "initializes normally"
+
+# --- first full backup: runs stanza-create, after which WAL archiving succeeds ---
+echo "Triggering initial full backup (creates the stanza)..."
+kubectl delete job pgbr-full -n "${NAMESPACE}" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+kubectl create job -n "${NAMESPACE}" pgbr-full --from=cronjob/"${FULLNAME}-pgbackrest-full"
+full_rc=0
+kubectl wait --for=condition=complete job/pgbr-full -n "${NAMESPACE}" --timeout=300s || full_rc=$?
+if [ "${full_rc}" -ne 0 ]; then
+  echo "  full-backup job did not complete; logs:"; kubectl logs -n "${NAMESPACE}" job/pgbr-full --tail=80 2>/dev/null || true
+fi
+assert_eq "initial full backup (stanza-create) succeeds" "0" "${full_rc}"
+pg_exec "${NAMESPACE}" "${POD}" "SELECT pg_stat_reset_shared('archiver')" "testuser" "testdb" >/dev/null 2>&1 || true
+
+# --- data written AFTER the backup, archived as WAL: recovering it requires WAL replay, not
+#     just unpacking the base backup ---
+echo "Writing post-backup data and archiving it as WAL..."
+pg_exec "${NAMESPACE}" "${POD}" "CREATE TABLE pitr_proof (id bigserial PRIMARY KEY, v text)" "testuser" "testdb"
+pg_exec "${NAMESPACE}" "${POD}" "INSERT INTO pitr_proof (v) SELECT repeat('x',256) FROM generate_series(1,5000)" "testuser" "testdb"
+seg=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT pg_walfile_name(pg_current_wal_lsn())" "testuser" "testdb" | tr -d '[:space:]')
+pg_exec "${NAMESPACE}" "${POD}" "SELECT pg_switch_wal()" "testuser" "testdb" >/dev/null
+for _ in $(seq 1 90); do
+  last=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT COALESCE(last_archived_wal,'')" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+  if [ -n "${last}" ] && [ ! "${last}" \< "${seg}" ]; then break; fi
+  sleep 2
+done
+failed=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT failed_count FROM pg_stat_archiver" "testuser" "testdb" 2>/dev/null || echo "")
+assert_eq "WAL archiving healthy before the simulated PVC loss" "0" "${failed}"
+
+# Identity of the cluster we must get back. A fresh initdb would produce a different one.
+sysid_before=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT system_identifier FROM pg_control_system()" "testuser" "testdb" | tr -d '[:space:]')
+pvc_uid_before=$(kubectl get pvc "${PVC}" -n "${NAMESPACE}" -o jsonpath='{.metadata.uid}')
+echo "Cluster system identifier before loss: ${sysid_before} (PVC uid ${pvc_uid_before})"
+
+# =============================================================================
+# Simulate TOTAL loss of replica 0's volume -- the node died and took the disk with it.
+# =============================================================================
+echo "Scaling to 0 and deleting the data PVC outright..."
+kubectl scale statefulset "${FULLNAME}" -n "${NAMESPACE}" --replicas=0
+kubectl wait --for=delete pod/"${POD}" -n "${NAMESPACE}" --timeout=300s 2>/dev/null || true
+# Delete only after the pod is gone: the pvc-protection finalizer would otherwise hold the PVC
+# in Terminating and the recreated pod could re-bind it, hiding the very loss we are simulating.
+kubectl delete pvc "${PVC}" -n "${NAMESPACE}" --wait=true --timeout=300s >/dev/null 2>&1 || true
+kubectl wait --for=delete pvc/"${PVC}" -n "${NAMESPACE}" --timeout=300s 2>/dev/null || true
+gone=$(kubectl get pvc "${PVC}" -n "${NAMESPACE}" --ignore-not-found -o name 2>/dev/null || true)
+assert_eq "data PVC is really gone (loss simulated)" "" "${gone}"
+
+echo "Scaling back up: the bootstrap init container should restore from S3..."
+kubectl scale statefulset "${FULLNAME}" -n "${NAMESPACE}" --replicas=1
+boot_rc=0
+wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 1 600 || boot_rc=$?
+if [ "${boot_rc}" -ne 0 ]; then
+  kubectl get pod "${POD}" -n "${NAMESPACE}" -o wide 2>/dev/null || true
+  kubectl logs -n "${NAMESPACE}" "${POD}" -c pgbackrest-bootstrap --tail=60 2>/dev/null || true
+  kubectl logs -n "${NAMESPACE}" "${POD}" -c postgresql --tail=60 2>/dev/null || true
+fi
+assert_eq "pod becomes ready after PVC loss" "0" "${boot_rc}"
+
+# The volume really is new...
+pvc_uid_after=$(kubectl get pvc "${PVC}" -n "${NAMESPACE}" -o jsonpath='{.metadata.uid}' 2>/dev/null || echo "")
+if [ -n "${pvc_uid_after}" ] && [ "${pvc_uid_after}" != "${pvc_uid_before}" ]; then
+  pass "a fresh PVC was provisioned (uid changed)"
+else
+  fail "a fresh PVC was provisioned (uid changed)" "uid before=${pvc_uid_before} after=${pvc_uid_after}: the old volume survived, so this run proves nothing"
+fi
+# ...and the bootstrap, not initdb, populated it.
+boot_logs=$(kubectl logs -n "${NAMESPACE}" "${POD}" -c pgbackrest-bootstrap 2>/dev/null || true)
+assert_contains "#266: bootstrap restored into the empty data directory" "${boot_logs}" "into the empty data directory"
+assert_contains "#266: bootstrap reports success" "${boot_logs}" "Bootstrap succeeded"
+
+# THE assertion: same cluster, not a new empty one.
+sysid_after=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT system_identifier FROM pg_control_system()" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+assert_eq "#266: the ORIGINAL cluster came back (system identifier unchanged)" "${sysid_before}" "${sysid_after}"
+rows_after=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT count(*) FROM pitr_proof" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+assert_eq "#266: post-backup data recovered via WAL replay (5000 rows)" "5000" "${rows_after}"
+in_recovery=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT pg_is_in_recovery()" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+assert_eq "#266: bootstrapped node promoted to read-write" "f" "${in_recovery}"
+# New writes work: it is a functioning primary, not a read-only leftover.
+pg_exec "${NAMESPACE}" "${POD}" "CREATE TABLE post_bootstrap_write (id int)" "testuser" "testdb" >/dev/null
+# INSERT then SELECT rather than INSERT ... RETURNING: psql prints the command tag
+# ("INSERT 0 1") alongside the returned row, which a whitespace strip would glue onto the value.
+pg_exec "${NAMESPACE}" "${POD}" "INSERT INTO post_bootstrap_write VALUES (7)" "testuser" "testdb" >/dev/null
+wrote=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT id FROM post_bootstrap_write" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+assert_eq "#266: bootstrapped primary accepts writes" "7" "${wrote}"
+
+# =============================================================================
+# Idempotency AC: an ordinary restart must NOT re-restore. The marker lives in PGDATA, which
+# survives a pod restart, so the bootstrap must skip and leave the data directory untouched.
+# =============================================================================
+echo "Restarting the pod with the PVC intact: the bootstrap must skip..."
+kubectl delete pod "${POD}" -n "${NAMESPACE}" --wait=true >/dev/null
+restart_rc=0
+wait_for_pods_ready "${NAMESPACE}" "app.kubernetes.io/component=postgresql" 1 600 || restart_rc=$?
+assert_eq "pod becomes ready after a plain restart" "0" "${restart_rc}"
+boot_logs2=$(kubectl logs -n "${NAMESPACE}" "${POD}" -c pgbackrest-bootstrap 2>/dev/null || true)
+assert_contains "#266: restart is a no-op (marker seen, already completed)" "${boot_logs2}" "Bootstrap already completed"
+assert_not_contains "#266: restart did NOT re-restore" "${boot_logs2}" "into the empty data directory"
+# Nothing was lost or rewound by the restart -- including the write made after bootstrapping.
+sysid_restart=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT system_identifier FROM pg_control_system()" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+assert_eq "#266: system identifier stable across the restart" "${sysid_before}" "${sysid_restart}"
+kept=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT id FROM post_bootstrap_write" "testuser" "testdb" 2>/dev/null | tr -d '[:space:]' || echo "")
+assert_eq "#266: the post-bootstrap write survived the restart (no re-restore)" "7" "${kept}"
+
+end_suite
+print_summary

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -1670,6 +1670,17 @@ assert_contains "#266: refuses to touch an initialized cluster" "${pgbr_boot_scr
 assert_contains "#266: skips when the completion marker is present" "${pgbr_boot_script}" "Bootstrap already completed"
 assert_contains "#266: resumes an aborted bootstrap (unreadable pg_control)" "${pgbr_boot_script}" "resuming an aborted bootstrap"
 assert_contains "#266: writes a completion marker inside PGDATA" "${pgbr_boot_script}" ".pgbackrest-bootstrap-complete"
+# jq parses `pgbackrest info`; repmgr.image is values-configurable, so a missing jq must name
+# itself rather than surface as "repository unreachable" during a healthy first install. The
+# check must sit AFTER the early exits: a pod with an intact data directory needs no jq.
+assert_contains "#266: names jq explicitly when it is missing" "${pgbr_boot_script}" "jq is required"
+jq_line=$(printf '%s\n' "${pgbr_boot_script}" | grep -n "jq is required" | cut -d: -f1)
+marker_line=$(printf '%s\n' "${pgbr_boot_script}" | grep -n "Bootstrap already completed" | cut -d: -f1)
+if [ -n "${jq_line}" ] && [ -n "${marker_line}" ] && [ "${jq_line}" -gt "${marker_line}" ]; then
+  pass "#266: jq check comes after the early exits (intact volume needs no jq)"
+else
+  fail "#266: jq check comes after the early exits (intact volume needs no jq)" "jq check at line ${jq_line}, marker check at ${marker_line}"
+fi
 assert_contains "#266: restores with --delta so a retry can resume" "${pgbr_boot_script}" "\-\-delta"
 # It must NOT start postgres -- the entrypoint does that, and recovery follows on startup.
 assert_not_contains "#266: bootstrap never starts postgres" "${pgbr_boot_script}" "pg_ctl -D"

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -1674,12 +1674,23 @@ assert_contains "#266: writes a completion marker inside PGDATA" "${pgbr_boot_sc
 # itself rather than surface as "repository unreachable" during a healthy first install. The
 # check must sit AFTER the early exits: a pod with an intact data directory needs no jq.
 assert_contains "#266: names jq explicitly when it is missing" "${pgbr_boot_script}" "jq is required"
+# EVERY early exit must precede the jq check, not just one of them: each returns before any JSON
+# is parsed, so a pod that needs no repository lookup must still start on an image without jq.
+# Checking only one boundary would let a regression slide the check up between the others.
 jq_line=$(printf '%s\n' "${pgbr_boot_script}" | grep -n "jq is required" | cut -d: -f1)
-marker_line=$(printf '%s\n' "${pgbr_boot_script}" | grep -n "Bootstrap already completed" | cut -d: -f1)
-if [ -n "${jq_line}" ] && [ -n "${marker_line}" ] && [ "${jq_line}" -gt "${marker_line}" ]; then
-  pass "#266: jq check comes after the early exits (intact volume needs no jq)"
+boot_exit_ok=1
+boot_exit_detail=""
+for early in "standbys clone from the primary" "Bootstrap already completed" "already holds an initialized cluster"; do
+  eline=$(printf '%s\n' "${pgbr_boot_script}" | grep -n "${early}" | head -1 | cut -d: -f1)
+  if [ -z "${eline}" ] || [ -z "${jq_line}" ] || [ "${jq_line}" -le "${eline}" ]; then
+    boot_exit_ok=0
+    boot_exit_detail="${boot_exit_detail} [\"${early}\" at ${eline:-missing} vs jq at ${jq_line:-missing}]"
+  fi
+done
+if [ "${boot_exit_ok}" = "1" ]; then
+  pass "#266: jq check comes after every early exit (a pod needing no repo lookup starts without jq)"
 else
-  fail "#266: jq check comes after the early exits (intact volume needs no jq)" "jq check at line ${jq_line}, marker check at ${marker_line}"
+  fail "#266: jq check comes after every early exit (a pod needing no repo lookup starts without jq)" "${boot_exit_detail}"
 fi
 assert_contains "#266: restores with --delta so a retry can resume" "${pgbr_boot_script}" "\-\-delta"
 # It must NOT start postgres -- the entrypoint does that, and recovery follows on startup.

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -1644,6 +1644,57 @@ assert_not_contains "#226: does not inherit postgresql.affinity (replica spreadi
 pgbr_res_enc=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.restore.enabled=true --set pgbackrest.repoEncryption.enabled=true --set pgbackrest.repoEncryption.existingSecret.name=cipher --show-only templates/pgbackrest-restore-job.yaml 2>&1)
 assert_contains "#226: repo-encryption passphrase wired into the restore" "${pgbr_res_enc}" "PGBACKREST_REPO1_CIPHER_PASS"
 
+# #266: bootstrap-from-backup -- an init container that seeds an EMPTY PGDATA on replica 0 from
+# the repo, so a lost PVC recovers instead of silently initdb-ing an empty cluster. Contrast
+# #226, which restores OVER live data under explicit operator control.
+assert_not_contains "#266: nothing rendered when bootstrap is disabled (default)" "${pgbr_noval}" "pgbackrest-bootstrap"
+assert_not_contains "#266: bootstrap.sh absent from the configmap when disabled" "${pgbr_noscript}" "bootstrap.sh:"
+pgbr_boot=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.bootstrap.enabled=true --show-only templates/statefulset.yaml 2>&1)
+assert_contains "#266: bootstrap init container renders when enabled" "${pgbr_boot}" "name: pgbackrest-bootstrap"
+assert_contains "#266: bootstrap runs the mounted bootstrap.sh" "${pgbr_boot}" "/scripts/bootstrap.sh"
+assert_contains "#266: bootstrap mounts the pgbackrest ConfigMap (repo settings + pg1-path)" "${pgbr_boot}" "mountPath: /etc/pgbackrest/pgbackrest.conf"
+assert_contains "#266: bootstrap mounts bootstrap.sh from the configmap" "${pgbr_boot}" "key: bootstrap.sh"
+assert_contains "#266: bootstrap targets the live PGDATA" "${pgbr_boot}" "value: /var/lib/postgresql/data/pgdata"
+assert_contains "#266: keyType=shared wires the static S3 key into the bootstrap" "${pgbr_boot}" "name: PGBACKREST_REPO1_S3_KEY"
+# Ordering is load-bearing: the bootstrap must populate PGDATA BEFORE repmgr-init inspects it
+# (init-repmgr.sh defers when PG_VERSION exists) and AFTER fix-permissions has chowned the
+# volume, or the restore cannot write. Compare line numbers in the rendered output.
+boot_init_order=$(printf '%s\n' "${pgbr_boot}" | grep -nE "^        - name: (fix-permissions|pgbackrest-bootstrap|repmgr-init)$" | tr '\n' ' ')
+assert_contains "#266: init order is fix-permissions -> pgbackrest-bootstrap -> repmgr-init" "${boot_init_order}" "fix-permissions.*pgbackrest-bootstrap.*repmgr-init"
+# The script body carries the safety state machine; assert each branch exists so a future
+# edit cannot quietly drop one.
+pgbr_boot_script=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.bootstrap.enabled=true --show-only templates/pgbackrest-configmap.yaml 2>&1)
+assert_contains "#266: bootstrap.sh present in the configmap when enabled" "${pgbr_boot_script}" "bootstrap.sh:"
+assert_contains "#266: only replica 0 bootstraps (standbys clone from it)" "${pgbr_boot_script}" 'ORDINAL" != "0"'
+assert_contains "#266: refuses to touch an initialized cluster" "${pgbr_boot_script}" "already holds an initialized cluster"
+assert_contains "#266: skips when the completion marker is present" "${pgbr_boot_script}" "Bootstrap already completed"
+assert_contains "#266: resumes an aborted bootstrap (unreadable pg_control)" "${pgbr_boot_script}" "resuming an aborted bootstrap"
+assert_contains "#266: writes a completion marker inside PGDATA" "${pgbr_boot_script}" ".pgbackrest-bootstrap-complete"
+assert_contains "#266: restores with --delta so a retry can resume" "${pgbr_boot_script}" "\-\-delta"
+# It must NOT start postgres -- the entrypoint does that, and recovery follows on startup.
+assert_not_contains "#266: bootstrap never starts postgres" "${pgbr_boot_script}" "pg_ctl -D"
+# PITR/backup-set wiring + guards.
+pgbr_boot_pitr=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.bootstrap.enabled=true --set pgbackrest.bootstrap.targetType=time --set-string 'pgbackrest.bootstrap.target=2026-03-22 12:00:00+00' --set pgbackrest.bootstrap.backupSet=20260322-010002F --show-only templates/statefulset.yaml 2>&1)
+assert_contains "#266: bootstrap PITR target wired into the env" "${pgbr_boot_pitr}" "2026-03-22 12:00:00+00"
+assert_contains "#266: bootstrap backupSet wired into the env" "${pgbr_boot_pitr}" "20260322-010002F"
+pgbr_boot_badtarget=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.bootstrap.enabled=true --set pgbackrest.bootstrap.targetType=time 2>&1 || true)
+assert_contains "#266: bootstrap targetType without target fails fast" "${pgbr_boot_badtarget}" "bootstrap.target is required"
+pgbr_boot_badtype=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.bootstrap.enabled=true --set pgbackrest.bootstrap.targetType=bogus 2>&1 || true)
+assert_contains "#266: invalid bootstrap targetType rejected" "${pgbr_boot_badtype}" "must be one of"
+pgbr_boot_nopersist=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.bootstrap.enabled=true --set postgresql.persistence.enabled=false 2>&1 || true)
+assert_contains "#266: bootstrap without persistence fails fast (would re-restore every restart)" "${pgbr_boot_nopersist}" "requires postgresql.persistence.enabled"
+pgbr_boot_nopgbr=$(helm template test-pg "${CHART_DIR}" --set pgbackrest.bootstrap.enabled=true 2>&1 || true)
+assert_contains "#266: bootstrap without pgbackrest fails fast" "${pgbr_boot_nopgbr}" "requires pgbackrest.enabled"
+# keyType=auto relies on the pod SA's workload identity -- no static keys anywhere.
+pgbr_boot_auto=$(helm template test-pg "${CHART_DIR}" --set pgbackrest.enabled=true --set repmgr.enabled=true --set pgbackrest.s3.endpoint=https://s3.test --set pgbackrest.s3.bucket=b --set pgbackrest.s3.keyType=auto --set pgbackrest.bootstrap.enabled=true --show-only templates/statefulset.yaml 2>&1)
+assert_not_contains "#266: keyType=auto emits no static S3 key env on the bootstrap" "${pgbr_boot_auto}" "PGBACKREST_REPO1_S3_KEY"
+pgbr_boot_enc=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.bootstrap.enabled=true --set pgbackrest.repoEncryption.enabled=true --set pgbackrest.repoEncryption.existingSecret.name=cipher --show-only templates/statefulset.yaml 2>&1)
+assert_contains "#266: repo-encryption passphrase wired into the bootstrap" "${pgbr_boot_enc}" "PGBACKREST_REPO1_CIPHER_PASS"
+# bootstrap and restore are orthogonal features and must be able to coexist.
+pgbr_both=$(helm template test-pg "${CHART_DIR}" ${pgbr_args} --set pgbackrest.bootstrap.enabled=true --set pgbackrest.restore.enabled=true 2>&1)
+assert_contains "#266: bootstrap + restore coexist (init container)" "${pgbr_both}" "name: pgbackrest-bootstrap"
+assert_contains "#266: bootstrap + restore coexist (restore CronJob)" "${pgbr_both}" "component: pgbackrest-restore"
+
 # #27: the backup + backup-validation Jobs run under a dedicated no-RBAC SA, not
 # the namespace default.
 backup_sa=$(helm template test-pg "${CHART_DIR}" ${backup_val_args} --show-only templates/backup-serviceaccount.yaml 2>&1)

--- a/pg/values.schema.json
+++ b/pg/values.schema.json
@@ -161,6 +161,18 @@
             "backoffLimit": { "type": "integer" }
           }
         },
+        "bootstrap": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "targetType": {
+              "enum": ["", "time", "xid", "name", "lsn"],
+              "description": "PITR target type (pgbackrest --type) applied when bootstrapping an empty PGDATA; empty restores the latest backup + replays all WAL. bootstrap.target is required when set."
+            },
+            "target": { "type": "string" },
+            "backupSet": { "type": "string" }
+          }
+        },
         "restore": {
           "type": "object",
           "properties": {

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -910,6 +910,43 @@ pgbackrest:
         cpu: "1"
         memory: 1Gi
 
+  # Bootstrap-from-backup (#266). Opt-in. Seeds an EMPTY data directory on replica 0 from this
+  # release's own pgBackRest repository, via an init container that runs before repmgr-init.
+  # The case it exists for: replica 0 loses its PVC (node failure, accidental delete, a storage
+  # class that reclaims). Without this, the entrypoint sees an empty PGDATA and initdb's a
+  # BRAND NEW EMPTY cluster -- the backups are intact in S3, but the running database is empty
+  # until someone notices. With it, the pod restores from S3 and replays the archived WAL on
+  # startup, with no operator action at all.
+  #
+  # Distinct from `restore` above, and safe to leave enabled:
+  #   restore   -- restores OVER a live data directory. Destructive, so it is operator-driven
+  #                (scale to 0, run the Job, scale up) and never automatic.
+  #   bootstrap -- only ever populates an EMPTY data directory. It refuses to touch an
+  #                initialized one, so an ordinary restart, rollout or re-schedule can never
+  #                re-restore over a running cluster.
+  # Only replica 0 bootstraps; standbys are cloned from it by repmgr as usual.
+  bootstrap:
+    enabled: false
+    # PITR target for the bootstrap. Empty (default) restores the latest backup set and replays
+    # all archived WAL -- what you want for recovering a lost replica. To pin a point in time:
+    #   targetType: time   target: "2026-03-22 12:00:00+00"
+    # targetType is one of: "" (latest) | time | xid | name | lsn (pgbackrest --type).
+    # NOTE a target is applied on EVERY fresh bootstrap of this release, not once -- leave both
+    # empty unless you deliberately want every rebuilt replica 0 pinned to that point.
+    targetType: ""
+    target: ""
+    # pgbackrest --set: bootstrap from a SPECIFIC backup set label instead of the latest.
+    backupSet: ""
+    # The init container restores the whole database over the network, so give it room; the pod
+    # stays in Init until it finishes (there is no Job deadline to tune here).
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+
 networkPolicy:
   enabled: false
   postgresql:

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,25 @@
 # pgvector chart changelog
 
+## 1.8.0 - 2026-07-31
+
+Inherited from pg's symlinked templates (`statefulset.yaml`, `pgbackrest-configmap.yaml`). See
+the [pg 1.8.0 changelog](../pg/CHANGELOG.md) for the full detail.
+
+### Added
+
+- **`pgbackrest.bootstrap.*` — automatic recovery from a lost PVC** (#266). Previously, losing
+  replica 0's volume meant the pod came back and `initdb`'d a brand new **empty** cluster while
+  the backups sat intact in S3 — silent, with nothing failing loudly. With
+  `pgbackrest.bootstrap.enabled=true` an init container seeds the empty data directory from this
+  release's own pgBackRest repository and PostgreSQL replays the archived WAL on startup.
+
+  Safe to leave enabled: it only ever writes into an *empty* PGDATA and refuses to touch an
+  initialized one, so a restart or rollout can never re-restore over a running cluster. An empty
+  repository is a no-op (a normal first install proceeds), while an *unreachable* repository
+  fails loudly rather than silently initializing an empty cluster. Only replica 0 bootstraps;
+  standbys are cloned from it by repmgr. Supports `bootstrap.targetType`/`target` and
+  `bootstrap.backupSet`.
+
 ## 1.7.0 - 2026-07-31
 
 Inherited from pg's symlinked templates (`pgbackrest-restore-job.yaml`,

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus repmgr replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 1.7.0
+version: 1.8.0
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -954,7 +954,7 @@ Setting `bootstrap.targetType`/`target` pins the bootstrap to a point in time �
 applies to **every** fresh bootstrap of this release, not just the next one, so leave both empty
 unless you really want every rebuilt replica 0 to land on that same target.
 
-Verified end to end by `the pg chart's `test-pgbackrest-bootstrap` suite`, which deletes replica 0's PVC
+Verified end to end by the pg chart's `test-pgbackrest-bootstrap` suite, which deletes replica 0's PVC
 outright and asserts the *same* cluster returns — the PostgreSQL system identifier is unchanged,
 which a fresh `initdb` could not produce — then restarts the pod and asserts the bootstrap does
 **not** run a second time.

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -897,6 +897,67 @@ helm install my-pgvector cagriekin/pgvector \
 | `pgbackrest.restore.backoffLimit` | Restore Job backoff limit (0 = one attempt; a half-written PGDATA should not be retried automatically) | `0` |
 | `pgbackrest.restore.resources.*` | Restore Job resource requests/limits | `200m`/`256Mi` … `1`/`1Gi` |
 | _scheduling_ | The restore pod inherits `postgresql.nodeSelector` and `postgresql.tolerations` so it lands where the data PVC can attach (`postgresql.affinity` is not inherited) | — |
+| `pgbackrest.bootstrap.enabled` | Seed an **empty** PGDATA on replica 0 from this release's repo via an init container (#266) — a lost PVC recovers instead of initdb-ing an empty cluster | `false` |
+| `pgbackrest.bootstrap.targetType` | PITR target type for the bootstrap: `""` (latest) \| `time` \| `xid` \| `name` \| `lsn`. `target` required when set. Applies to **every** fresh bootstrap, not once | `""` |
+| `pgbackrest.bootstrap.target` | PITR target value for the type above | `""` |
+| `pgbackrest.bootstrap.backupSet` | `pgbackrest --set`: bootstrap from a specific backup set label instead of the latest | `""` |
+| `pgbackrest.bootstrap.resources.*` | Bootstrap init-container resource requests/limits | `200m`/`256Mi` … `1`/`1Gi` |
+
+### Bootstrap from backup: automatic recovery from a lost PVC (#266)
+
+Without this, losing replica 0's PVC is quietly the worst kind of outage. The pod comes back,
+the entrypoint finds an empty data directory, and it **`initdb`s a brand new empty cluster** —
+your backups are safe in S3, but the live database is empty and nothing has failed loudly.
+
+`pgbackrest.bootstrap.enabled=true` adds an init container that runs before `repmgr-init` and
+seeds an *empty* PGDATA from this release's own repository. PostgreSQL then replays the archived
+WAL on startup and promotes, so a lost volume self-heals with no operator action:
+
+```yaml
+pgbackrest:
+  enabled: true
+  bootstrap:
+    enabled: true
+```
+
+**It is safe to leave enabled.** It only ever writes into an *empty* data directory:
+
+| Data directory state | What the bootstrap does |
+|---|---|
+| Empty, repository has backups | Restores, writes a completion marker, lets postgres replay WAL |
+| Empty, repository has **no** backup yet | Nothing — a normal first install proceeds and `initdb` runs |
+| Empty, repository **unreachable** | **Fails loudly** and the pod stays in `Init` |
+| Already initialized | Nothing — refuses to touch it, whatever the marker says |
+| Partially restored (aborted attempt) | Resumes the restore (`--delta`) |
+| Any replica other than 0 | Nothing — standbys are cloned from the primary by repmgr |
+
+That third row is deliberate: if the repository cannot be reached, the state of the backups is
+*unknown*, and initializing an empty cluster then would destroy a database that is probably
+still recoverable. Failing to start is the safe outcome. (Reached only when PGDATA is empty, so
+a pod rescheduled with an intact volume never depends on S3 being up.)
+
+The completion marker lives at `$PGDATA/.pgbackrest-bootstrap-complete` and records the stanza,
+backup set, target and system identifier used. Because it lives inside PGDATA it shares the
+volume's lifecycle — losing the volume clears it exactly when a fresh bootstrap becomes correct
+again, with no external state to drift.
+
+This is the automatic counterpart to the restore Job above; they are orthogonal and can both be
+enabled:
+
+| | `bootstrap` | `restore` |
+|---|---|---|
+| Writes into | An **empty** PGDATA only | A **live** PGDATA (destructive) |
+| Triggered by | Pod startup, automatically | An operator (`kubectl create job`) |
+| Use it for | A lost or replaced PVC | Rolling the database back to a point in time |
+
+Setting `bootstrap.targetType`/`target` pins the bootstrap to a point in time — but note it
+applies to **every** fresh bootstrap of this release, not just the next one, so leave both empty
+unless you really want every rebuilt replica 0 to land on that same target.
+
+Verified end to end by `the pg chart's `test-pgbackrest-bootstrap` suite`, which deletes replica 0's PVC
+outright and asserts the *same* cluster returns — the PostgreSQL system identifier is unchanged,
+which a fresh `initdb` could not produce — then restarts the pod and asserts the bootstrap does
+**not** run a second time.
 
 ### Keyless backups (cloud workload identity)
 

--- a/pgvector/values.schema.json
+++ b/pgvector/values.schema.json
@@ -161,6 +161,18 @@
             "backoffLimit": { "type": "integer" }
           }
         },
+        "bootstrap": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "targetType": {
+              "enum": ["", "time", "xid", "name", "lsn"],
+              "description": "PITR target type (pgbackrest --type) applied when bootstrapping an empty PGDATA; empty restores the latest backup + replays all WAL. bootstrap.target is required when set."
+            },
+            "target": { "type": "string" },
+            "backupSet": { "type": "string" }
+          }
+        },
         "restore": {
           "type": "object",
           "properties": {

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -846,6 +846,43 @@ pgbackrest:
         cpu: "1"
         memory: 1Gi
 
+  # Bootstrap-from-backup (#266). Opt-in. Seeds an EMPTY data directory on replica 0 from this
+  # release's own pgBackRest repository, via an init container that runs before repmgr-init.
+  # The case it exists for: replica 0 loses its PVC (node failure, accidental delete, a storage
+  # class that reclaims). Without this, the entrypoint sees an empty PGDATA and initdb's a
+  # BRAND NEW EMPTY cluster -- the backups are intact in S3, but the running database is empty
+  # until someone notices. With it, the pod restores from S3 and replays the archived WAL on
+  # startup, with no operator action at all.
+  #
+  # Distinct from `restore` above, and safe to leave enabled:
+  #   restore   -- restores OVER a live data directory. Destructive, so it is operator-driven
+  #                (scale to 0, run the Job, scale up) and never automatic.
+  #   bootstrap -- only ever populates an EMPTY data directory. It refuses to touch an
+  #                initialized one, so an ordinary restart, rollout or re-schedule can never
+  #                re-restore over a running cluster.
+  # Only replica 0 bootstraps; standbys are cloned from it by repmgr as usual.
+  bootstrap:
+    enabled: false
+    # PITR target for the bootstrap. Empty (default) restores the latest backup set and replays
+    # all archived WAL -- what you want for recovering a lost replica. To pin a point in time:
+    #   targetType: time   target: "2026-03-22 12:00:00+00"
+    # targetType is one of: "" (latest) | time | xid | name | lsn (pgbackrest --type).
+    # NOTE a target is applied on EVERY fresh bootstrap of this release, not once -- leave both
+    # empty unless you deliberately want every rebuilt replica 0 pinned to that point.
+    targetType: ""
+    target: ""
+    # pgbackrest --set: bootstrap from a SPECIFIC backup set label instead of the latest.
+    backupSet: ""
+    # The init container restores the whole database over the network, so give it room; the pod
+    # stays in Init until it finishes (there is no Job deadline to tune here).
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+
 networkPolicy:
   enabled: false
   postgresql:


### PR DESCRIPTION
Closes #266. Scoped to **this release's own repository** (the option chosen when starting the work); cross-repo cloning into a fresh namespace is not included — see "Not in scope" below.

## The failure this fixes

Losing replica 0's PVC was quietly the worst kind of outage. The pod came back, the entrypoint found an empty data directory, and it `initdb`'d a **brand new empty cluster**. The backups sat intact in S3, the live database was empty, and nothing failed loudly.

`pgbackrest.bootstrap.enabled=true` adds an init container (before `repmgr-init`) that seeds an *empty* PGDATA from the repository. PostgreSQL then replays the archived WAL on startup and promotes, so a lost volume self-heals with no operator action.

## Two things that made this smaller and safer than the issue assumed

**No image change, and no hot-path risk.** `init-repmgr.sh:85` already defers when PGDATA is populated ("Primary-state data directory present"), and `entrypoint.sh` skips `initdb` when `PG_VERSION` exists — so an init container ordered before `repmgr-init` slots in and recovery follows the *identical* path to a scale-up after #226's Job. The issue expected to modify the StatefulSet's hot path; the default render is byte-identical apart from the chart-version label (verified with the repmgrd byte-stability check).

**The data-loss footgun is designed out, not documented around.** The issue proposed a completion marker to stop a rollout re-restoring. Instead the bootstrap only ever writes into an *empty* PGDATA and refuses an initialized one **regardless of the marker** — so a restart physically cannot re-restore over a live cluster. The marker is then just diagnostics plus resume state, not the safety guarantee.

Full state machine:

| Data directory | Repository | Action |
|---|---|---|
| Empty | has backups | Restore, write marker, postgres replays WAL |
| Empty | no backup yet | **Nothing** — normal first install proceeds, `initdb` runs |
| Empty | **unreachable** | **Fail loudly**, pod stays in `Init` |
| Initialized | any | **Nothing** — refuse to touch it, marker or not |
| Partially restored | any | Resume with `--delta` |
| Any ordinal ≠ 0 | any | Nothing — standbys are cloned from the primary by repmgr |

## Two bugs caught by probing the image rather than trusting the design

Both would have shipped:

1. **A fresh install with `bootstrap.enabled=true` would never have started a pod.** `pgbackrest restore` with no backup exits 75; under `set -e` the init container fails, and Kubernetes retries init containers *forever*. The script now probes repository state first and no-ops when there is nothing to restore.
2. **`pgbackrest info` exits 0 even when the repository is unreachable**, so exit status cannot distinguish "no backup yet" from "S3 is down". Only the JSON `status.code` does (`1`/`2` benign, `99` = `HostConnectError`). That distinction is the entire safety story: "no backup yet" must initialize normally, while "cannot reach the repo" must **refuse to start** rather than silently `initdb` over a database that is probably still recoverable.

Both were reproduced in the repmgr image (posix repo with no stanza, and a deliberately invalid S3 endpoint) before any cluster was involved. Note the ordering: the `PG_VERSION`/marker checks run *before* the probe, so a pod rescheduled with an intact volume never depends on S3 being reachable.

## Testing

- **All seven decision branches exercised directly in the image** (ordinal ≠ 0, empty repo, unreachable repo, live cluster, marker present, aborted restore, has-backups) before touching Kubernetes.
- **29 new template assertions — 962/962**, green on **both** helm 3.14.2 (the CI pin) and 4.2.2. Includes asserting the init-container *order* `fix-permissions → pgbackrest-bootstrap → repmgr-init`, since that ordering is what makes the whole thing work.
- **New live suite `make -C pg test-pgbackrest-bootstrap` — 18/18** (added to the CI matrix). It deletes replica 0's PVC outright and hinges on the **PostgreSQL system identifier being unchanged**, which a fresh `initdb` cannot produce — so the test cannot pass merely because a healthy-looking pod appeared. The PVC uid is checked too, so it cannot pass because the volume secretly survived. It then restarts the pod and asserts the bootstrap does **not** run again, and that a write made after bootstrapping survives.
- helm-unittest (all 36 suites), `helm lint`, and the byte-stability check pass.

## Not in scope

Cross-repo cloning (point a new release at another cluster's `repo1-path`/stanza for fresh-namespace DR or a prod→staging clone). Beyond the extra credential/encryption path, the restored `repmgr.nodes` describes the *source* cluster, so the new release needs primary re-registration and `standby register --force`. Worth its own issue if wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional pgBackRest bootstrap recovery for empty or replaced replica-0 storage.
  * Supports latest-backup recovery, point-in-time targets, backup-set selection, resumable restores, and configurable resources.
  * Preserves initialized data and records successful recovery status.
  * Added equivalent configuration and documentation for PostgreSQL and pgvector charts.

* **Documentation**
  * Documented bootstrap configuration, recovery behavior, validation, and failure handling.

* **Tests**
  * Added template and end-to-end coverage for recovery, persistence, credentials, and safety scenarios.

* **Chores**
  * Released chart version 1.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->