### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/images/repmgr/agent/cmd/agent/main.go
+++ b/images/repmgr/agent/cmd/agent/main.go
@@ -61,6 +61,17 @@ func main() {
 		log.Error("config", "err", err)
 		os.Exit(1)
 	}
+	logStartupConfig(log, cfg)
+
+	a, err := newAgent(cfg, log)
+	if err != nil {
+		log.Error("init", "err", err)
+		os.Exit(1)
+	}
+	a.run()
+}
+
+func logStartupConfig(log *slog.Logger, cfg *config.Config) {
 	log.Info("starting pg-ha-agent",
 		"podName", cfg.PodName,
 		"namespace", cfg.Namespace,
@@ -77,13 +88,6 @@ func main() {
 		"cascadeReplication", cfg.CascadeReplication,
 		"pgMajor", cfg.PGMajor,
 	)
-
-	a, err := newAgent(cfg, log)
-	if err != nil {
-		log.Error("init", "err", err)
-		os.Exit(1)
-	}
-	a.run()
 }
 
 // runRBACBootstrap reads the bootstrap inputs from env and drives the etcd Auth API.

--- a/images/repmgr/agent/cmd/agent/main.go
+++ b/images/repmgr/agent/cmd/agent/main.go
@@ -61,7 +61,22 @@ func main() {
 		log.Error("config", "err", err)
 		os.Exit(1)
 	}
-	log.Info("starting pg-ha-agent", "config", cfg.String())
+	log.Info("starting pg-ha-agent",
+		"podName", cfg.PodName,
+		"namespace", cfg.Namespace,
+		"leaseName", cfg.LeaseName,
+		"dcsBackend", cfg.DCSBackend,
+		"reconcileInterval", cfg.ReconcileInterval,
+		"leaseDuration", cfg.LeaseDuration,
+		"renewDeadline", cfg.RenewDeadline,
+		"retryPeriod", cfg.RetryPeriod,
+		"nodeCount", cfg.NodeCount,
+		"headlessService", cfg.HeadlessService,
+		"masterService", cfg.MasterService,
+		"markerName", cfg.MarkerName,
+		"cascadeReplication", cfg.CascadeReplication,
+		"pgMajor", cfg.PGMajor,
+	)
 
 	a, err := newAgent(cfg, log)
 	if err != nil {

--- a/images/repmgr/agent/cmd/agent/main_test.go
+++ b/images/repmgr/agent/cmd/agent/main_test.go
@@ -24,6 +24,9 @@ func TestLogStartupConfigExcludesSecrets(t *testing.T) {
 	const (
 		repmgrSecret   = "repmgr-password-sentinel"
 		postgresSecret = "postgres-password-sentinel"
+		etcdCert       = "etcd-cert-sentinel"
+		etcdKey        = "etcd-key-sentinel"
+		etcdCA         = "etcd-ca-sentinel"
 	)
 	var out bytes.Buffer
 	cfg := &config.Config{
@@ -43,6 +46,9 @@ func TestLogStartupConfigExcludesSecrets(t *testing.T) {
 		PGMajor:            "17",
 		RepmgrPassword:     repmgrSecret,
 		PostgresPassword:   postgresSecret,
+		EtcdCertFile:       etcdCert,
+		EtcdKeyFile:        etcdKey,
+		EtcdCAFile:         etcdCA,
 	}
 
 	logStartupConfig(slog.New(slog.NewTextHandler(&out, nil)), cfg)
@@ -69,7 +75,11 @@ func TestLogStartupConfigExcludesSecrets(t *testing.T) {
 			t.Errorf("startup log missing %q: %s", want, logLine)
 		}
 	}
-	for _, forbidden := range []string{repmgrSecret, postgresSecret, "RepmgrPassword", "PostgresPassword"} {
+	for _, forbidden := range []string{
+		repmgrSecret, postgresSecret, etcdCert, etcdKey, etcdCA,
+		"RepmgrPassword", "PostgresPassword",
+		"EtcdCertFile", "EtcdKeyFile", "EtcdCAFile",
+	} {
 		if strings.Contains(logLine, forbidden) {
 			t.Errorf("startup log leaked sensitive config %q: %s", forbidden, logLine)
 		}

--- a/images/repmgr/agent/cmd/agent/main_test.go
+++ b/images/repmgr/agent/cmd/agent/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -18,6 +19,62 @@ import (
 	"github.com/cagriekin/pg-ha-agent/internal/process"
 	"github.com/cagriekin/pg-ha-agent/internal/reconcile"
 )
+
+func TestLogStartupConfigExcludesSecrets(t *testing.T) {
+	const (
+		repmgrSecret   = "repmgr-password-sentinel"
+		postgresSecret = "postgres-password-sentinel"
+	)
+	var out bytes.Buffer
+	cfg := &config.Config{
+		PodName:            "pg-0",
+		Namespace:          "db",
+		LeaseName:          "pg-leader",
+		DCSBackend:         "kubernetes",
+		ReconcileInterval:  5 * time.Second,
+		LeaseDuration:      15 * time.Second,
+		RenewDeadline:      10 * time.Second,
+		RetryPeriod:        2 * time.Second,
+		NodeCount:          3,
+		HeadlessService:    "pg-headless",
+		MasterService:      "pg",
+		MarkerName:         "pg-primary",
+		CascadeReplication: true,
+		PGMajor:            "17",
+		RepmgrPassword:     repmgrSecret,
+		PostgresPassword:   postgresSecret,
+	}
+
+	logStartupConfig(slog.New(slog.NewTextHandler(&out, nil)), cfg)
+	logLine := out.String()
+
+	for _, want := range []string{
+		"starting pg-ha-agent",
+		"podName=pg-0",
+		"namespace=db",
+		"leaseName=pg-leader",
+		"dcsBackend=kubernetes",
+		"reconcileInterval=5s",
+		"leaseDuration=15s",
+		"renewDeadline=10s",
+		"retryPeriod=2s",
+		"nodeCount=3",
+		"headlessService=pg-headless",
+		"masterService=pg",
+		"markerName=pg-primary",
+		"cascadeReplication=true",
+		"pgMajor=17",
+	} {
+		if !strings.Contains(logLine, want) {
+			t.Errorf("startup log missing %q: %s", want, logLine)
+		}
+	}
+	for _, forbidden := range []string{repmgrSecret, postgresSecret, "RepmgrPassword", "PostgresPassword"} {
+		if strings.Contains(logLine, forbidden) {
+			t.Errorf("startup log leaked sensitive config %q: %s", forbidden, logLine)
+		}
+	}
+}
 
 // --- fakes for the act() path ---
 


### PR DESCRIPTION
Potential fix for [https://github.com/cagriekin/charts/security/code-scanning/5](https://github.com/cagriekin/charts/security/code-scanning/5)

To fix this safely without changing functionality, stop logging `cfg.String()` and instead log only a curated set of non-secret configuration fields at startup.

Best single fix in `images/repmgr/agent/cmd/agent/main.go`:
- Replace line 64 logging call with a structured log that includes only operationally useful, non-sensitive values (for example: pod/namespace identity, lease name, backend choice, reconcile timings, node count, service names, feature flags, PG major).
- Do **not** include `RepmgrPassword`, `PostgresPassword`, TLS private keys/certs, or any field that may contain secrets.
- No new imports, methods, or dependencies are required.

This addresses both variants (`REPMGR_PASSWORD`, `POSTGRES_PASSWORD`) because it removes the whole-string serialization path from `Config` to logs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup logs by displaying selected configuration details individually, making them clearer and easier to read.
  * Prevented sensitive password values and field names from appearing in startup logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->