### PR TITLE
feat(pg,pgvector): bound control.restore's job-create grant with a ValidatingAdmissionPolicy (#279)

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -25,10 +25,20 @@
   | `pg-ha/restore=<fullname>` label | provenance, and it fails closed if chart and policy drift |
   | `serviceAccountName` == the release's own SA | removes the escalation; what is left is "the privileges I already hold" |
   | `automountServiceAccountToken: false`, stated explicitly | makes SA-naming moot: the pod gets no token |
-  | no `hostNetwork` / `hostPID` / `hostIPC` | no escape to the node |
-  | one container, running this release's repmgr image | bounds what code enters the cluster on this token |
+  | no `hostNetwork` / `hostPID` / `hostIPC`, no explicit `nodeName` | no escape to the node, and no placing the pod by hand |
+  | the **pod's own labels**, limited to this release's restore labels plus the batch controller's | a restore pod labelled `component=postgresql` would join the write Service's endpoints — Ready immediately, since it has no readiness probe — and receive application traffic and credentials |
+  | no `manualSelector` | the Job's selector and identity labels stay server-assigned |
+  | one container, no init or ephemeral containers, running this release's repmgr image | bounds what code enters the cluster on this token |
+  | `command` == this release's restore entrypoint, no `args` | the image pin alone is weak: the postgresql container already runs this image against this volume, so without this the Job is "run anything as the database's uid with the live PGDATA mounted" |
+  | this release's pod and container `securityContext` | no `privileged`, no `runAsUser: 0`, no added capabilities — otherwise the Job is a strictly *larger* privilege set than the token started with |
+  | requests and limits present; `parallelism`/`completions` ≤ 1 | the one permitted Job name is otherwise a repeatable way to fill the namespace quota and evict the database's own pods |
   | volumes limited to the three the restore template renders | with the token gone, mounting another workload's Secret was the remaining way out — this closes it, along with `hostPath` and projected tokens |
   | no `envFrom`; `valueFrom` limited to the downward API and the release's own Secrets | the same bound for env |
+
+  The security contexts, resources and command are pinned to **what this release's values
+  render**, not to a fixed hardened profile, so changing `postgresql.containerSecurityContext`
+  moves the pin with it — a chart that denied its own restore Job would be worse than no
+  policy.
 
   Every other creator of Jobs — humans, GitOps controllers, the CronJob controller, other
   workloads — is **unaffected**; that direction is asserted in the KinD suite alongside the
@@ -51,8 +61,19 @@
             acknowledgeUnbounded: false
   ```
 
-  With this in place the feature is defensible rather than advisory, including for the
-  deployments that most want a preflight-validated restore API and run untrusted SQL.
+  **What it does not bound**, stated plainly because it decides whether the feature belongs
+  on a given cluster: the restore *parameters*. Anything holding the token can still create
+  the one permitted Job with its own `TARGET`/`BACKUP_SET`/`FORCE` — this release's own
+  restore, over the live PGDATA, without presenting a certificate to the control API. A
+  restore over the live data directory is the operation being exposed, so admission has
+  nothing left to reject; pgBackRest's `postmaster.pid` interlock still means this needs the
+  StatefulSet already scaled to 0.
+
+  So the policy turns "namespace-wide privilege escalation from a SQL injection" into "an
+  unauthenticated trigger for this release's own restore". That is a large reduction, and it
+  is what makes the feature defensible rather than advisory — but where untrusted SQL runs
+  and an unscheduled restore would itself be a serious incident, leaving `control.restore`
+  off remains the right answer.
 
 - `pgbackrest.restore.mode=cronjob` now renders `jobTemplate.metadata.labels` with
   `pg-ha/restore=<fullname>`. Both `kubectl create job --from=cronjob/...` and the control
@@ -73,7 +94,14 @@
   objects (or are below 1.30, or manage one policy centrally)? Set
   `repmgr.agent.control.restore.admissionPolicy.enabled: false` **and**
   `acknowledgeUnbounded: true` to keep 1.9.0's behaviour, which the render otherwise
-  refuses.
+  refuses. Below 1.30 the render **fails with the version it detected** rather than letting
+  the apply abort halfway with "no matches for kind ValidatingAdmissionPolicy", so an
+  upgrade cannot leave a release half-applied.
+- Values interpolated into the policy's CEL expressions (`pgbackrest.existingSecret.name`,
+  `pgbackrest.repoEncryption.existingSecret.name`, the image reference, `fullnameOverride`)
+  are now charset-validated at render time. A name containing a quote or whitespace fails
+  the render with the offending value named, instead of producing a policy the API server
+  rejects — or, worse, one whose validation is a tautology.
 - A cluster whose **mutating** admission rewrites `Job` objects (sidecar injectors act on
   Pods and are unaffected) can make the cloned Job stop matching a pin. The denial names the
   exact field, and the same two values turn the policy off.

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,83 @@
 # pg chart changelog
 
+## 1.10.0 - 2026-08-02
+
+### Added
+
+- **`control.restore`'s job-create grant is now bounded by a `ValidatingAdmissionPolicy`**
+  (#279), rendered by default whenever `repmgr.agent.control.restore.enabled` is set.
+
+  1.9.0 shipped API-driven restore with an honest warning rather than a fix: triggering a
+  restore needs `create` on `jobs`, RBAC **cannot** restrict a create by `resourceName`, and
+  so the grant let anything holding the database pods' ServiceAccount token create arbitrary
+  Jobs in the namespace — naming any ServiceAccount, with no separate permission check. On a
+  token mounted beside a PostgreSQL that runs user-supplied SQL, that is a namespace-wide
+  privilege-escalation primitive, and the documented advice was to leave the feature off.
+
+  The missing restriction is content-based, which is a layer RBAC does not reach.
+  `ValidatingAdmissionPolicy` is exactly that layer, in-tree and GA since Kubernetes 1.30 —
+  no webhook, no serving certificate, nothing that can be down. The policy polices **one
+  subject**, this release's ServiceAccount, and requires of every Job it creates:
+
+  | Pinned | Why |
+  |---|---|
+  | `metadata.name` == the agent's one deterministic Job name | the `resourceName` restriction RBAC refused to give — `create` collapses to a single object |
+  | `pg-ha/restore=<fullname>` label | provenance, and it fails closed if chart and policy drift |
+  | `serviceAccountName` == the release's own SA | removes the escalation; what is left is "the privileges I already hold" |
+  | `automountServiceAccountToken: false`, stated explicitly | makes SA-naming moot: the pod gets no token |
+  | no `hostNetwork` / `hostPID` / `hostIPC` | no escape to the node |
+  | one container, running this release's repmgr image | bounds what code enters the cluster on this token |
+  | volumes limited to the three the restore template renders | with the token gone, mounting another workload's Secret was the remaining way out — this closes it, along with `hostPath` and projected tokens |
+  | no `envFrom`; `valueFrom` limited to the downward API and the release's own Secrets | the same bound for env |
+
+  Every other creator of Jobs — humans, GitOps controllers, the CronJob controller, other
+  workloads — is **unaffected**; that direction is asserted in the KinD suite alongside the
+  denials, because a policy that broke every other controller in the namespace would be
+  worse than the hole it closes.
+
+  `failurePolicy: Fail` is load-bearing: under `Ignore` an evaluation failure would
+  silently re-open the hole. In the same spirit the grant and its bound cannot be separated
+  — rendering the RBAC without the policy **fails the render** unless you say so in values:
+
+  ```yaml
+  repmgr:
+    agent:
+      control:
+        restore:
+          enabled: true
+          allowedClientCNs: [dba-break-glass]
+          admissionPolicy:
+            enabled: true            # default
+            acknowledgeUnbounded: false
+  ```
+
+  With this in place the feature is defensible rather than advisory, including for the
+  deployments that most want a preflight-validated restore API and run untrusted SQL.
+
+- `pgbackrest.restore.mode=cronjob` now renders `jobTemplate.metadata.labels` with
+  `pg-ha/restore=<fullname>`. Both `kubectl create job --from=cronjob/...` and the control
+  API's clone copy jobTemplate labels onto the Job they create, and nothing else does — so
+  a cloned restore Job is now selectable (`kubectl get jobs -l pg-ha/restore=<fullname>`)
+  where before it carried no labels at all. Deliberately *not* the full `app.kubernetes.io`
+  set: a Job the agent creates is not Helm-managed, and claiming otherwise invites a GitOps
+  controller to prune it mid-restore.
+
+### Upgrading
+
+- **Requires Kubernetes ≥ 1.30 and cluster-scoped `create` on
+  `admissionregistration.k8s.io` (`ValidatingAdmissionPolicy`, `ValidatingAdmissionPolicy-
+  Binding`) — but only if you enable `repmgr.agent.control.restore`.** These are this
+  chart's first cluster-scoped objects; a default install renders none of them, so a
+  namespace-limited installer is unaffected unless it opts into restore triggering.
+- Already running `control.restore.enabled: true` on 1.9.0 and cannot render cluster-scoped
+  objects (or are below 1.30, or manage one policy centrally)? Set
+  `repmgr.agent.control.restore.admissionPolicy.enabled: false` **and**
+  `acknowledgeUnbounded: true` to keep 1.9.0's behaviour, which the render otherwise
+  refuses.
+- A cluster whose **mutating** admission rewrites `Job` objects (sidecar injectors act on
+  Pods and are unaffected) can make the cloned Job stop matching a pin. The denial names the
+  exact field, and the same two values turn the policy off.
+
 ## 1.9.0 - 2026-08-01
 
 ### Added

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -25,11 +25,11 @@
   | `pg-ha/restore=<fullname>` label | provenance, and it fails closed if chart and policy drift |
   | `serviceAccountName` == the release's own SA | removes the escalation; what is left is "the privileges I already hold" |
   | `automountServiceAccountToken: false`, stated explicitly | makes SA-naming moot: the pod gets no token |
-  | no `hostNetwork` / `hostPID` / `hostIPC`, no explicit `nodeName` | no escape to the node, and no placing the pod by hand |
+  | no `hostNetwork` / `hostPID` / `hostIPC`, no explicit `nodeName`, only this release's `priorityClassName` | no escape to the node, no placing the pod by hand, and no claiming a high-priority class to make the scheduler preempt this release's own postgresql pods |
   | the **pod's own labels**, limited to this release's restore labels plus the batch controller's | a restore pod labelled `component=postgresql` would join the write Service's endpoints — Ready immediately, since it has no readiness probe — and receive application traffic and credentials |
   | no `manualSelector` | the Job's selector and identity labels stay server-assigned |
   | one container, no init or ephemeral containers, running this release's repmgr image | bounds what code enters the cluster on this token |
-  | `command` == this release's restore entrypoint, no `args` | the image pin alone is weak: the postgresql container already runs this image against this volume, so without this the Job is "run anything as the database's uid with the live PGDATA mounted" |
+  | `command` == this release's restore entrypoint, no `args`, no `lifecycle` hooks | the image pin alone is weak: the postgresql container already runs this image against this volume, so without this the Job is "run anything as the database's uid with the live PGDATA mounted" |
   | this release's pod and container `securityContext` | no `privileged`, no `runAsUser: 0`, no added capabilities — otherwise the Job is a strictly *larger* privilege set than the token started with |
   | requests and limits present; `parallelism`/`completions` ≤ 1 | the one permitted Job name is otherwise a repeatable way to fill the namespace quota and evict the database's own pods |
   | volumes limited to the three the restore template renders | with the token gone, mounting another workload's Secret was the remaining way out — this closes it, along with `hostPath` and projected tokens |
@@ -69,6 +69,12 @@
   nothing left to reject; pgBackRest's `postmaster.pid` interlock still means this needs the
   StatefulSet already scaled to 0.
 
+  Nor is the command pin a sandbox: bash reads `$BASH_ENV`, and an actor who already runs code
+  in the postgresql container can write a file into PGDATA, which this Job mounts. That
+  reaches uid 101 with no token and only this release's volumes — the privileges already held,
+  which is the bar — but the image, security-context, volume and env pins are what hold it,
+  not the command pin alone.
+
   So the policy turns "namespace-wide privilege escalation from a SQL injection" into "an
   unauthenticated trigger for this release's own restore". That is a large reduction, and it
   is what makes the feature defensible rather than advisory — but where untrusted SQL runs
@@ -94,9 +100,12 @@
   objects (or are below 1.30, or manage one policy centrally)? Set
   `repmgr.agent.control.restore.admissionPolicy.enabled: false` **and**
   `acknowledgeUnbounded: true` to keep 1.9.0's behaviour, which the render otherwise
-  refuses. Below 1.30 the render **fails with the version it detected** rather than letting
-  the apply abort halfway with "no matches for kind ValidatingAdmissionPolicy", so an
-  upgrade cannot leave a release half-applied.
+  refuses. Without the API the render **fails** rather than letting the apply abort halfway
+  with "no matches for kind ValidatingAdmissionPolicy", so an upgrade cannot leave a release
+  half-applied. The precondition checked is the presence of `admissionregistration.k8s.io/v1`,
+  not the reported Kubernetes version: with no cluster to query, `.Capabilities.KubeVersion` is
+  the *helm client's* built-in version (3.14 reports v1.29), so a version floor would break
+  every `helm template` run by an older helm regardless of the target cluster.
 - Values interpolated into the policy's CEL expressions (`pgbackrest.existingSecret.name`,
   `pgbackrest.repoEncryption.existingSecret.name`, the image reference, `fullnameOverride`)
   are now charset-validated at render time. A name containing a quote or whitespace fails

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with repmgr replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 1.9.0
+version: 1.10.0
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/README.md
+++ b/pg/README.md
@@ -576,11 +576,11 @@ this release's ServiceAccount, and requires of every Job that subject creates:
 | label `pg-ha/restore=<release>-pg` | provenance; fails closed if chart and policy ever drift |
 | `serviceAccountName` == `<release>-pg-repmgr` | the escalation itself — what is left is "the privileges the token already holds" |
 | `automountServiceAccountToken: false`, stated explicitly (absent is a denial) | makes naming a ServiceAccount moot: the pod gets no token |
-| no `hostNetwork` / `hostPID` / `hostIPC`, and no explicit `nodeName` | escape to the node, and placing the pod by hand instead of through the scheduler |
+| no `hostNetwork` / `hostPID` / `hostIPC`, no explicit `nodeName`, and only this release's `priorityClassName` | escape to the node; placing the pod by hand instead of through the scheduler; and claiming a high-priority class so the scheduler **preempts this release's own postgresql pods** (referencing a PriorityClass needs no permission). `nodeSelector`/`tolerations` stay unpinned — inherited from `postgresql.*` so the restore can land where the volume attaches, and unlike priority they can only *restrict* placement |
 | the **pod's own labels**: only this release's restore labels plus the batch controller's | joining this release's Service endpoints. A restore pod labelled `component=postgresql` would be added to the write Service — with no readiness probe it is Ready at once — and would receive application traffic and its credentials |
 | no `manualSelector` | a caller-supplied Job selector and identity labels |
 | exactly one container, no init or ephemeral containers, running this release's repmgr image | what code enters the cluster on this token |
-| `command` == this release's restore entrypoint, no `args` | the image pin alone is weak — the postgresql container already runs this image against this volume. Without this, the Job is "run anything as the database's uid with the live PGDATA mounted", which destroys data with no privilege escalation at all |
+| `command` == this release's restore entrypoint, no `args`, no `lifecycle` hooks | the image pin alone is weak — the postgresql container already runs this image against this volume. Without this, the Job is "run anything as the database's uid with the live PGDATA mounted", which destroys data with no privilege escalation at all. A `postStart` exec hook would sidestep a `command`-only pin |
 | this release's **pod and container `securityContext`** (`privileged`, `allowPrivilegeEscalation`, `runAsUser`, `runAsNonRoot`, added capabilities) | a root/privileged container with `CAP_SYS_ADMIN` — which reads every other pod's token off the kubelet and is *strictly more* than the token started with |
 | CPU and memory requests and limits present; `parallelism` and `completions` ≤ 1 | one permitted Job name as a repeatable way to fill the namespace quota and evict the database's own pods |
 | volumes limited to the three the restore template renders (`emptyDir`, ConfigMap `<release>-pg-pgbackrest`, PVC `data-<release>-pg-<podOrdinal>`) | with the token gone this is the one that matters most: arbitrary Secret mounts, `hostPath`, and projected service-account tokens all fall out as denials |
@@ -609,6 +609,12 @@ cluster:
   restore over the live data directory *is* the operation being exposed, so admission has
   nothing left to reject. pgBackRest still refuses to restore while `postmaster.pid` exists,
   which in practice means this needs the StatefulSet already scaled to 0.
+- **The command pin is not a sandbox.** Bash reads `$BASH_ENV`, and an actor who already runs
+  code in the postgresql container can write a file into PGDATA — which this Job mounts. So
+  code execution inside the restore container is reachable. What it reaches is uid 101 with no
+  token and only this release's volumes: the privileges already held, which is the bar this
+  policy is written to. The image, security-context, volume and env pins are what hold that
+  bar — not the command pin alone.
 - **It is not a check that the Job matches the release in full.** CEL sees only the admission
   request, so the verbatim-`jobTemplate` clone remains what guarantees the rest. This is
   defence in depth on top of that.
@@ -641,8 +647,13 @@ Before you enable restore triggering, two operational consequences:
 - **These are this chart's only cluster-scoped objects.** The installing identity needs
   cluster-scoped `create` on `admissionregistration.k8s.io`
   (`ValidatingAdmissionPolicy`, `ValidatingAdmissionPolicyBinding`), and the cluster must be
-  **≥ 1.30** — below that the *render* fails with the version it found, rather than the apply
-  failing halfway. A default install renders neither object, so a namespace-limited installer
+  **≥ 1.30**. That is enforced by asking whether `admissionregistration.k8s.io/v1` exists, not
+  by comparing the reported Kubernetes version: with no cluster to query, `.Capabilities.
+  KubeVersion` is the *helm client's own* built-in version, so a version floor would fail
+  every `helm template` run by a slightly older helm (3.14 reports v1.29) no matter what the
+  target cluster is. Asking for the API group is also the more accurate question — it is false
+  where 1.30+ has the group disabled via `--runtime-config`. Either way the *render* fails,
+  rather than the apply failing halfway. A default install renders neither object, so a namespace-limited installer
   is unaffected until it opts in. The names carry the namespace and release for readability
   and a hash of the pair for uniqueness (`<namespace>-<release>-pg-restore-guard-<hash>`);
   the hash is the part that matters, because a plain hyphen join is ambiguous when either

--- a/pg/README.md
+++ b/pg/README.md
@@ -576,10 +576,20 @@ this release's ServiceAccount, and requires of every Job that subject creates:
 | label `pg-ha/restore=<release>-pg` | provenance; fails closed if chart and policy ever drift |
 | `serviceAccountName` == `<release>-pg-repmgr` | the escalation itself — what is left is "the privileges the token already holds" |
 | `automountServiceAccountToken: false`, stated explicitly (absent is a denial) | makes naming a ServiceAccount moot: the pod gets no token |
-| no `hostNetwork` / `hostPID` / `hostIPC` | escape to the node |
-| exactly one container, running this release's repmgr image | what code enters the cluster on this token |
+| no `hostNetwork` / `hostPID` / `hostIPC`, and no explicit `nodeName` | escape to the node, and placing the pod by hand instead of through the scheduler |
+| the **pod's own labels**: only this release's restore labels plus the batch controller's | joining this release's Service endpoints. A restore pod labelled `component=postgresql` would be added to the write Service — with no readiness probe it is Ready at once — and would receive application traffic and its credentials |
+| no `manualSelector` | a caller-supplied Job selector and identity labels |
+| exactly one container, no init or ephemeral containers, running this release's repmgr image | what code enters the cluster on this token |
+| `command` == this release's restore entrypoint, no `args` | the image pin alone is weak — the postgresql container already runs this image against this volume. Without this, the Job is "run anything as the database's uid with the live PGDATA mounted", which destroys data with no privilege escalation at all |
+| this release's **pod and container `securityContext`** (`privileged`, `allowPrivilegeEscalation`, `runAsUser`, `runAsNonRoot`, added capabilities) | a root/privileged container with `CAP_SYS_ADMIN` — which reads every other pod's token off the kubelet and is *strictly more* than the token started with |
+| CPU and memory requests and limits present; `parallelism` and `completions` ≤ 1 | one permitted Job name as a repeatable way to fill the namespace quota and evict the database's own pods |
 | volumes limited to the three the restore template renders (`emptyDir`, ConfigMap `<release>-pg-pgbackrest`, PVC `data-<release>-pg-<podOrdinal>`) | with the token gone this is the one that matters most: arbitrary Secret mounts, `hostPath`, and projected service-account tokens all fall out as denials |
 | no `envFrom`; `valueFrom` limited to the downward API and this release's own Secrets | the same bound for env — a key from any other Secret or ConfigMap |
+
+The security contexts, resources and command are pinned to **what this release's own values
+render**, not to a fixed hardened profile: change `postgresql.containerSecurityContext` and
+the pin moves with it. A chart that denied its own restore Job would be worse than no policy,
+so every pin is derived from the same values the `jobTemplate` is.
 
 **Everyone else is untouched.** Humans, GitOps controllers, the CronJob controller and every
 other workload create Jobs exactly as before; the policy matches on
@@ -587,9 +597,27 @@ other workload create Jobs exactly as before; the policy matches on
 suite next to the denials, because a policy that broke every other controller in the
 namespace would be worse than the hole it closes.
 
-What it is not: a check that the Job matches the release *in full*. CEL sees only the
-admission request, so the verbatim-`jobTemplate` clone remains what guarantees the rest.
-This is defence in depth on top of that.
+##### What this does *not* bound
+
+Be clear-eyed about the residual, because it decides whether this feature belongs on your
+cluster:
+
+- **The restore parameters are not bounded, and cannot be.** Anything holding the token can
+  still create the one permitted Job with its own `TARGET`, `BACKUP_SET` and `FORCE` — a real
+  restore of this release, over the live PGDATA, without presenting a client certificate to
+  the control API. `allowedClientCNs` guards the API; it cannot guard `create jobs`. A
+  restore over the live data directory *is* the operation being exposed, so admission has
+  nothing left to reject. pgBackRest still refuses to restore while `postmaster.pid` exists,
+  which in practice means this needs the StatefulSet already scaled to 0.
+- **It is not a check that the Job matches the release in full.** CEL sees only the admission
+  request, so the verbatim-`jobTemplate` clone remains what guarantees the rest. This is
+  defence in depth on top of that.
+
+So the policy turns "namespace-wide privilege escalation from a SQL injection" into "an
+unauthenticated trigger for this release's own restore". That is a large reduction and the
+reason the feature is defensible at all — but on a cluster where untrusted SQL runs and an
+unscheduled restore would itself be a serious incident, **leaving `control.restore` off is
+still the right answer.**
 
 `failurePolicy: Fail` is deliberate — under `Ignore`, an evaluation failure would silently
 re-open the hole while the grant stayed rendered. For the same reason the grant and its bound
@@ -613,11 +641,14 @@ Before you enable restore triggering, two operational consequences:
 - **These are this chart's only cluster-scoped objects.** The installing identity needs
   cluster-scoped `create` on `admissionregistration.k8s.io`
   (`ValidatingAdmissionPolicy`, `ValidatingAdmissionPolicyBinding`), and the cluster must be
-  **≥ 1.30**. A default install renders neither object, so a namespace-limited installer is
-  unaffected until it opts in. The names are namespace-prefixed
-  (`<namespace>-<release>-pg-restore-guard`) so two releases cannot collide, and the binding
-  is scoped to the release namespace by `kubernetes.io/metadata.name` — a label the API
-  server sets itself, so it cannot be left off.
+  **≥ 1.30** — below that the *render* fails with the version it found, rather than the apply
+  failing halfway. A default install renders neither object, so a namespace-limited installer
+  is unaffected until it opts in. The names carry the namespace and release for readability
+  and a hash of the pair for uniqueness (`<namespace>-<release>-pg-restore-guard-<hash>`);
+  the hash is the part that matters, because a plain hyphen join is ambiguous when either
+  segment contains hyphens. The binding is scoped to the release namespace by
+  `kubernetes.io/metadata.name` — a label the API server sets itself, so it cannot be left
+  off.
 - **Mutating admission that rewrites `Job` objects can make the clone stop matching a pin.**
   Sidecar injectors act on *Pods* and are unaffected, but a policy engine that mutates pod
   controllers may not be. The denial names the exact field, so you will know immediately

--- a/pg/README.md
+++ b/pg/README.md
@@ -518,19 +518,20 @@ cannot observe another member's data directory.)
 #### API-driven PITR restore — `repmgr.agent.control.restore`
 
 `POST /v1/restore` triggers the chart's [pgBackRest restore Job](#point-in-time-recovery).
-It is a **separate opt-in from the rest of the API**, and the reason is a genuine
-privilege trade-off you should decide deliberately:
+It is a **separate opt-in from the rest of the API**, because it is the only part of the API
+that widens the database pods' Kubernetes privileges at all:
 
 > Creating a Job requires `create` on `jobs`, and RBAC **cannot** restrict `create` by
-> `resourceName`. So this grant lets anything holding the database pods' ServiceAccount
-> token create arbitrary Jobs in the namespace — and a Job's pod may name any
+> `resourceName`. So that grant, *by itself*, lets anything holding the database pods'
+> ServiceAccount token create arbitrary Jobs in the namespace — and a Job's pod may name any
 > ServiceAccount, with no separate permission check. That makes it a namespace-wide
 > privilege-escalation primitive, on a token mounted next to a PostgreSQL that runs
-> user-supplied SQL. The equivalent kubectl path
-> (`kubectl create job --from=cronjob/<release>-pg-pgbackrest-restore`) needs none of it.
-> Leave this off unless API-driven restore is worth that trade.
+> user-supplied SQL.
 
-Nothing else in the API adds any RBAC at all.
+Since 1.10.0 that grant does not travel alone: a
+[`ValidatingAdmissionPolicy`](#bounding-the-job-create-grant--admissionpolicy) bounds it by
+**content**, which is the restriction RBAC has no way to express. Nothing else in the API
+adds any RBAC at all.
 
 **What the grant buys** is choosing the recovery point *in the request*: `targetType`,
 `target` and `backupSet` are applied to the Job the agent creates, so an operator can
@@ -557,6 +558,76 @@ The two lists **compose** — `control.allowedClientCNs` is the door to the API 
 `control.restore.allowedClientCNs` an extra lock on this one verb — so when the outer list
 is non-empty a restore client must appear in **both**. A 403 tells you which list refused
 the call.
+
+##### Bounding the job-create grant — `admissionPolicy`
+
+`allowedClientCNs` bounds who may *ask the API* for a restore. It says nothing about what
+anyone holding the pods' ServiceAccount token can do with `create jobs` directly, and
+neither can RBAC: authorization sees a verb and a resource, never the object's content.
+
+So the chart renders a `ValidatingAdmissionPolicy` and its binding alongside the grant —
+in-tree, **GA since Kubernetes 1.30**, so there is no webhook to deploy, no serving
+certificate to rotate, and nothing here that can be *down*. It polices exactly one subject,
+this release's ServiceAccount, and requires of every Job that subject creates:
+
+| Pinned | What it takes away |
+|---|---|
+| `metadata.name` == `<release>-pg-pgbackrest-restore-api` | the `resourceName` restriction RBAC refused to give: `create` collapses to one object. `generateName` cannot dodge it — validating admission sees the final name |
+| label `pg-ha/restore=<release>-pg` | provenance; fails closed if chart and policy ever drift |
+| `serviceAccountName` == `<release>-pg-repmgr` | the escalation itself — what is left is "the privileges the token already holds" |
+| `automountServiceAccountToken: false`, stated explicitly (absent is a denial) | makes naming a ServiceAccount moot: the pod gets no token |
+| no `hostNetwork` / `hostPID` / `hostIPC` | escape to the node |
+| exactly one container, running this release's repmgr image | what code enters the cluster on this token |
+| volumes limited to the three the restore template renders (`emptyDir`, ConfigMap `<release>-pg-pgbackrest`, PVC `data-<release>-pg-<podOrdinal>`) | with the token gone this is the one that matters most: arbitrary Secret mounts, `hostPath`, and projected service-account tokens all fall out as denials |
+| no `envFrom`; `valueFrom` limited to the downward API and this release's own Secrets | the same bound for env — a key from any other Secret or ConfigMap |
+
+**Everyone else is untouched.** Humans, GitOps controllers, the CronJob controller and every
+other workload create Jobs exactly as before; the policy matches on
+`request.userInfo.username` and nothing else. That direction is asserted in the integration
+suite next to the denials, because a policy that broke every other controller in the
+namespace would be worse than the hole it closes.
+
+What it is not: a check that the Job matches the release *in full*. CEL sees only the
+admission request, so the verbatim-`jobTemplate` clone remains what guarantees the rest.
+This is defence in depth on top of that.
+
+`failurePolicy: Fail` is deliberate — under `Ignore`, an evaluation failure would silently
+re-open the hole while the grant stayed rendered. For the same reason the grant and its bound
+cannot be separated by accident: **rendering the RBAC without the policy fails the render**
+unless you acknowledge the trade in values.
+
+```yaml
+repmgr:
+  agent:
+    control:
+      restore:
+        enabled: true
+        allowedClientCNs: [dba-break-glass]
+        admissionPolicy:
+          enabled: true               # default
+          acknowledgeUnbounded: false # required to be true if you set enabled: false
+```
+
+Before you enable restore triggering, two operational consequences:
+
+- **These are this chart's only cluster-scoped objects.** The installing identity needs
+  cluster-scoped `create` on `admissionregistration.k8s.io`
+  (`ValidatingAdmissionPolicy`, `ValidatingAdmissionPolicyBinding`), and the cluster must be
+  **≥ 1.30**. A default install renders neither object, so a namespace-limited installer is
+  unaffected until it opts in. The names are namespace-prefixed
+  (`<namespace>-<release>-pg-restore-guard`) so two releases cannot collide, and the binding
+  is scoped to the release namespace by `kubernetes.io/metadata.name` — a label the API
+  server sets itself, so it cannot be left off.
+- **Mutating admission that rewrites `Job` objects can make the clone stop matching a pin.**
+  Sidecar injectors act on *Pods* and are unaffected, but a policy engine that mutates pod
+  controllers may not be. The denial names the exact field, so you will know immediately
+  rather than during an incident.
+
+Legitimate reasons to turn it off — a cluster below 1.30, a namespace-limited installer, one
+policy managed centrally by a platform team, or simply accepting the unbounded grant as
+1.9.0 required — are all real. Set `admissionPolicy.enabled: false` **and**
+`acknowledgeUnbounded: true`; the second is what keeps the decision reviewable in values
+rather than invisible in a Role.
 
 What it does and does not control:
 

--- a/pg/templates/_helpers.tpl
+++ b/pg/templates/_helpers.tpl
@@ -700,6 +700,26 @@ with: {{- if eq (include "pg.agentMode" .) "true" }}
 {{- and .Values.repmgr.enabled (eq (include "pg.failoverMode" .) "repmgrd") -}}
 {{- end -}}
 
+{{- /* The single condition under which the `create jobs` grant is rendered (#276). Both
+       rbac.yaml (the grant) and agent-restore-admissionpolicy.yaml (the bound on it) gate
+       on THIS helper rather than on the value directly, so the grant and its guard cannot
+       drift apart -- a Role that carries the escalation primitive without the policy that
+       bounds it is the failure mode #279 exists to prevent. */ -}}
+{{- define "pg.controlRestoreEnabled" -}}
+{{- and .Values.repmgr.enabled (eq (include "pg.agentMode" .) "true") .Values.repmgr.agent.control.restore.enabled -}}
+{{- end -}}
+
+{{- /* Name of the ValidatingAdmissionPolicy (and its binding) that bounds the restore
+       Job-create grant (#279). Both objects are CLUSTER-scoped, so the name is prefixed
+       with the release namespace: pg.fullname is only namespace-unique, and two releases
+       of this chart in different namespaces would otherwise fight over one policy object.
+       Worst case is 63 (namespace) + 1 + 63 (fullname) + 14 = 141 characters, comfortably
+       inside the 253-character DNS-subdomain limit these kinds validate against, so no
+       truncation (which could collide two releases onto one policy) is needed. */ -}}
+{{- define "pg.restoreGuardName" -}}
+{{- printf "%s-%s-restore-guard" .Release.Namespace (include "pg.fullname" .) -}}
+{{- end -}}
+
 {{- /* True in agent mode when the leadership backend is etcd (repmgr.agent.dcs.backend
        == "etcd"), false otherwise. Nil-safe at every level so a partial overlay does
        not nil-pointer; defaults to the kubernetes backend. */ -}}

--- a/pg/templates/_helpers.tpl
+++ b/pg/templates/_helpers.tpl
@@ -710,14 +710,79 @@ with: {{- if eq (include "pg.agentMode" .) "true" }}
 {{- end -}}
 
 {{- /* Name of the ValidatingAdmissionPolicy (and its binding) that bounds the restore
-       Job-create grant (#279). Both objects are CLUSTER-scoped, so the name is prefixed
-       with the release namespace: pg.fullname is only namespace-unique, and two releases
-       of this chart in different namespaces would otherwise fight over one policy object.
-       Worst case is 63 (namespace) + 1 + 63 (fullname) + 14 = 141 characters, comfortably
-       inside the 253-character DNS-subdomain limit these kinds validate against, so no
-       truncation (which could collide two releases onto one policy) is needed. */ -}}
+       Job-create grant (#279). Both objects are CLUSTER-scoped, so the name has to be
+       unique per (namespace, release): pg.fullname alone is only namespace-unique, and two
+       releases in different namespaces would otherwise fight over one policy object.
+
+       The namespace and fullname are there to be read, but they are NOT what makes the
+       name unique -- joining them with a hyphen is ambiguous, because both segments may
+       contain hyphens themselves ("db" in namespace "pg-prod" and "prod-db" in namespace
+       "pg" both produce pg-prod-db-restore-guard). The trailing hash of the unambiguous
+       "<namespace>/<fullname>" pair is the actual discriminator. That matters more than it
+       looks: on a collision the second install fails with an ownership error, and an
+       operator who resolves it by adoption -- or who later uninstalls the first release --
+       leaves the survivor's `create jobs` grant with no policy bounding it, which is the
+       exact state #279 exists to make unreachable.
+
+       Worst case is 63 (namespace) + 1 + 63 (fullname) + 14 + 9 = 150 characters, inside
+       the 253-character DNS-subdomain limit these kinds validate against, so nothing is
+       truncated (truncation would reintroduce collisions). */ -}}
 {{- define "pg.restoreGuardName" -}}
-{{- printf "%s-%s-restore-guard" .Release.Namespace (include "pg.fullname" .) -}}
+{{- $fullname := include "pg.fullname" . -}}
+{{- printf "%s-%s-restore-guard-%s" .Release.Namespace $fullname (printf "%s/%s" .Release.Namespace $fullname | sha256sum | trunc 8) -}}
+{{- end -}}
+
+{{- /* The restore container's command, defined once (#279). pgbackrest-restore-job.yaml
+       renders it as YAML flow style and agent-restore-admissionpolicy.yaml pins it as a
+       CEL list literal (the same text with CEL's single quotes), so the policy cannot
+       drift from the command it is meant to pin. */ -}}
+{{- define "pg.restoreCommandJSON" -}}
+["/bin/bash", "/scripts/restore.sh"]
+{{- end -}}
+
+{{- /* CEL fragment pinning one scalar field to exactly what the chart renders (#279):
+       "present and equal" when the release's values set the field, "absent" when they do
+       not -- which is precisely the shape the rendered Job has, so the policy can never
+       deny the release's own restore. Args: (list <CEL path> <values dict> <key>). */ -}}
+{{- define "pg.celScalarPin" -}}
+{{- $path := index . 0 -}}
+{{- $src := index . 1 -}}
+{{- $key := index . 2 -}}
+{{- if hasKey $src $key -}}
+{{- $v := index $src $key -}}
+{{- if kindIs "string" $v -}}
+(has({{ $path }}) && {{ $path }} == '{{ $v }}')
+{{- else -}}
+(has({{ $path }}) && {{ $path }} == {{ $v }})
+{{- end -}}
+{{- else -}}
+!has({{ $path }})
+{{- end -}}
+{{- end -}}
+
+{{- /* Reject values that cannot be safely interpolated into a single-quoted CEL string
+       literal (#279). agent-restore-admissionpolicy.yaml embeds names straight into CEL
+       expressions -- 'PGBACKREST_REPO1_S3_KEY' style Secret names, the image reference,
+       the namespace, the fullname -- and CEL has no escaping helper on the helm side. A
+       value containing an apostrophe produces a syntactically broken expression that
+       renders, lints and unit-tests clean and only fails when the API server parses the
+       policy; a crafted value (`x' || true || '`) would instead produce a TAUTOLOGICAL
+       validation, leaving a policy that looks installed and enforces nothing. Both are
+       exactly the apply-time failure the chart's render-time-validation rule exists to
+       prevent, so the charset is checked here instead.
+
+       The allowed set is the union of what Kubernetes object names and OCI image
+       references need: alphanumerics plus . _ - / : @ (no quotes, no backslash, no
+       whitespace). Callers pass a list of (label, value) pairs so the message can say
+       which input was wrong. */ -}}
+{{- define "pg.validateCelLiterals" -}}
+{{- range $pair := . -}}
+{{- $label := index $pair 0 -}}
+{{- $value := index $pair 1 | toString -}}
+{{- if not (regexMatch "^[A-Za-z0-9][A-Za-z0-9._:/@-]*$" $value) -}}
+{{- fail (printf "%s is %q, which cannot be embedded in the restore admission policy's CEL expressions (#279): it must match ^[A-Za-z0-9][A-Za-z0-9._:/@-]*$ (alphanumerics and . _ - / : @). Quotes, whitespace and backslashes would either break the policy at apply time or silently turn a validation into a tautology. Fix the value, or disable the policy deliberately with repmgr.agent.control.restore.admissionPolicy.enabled=false plus acknowledgeUnbounded=true" $label $value) -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{- /* True in agent mode when the leadership backend is etcd (repmgr.agent.dcs.backend

--- a/pg/templates/agent-restore-admissionpolicy.yaml
+++ b/pg/templates/agent-restore-admissionpolicy.yaml
@@ -1,0 +1,196 @@
+{{- if eq (include "pg.controlRestoreEnabled" .) "true" }}
+{{- if .Values.repmgr.agent.control.restore.admissionPolicy.enabled }}
+{{- /* Bound the restore Job-create grant by CONTENT, not just by verb (#279).
+
+       rbac.yaml has to hand the database pods' ServiceAccount `create` on `batch/jobs`,
+       and RBAC cannot restrict a create by resourceName -- the API server does not know
+       the object's name at authorization time. So that grant alone lets anything holding
+       the token (i.e. anything that achieves code execution in a PostgreSQL running
+       user-supplied SQL) create ARBITRARY Jobs in the namespace, and a Job's pod may name
+       any ServiceAccount with no separate permission check. That is a namespace-wide
+       privilege-escalation primitive, and it is why control.restore shipped in 1.9.0 as
+       "leave it off unless the trade is worth it".
+
+       The restriction has to happen at a layer RBAC does not reach. ValidatingAdmission-
+       Policy is exactly that layer: it is in-tree and GA since Kubernetes 1.30, so this
+       adds no webhook, no serving certificate and no new failure domain -- unlike a
+       webhook, there is nothing here that can be down.
+
+       This is defence in depth ON TOP OF the agent's own bounds (verbatim jobTemplate
+       clone, valueFrom env never overwritten, podOrdinal not an API decision, never
+       --force), not a replacement for them: those bound what the AGENT builds, and this
+       bounds what anyone else holding the same token can build.
+
+       Deliberately NOT gated on `.Capabilities.APIVersions`: with no cluster to query
+       (plain `helm template`, and therefore every unit test and the kubeconform gate)
+       helm falls back to a capability set containing only core/v1, so a capabilities
+       check would silently drop the policy in exactly the render paths that verify it is
+       present. The Kubernetes >= 1.30 requirement is documented instead, and the operator
+       opts out explicitly (admissionPolicy.enabled=false + acknowledgeUnbounded=true),
+       which is a decision that belongs in values rather than in cluster introspection. */}}
+{{- $fullname := include "pg.fullname" . }}
+{{- $guard := include "pg.restoreGuardName" . }}
+{{- /* The Secrets the rendered restore Job legitimately reads through secretKeyRef. Any
+       other Secret in the namespace must stay unreachable: a Job that could mount or
+       project an arbitrary Secret would be the same exfiltration primitive by another
+       route. Built from the same values the Job's env is built from, so the two cannot
+       disagree. */}}
+{{- $secretRefs := list }}
+{{- if eq .Values.pgbackrest.s3.keyType "shared" }}
+{{- $secretRefs = append $secretRefs (include "pg.pgbackrestS3SecretName" .) }}
+{{- end }}
+{{- if .Values.pgbackrest.repoEncryption.enabled }}
+{{- $secretRefs = append $secretRefs .Values.pgbackrest.repoEncryption.existingSecret.name }}
+{{- end }}
+{{- /* With keyType=auto and no repo encryption the release reads no Secret at all, and the
+       rule becomes "no secretKeyRef whatsoever" rather than an empty allowlist -- clearer
+       to read in a denial message, and it avoids leaning on CEL's typing of `x in []`. */}}
+{{- $secretRule := "!has(e.valueFrom.secretKeyRef)" }}
+{{- if $secretRefs }}
+{{- $secretRule = printf "(has(e.valueFrom.secretKeyRef) && e.valueFrom.secretKeyRef.name in ['%s'])" (join "','" $secretRefs) }}
+{{- end }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  # Cluster-scoped: namespace-prefixed so two releases cannot collide (pg.restoreGuardName).
+  name: {{ $guard }}
+  labels:
+    {{- include "pg.labels" . | nindent 4 }}
+  {{- with (include "pg.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- /* Fail, not Ignore, and it is load-bearing: with Ignore a policy-evaluation failure
+         would silently re-open the hole this exists to close, which is the worst possible
+         shape -- the grant still rendered, the bound quietly absent. Every expression
+         below is written to be evaluable (has() guards on every optional field), so a
+         failure here means something is wrong that SHOULD stop a restore. */}}
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["jobs"]
+  {{- /* CREATE only. The agent has no update/patch on jobs (and a Job's spec is immutable
+         anyway), so matching updates would police nothing and could only add false
+         denials on status writes by the Job controller. */}}
+  matchConditions:
+    # Police ONE subject: this release's ServiceAccount. Humans, GitOps controllers, the
+    # CronJob controller and every other workload in the cluster create Jobs unaffected --
+    # which matters as much as the denials do, because a policy that broke every other
+    # controller in the namespace would be worse than the hole it closes.
+    #
+    # Exact equality rather than a prefix/suffix match: matching on the ServiceAccount name
+    # alone would also police an identically-named ServiceAccount in an unrelated namespace
+    # (and break that release's restores), and the username already carries the namespace.
+    - name: only-this-releases-agent
+      expression: "request.userInfo.username == 'system:serviceaccount:{{ .Release.Namespace }}:{{ $fullname }}-repmgr'"
+  variables:
+    # spec.template is required on a Job, so this cannot fail to evaluate.
+    - name: pod
+      expression: "object.spec.template.spec"
+  validations:
+    # 1. The bound RBAC could not express, and the one that collapses the grant: the agent
+    #    always creates ONE deterministic Job name (which is why get/delete ARE scopeable
+    #    in rbac.yaml). Pinning it here means `create jobs` becomes, in effect, create on
+    #    that single object -- the resourceName restriction RBAC refused to give.
+    #
+    #    generateName cannot slip past this: name generation happens before VALIDATING
+    #    admission runs, so object.metadata.name is the final name (a mutating webhook, by
+    #    contrast, would see it empty). A generated name never equals the pinned one.
+    - expression: "object.metadata.name == '{{ $fullname }}-pgbackrest-restore-api'"
+      message: "the pg agent may create only the Job {{ $fullname }}-pgbackrest-restore-api (repmgr.agent.control.restore, #279)"
+      reason: Forbidden
+    # 2. Provenance, and it is why the CronJob's jobTemplate carries this label: the agent
+    #    copies jobTemplate labels onto the Job it clones, so a Job without it did not come
+    #    from this release's restore template. Not a bound by itself (a caller can add a
+    #    label) -- it makes the object attributable, and it fails closed if the chart's
+    #    template and this policy ever drift apart.
+    - expression: "has(object.metadata.labels) && 'pg-ha/restore' in object.metadata.labels && object.metadata.labels['pg-ha/restore'] == '{{ $fullname }}'"
+      message: "the pg agent's Jobs must carry pg-ha/restore={{ $fullname }}, the label this release's restore jobTemplate renders"
+      reason: Forbidden
+    # 3+4. The escalation itself. Naming another ServiceAccount is the primitive; requiring
+    #    the release's own SA removes the "escalate" and leaves only "same privileges I
+    #    already hold". Requiring automountServiceAccountToken=false explicitly (absent
+    #    counts as a denial, not a pass) is what makes SA-naming moot in the first place:
+    #    the pod gets no token to use. The rendered Job sets both.
+    - expression: "has(variables.pod.serviceAccountName) && variables.pod.serviceAccountName == '{{ $fullname }}-repmgr'"
+      message: "the pg agent may only create Jobs running as ServiceAccount {{ $fullname }}-repmgr -- naming another ServiceAccount is the privilege escalation this policy exists to deny"
+      reason: Forbidden
+    - expression: "has(variables.pod.automountServiceAccountToken) && variables.pod.automountServiceAccountToken == false"
+      message: "the pg agent's Jobs must set automountServiceAccountToken: false explicitly (the restore talks to S3 and the PVC, never to the Kubernetes API)"
+      reason: Forbidden
+    # 5. Host namespaces: an escape from the pod boundary to the node, and the restore
+    #    needs none of the three.
+    - expression: "(!has(variables.pod.hostNetwork) || variables.pod.hostNetwork == false) && (!has(variables.pod.hostPID) || variables.pod.hostPID == false) && (!has(variables.pod.hostIPC) || variables.pod.hostIPC == false)"
+      message: "hostNetwork, hostPID and hostIPC are not permitted on the pg agent's Jobs"
+      reason: Forbidden
+    # 6+7. One container, running the release's own image. The agent already refuses to
+    #    clone a jobTemplate with anything other than exactly one container (it will not
+    #    guess which container's env to rewrite), so this matches the agent's own rule.
+    #    The image pin bounds what code enters the cluster on this token; it is a weaker
+    #    bound than it looks -- the postgresql container runs the same image with the same
+    #    data volume already -- which is why the container's command is deliberately NOT
+    #    pinned here: it would add no bound the volume and env rules below do not, and a
+    #    command array is exactly the kind of detail that drifts and produces a false
+    #    denial during an incident.
+    - expression: "size(variables.pod.containers) == 1 && (!has(variables.pod.initContainers) || size(variables.pod.initContainers) == 0)"
+      message: "the pg agent's Jobs must have exactly one container and no init containers"
+      reason: Forbidden
+    - expression: "variables.pod.containers.all(c, c.image == '{{ include "pg.repmgrImage" . }}')"
+      message: "the pg agent's Jobs may only run this release's repmgr image ({{ include "pg.repmgrImage" . }})"
+      reason: Forbidden
+    # 8. Volumes, and after the ServiceAccount pin this is the check that matters most.
+    #    With the token gone, mounting somebody else's Secret is the remaining way to reach
+    #    outside this release -- so the sources are pinned to exactly the three the restore
+    #    template renders. hostPath, projected service-account tokens, arbitrary Secrets
+    #    and arbitrary PVCs all fall out of this as denials rather than needing a rule each.
+    - expression: >-
+        !has(variables.pod.volumes) || variables.pod.volumes.all(v,
+        has(v.emptyDir)
+        || (has(v.configMap) && v.configMap.name == '{{ $fullname }}-pgbackrest')
+        || (has(v.persistentVolumeClaim) && v.persistentVolumeClaim.claimName == 'data-{{ $fullname }}-{{ .Values.pgbackrest.restore.podOrdinal }}'))
+      message: "the pg agent's Jobs may mount only this release's restore volumes: emptyDir, configMap {{ $fullname }}-pgbackrest, and PVC data-{{ $fullname }}-{{ .Values.pgbackrest.restore.podOrdinal }}"
+      reason: Forbidden
+    # 9. The same bound for env: envFrom pulls a whole Secret or ConfigMap, and
+    #    secretKeyRef/configMapKeyRef pull a key from any of them. Only fieldRef (the
+    #    downward API, which can read nothing but the pod's own metadata) and the
+    #    release's own Secrets are allowed through.
+    - expression: >-
+        variables.pod.containers.all(c, !has(c.envFrom) && (!has(c.env) || c.env.all(e,
+        !has(e.valueFrom) || has(e.valueFrom.fieldRef) || {{ $secretRule }})))
+      message: "the pg agent's Jobs may not use envFrom, and may reference only the downward API or this release's own Secrets{{ with $secretRefs }} ({{ join ", " . }}){{ end }} through env valueFrom"
+      reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $guard }}
+  labels:
+    {{- include "pg.labels" . | nindent 4 }}
+  {{- with (include "pg.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  policyName: {{ $guard }}
+  validationActions: ["Deny"]
+  {{- /* Scoped to the release namespace via kubernetes.io/metadata.name, a label the API
+         server sets on every namespace itself (immutable, and always present since 1.21) --
+         so unlike binding on a label the chart would have to ask an operator to apply, this
+         cannot be left off. It exists to bound the blast radius of a policy-evaluation
+         failure under failurePolicy: Fail to this namespace; it is NOT what enforces the
+         rules, which is why the policy still pins the subject exactly in matchConditions.
+
+         Note what is deliberately absent: an objectSelector. Narrowing the BINDING by the
+         pg-ha/restore label would make validation #2 self-defeating -- a Job created
+         without the label would simply not match the binding, and would be admitted. What
+         the caller controls must be checked by a validation, never by a match rule. */}}
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/pg/templates/agent-restore-admissionpolicy.yaml
+++ b/pg/templates/agent-restore-admissionpolicy.yaml
@@ -19,33 +19,51 @@
        WHAT THIS DOES AND DOES NOT ACHIEVE. The validations below pin the Job to the shape
        this release's own restore template renders: one deterministic name, this release's
        ServiceAccount with no token, this release's image running this release's restore
-       command, this release's volumes, env and security contexts, and a single pod. What
-       is left is therefore "run this release's restore, with attacker-chosen restore
-       PARAMETERS (the literal env values: target, backup set, force)" -- i.e. the
-       operation the feature exists to expose, reachable without going through the control
-       API's mTLS and restore.allowedClientCNs. That residual is inherent to `create jobs`
-       and cannot be closed by admission: a restore over the live PGDATA is what a restore
-       IS. It is documented in README.md rather than papered over, and it is why the
-       feature stays opt-in.
+       command, this release's volumes, env, placement and security contexts, and a single
+       pod. Two things are left, both documented in README.md rather than papered over:
+
+         * The restore PARAMETERS (the literal env values: target, backup set, force). So a
+           token holder can run this release's own restore, over the live PGDATA, without
+           going through the control API's mTLS and restore.allowedClientCNs. Inherent to
+           `create jobs` and not closable by admission -- a restore over the live data
+           directory is what a restore IS.
+         * Code execution inside the pinned container. The command pin is not a sandbox:
+           bash reads $BASH_ENV, and an actor who already runs code in the postgresql
+           container can write a file into PGDATA, which this Job mounts. What that reaches
+           is uid 101 with no token and only this release's volumes -- the privileges
+           already held, which is the bar this policy is written to -- but it is not "only
+           restore.sh can run", and the pins below (image, security contexts, volumes, env)
+           are what keep it at that bar rather than the command pin alone.
+
+       Both are why the feature stays opt-in.
 
        This is also defence in depth ON TOP OF the agent's own bounds (verbatim jobTemplate
        clone, valueFrom env never overwritten, podOrdinal not an API decision, never
        --force), not a replacement for them: those bound what the AGENT builds, and this
        bounds what anyone else holding the same token can build.
 
-       Deliberately NOT gated on `.Capabilities.APIVersions`: with no cluster to query
-       (plain `helm template`, and therefore every unit test and the kubeconform gate)
-       helm falls back to a capability set containing only core/v1, so a capabilities
-       check would silently drop the policy in exactly the render paths that verify it is
-       present. `.Capabilities.KubeVersion` has no such hole -- it always carries a version
-       (the client's own when there is no cluster) -- so THAT is what the >= 1.30 floor
-       below is checked against. */}}
-{{- /* Fail at render time, not at apply time: `admissionregistration.k8s.io/v1` does not
-       exist before 1.30, and without this an upgrade from 1.9.0 on an older cluster would
-       render clean and then abort mid-apply with "no matches for kind
-       ValidatingAdmissionPolicy", leaving the release in a failed state. */}}
-{{- if not (semverCompare ">=1.30.0-0" .Capabilities.KubeVersion.Version) }}
-{{- fail (printf "repmgr.agent.control.restore requires Kubernetes >= 1.30 for the ValidatingAdmissionPolicy that bounds its `create jobs` grant, but this cluster reports %s (#279). Upgrade the cluster, or set repmgr.agent.control.restore.admissionPolicy.enabled=false together with acknowledgeUnbounded=true to run the feature with an unbounded grant deliberately" .Capabilities.KubeVersion.Version) }}
+       The >= 1.30 requirement is enforced below by asking whether the API GROUP EXISTS,
+       not by comparing `.Capabilities.KubeVersion` against 1.30. The version comparison
+       looks equivalent and is not: with no cluster to query, `.Capabilities.KubeVersion`
+       is the HELM CLIENT'S OWN built-in version (helm 3.14 reports v1.29), so a semver
+       floor fails every `helm template` run by a slightly older helm -- CI, a GitOps
+       dry-run, `helm diff` -- regardless of what the target cluster actually is. Asking
+       for the API group is also the more accurate question: it is true wherever the kind
+       can be created and false where 1.30+ has it disabled via --runtime-config.
+
+       `.Capabilities.APIVersions` is safe to consult here BECAUSE this is a fail and not
+       a silent skip. Helm's no-cluster default set already contains
+       admissionregistration.k8s.io/v1 (53 entries, not core/v1 only), so `helm template`
+       and the kubeconform gate render the policy without a cluster; a real install or
+       upgrade replaces that set with server discovery, which is what makes the fail fire
+       on a cluster that genuinely cannot host it. helm-unittest's default set is the one
+       exception -- it does NOT include the group -- so the suite declares it, and the
+       fail's own test is the suite that declines to. */}}
+{{- /* Fail at render time, not at apply time: without this, an upgrade from 1.9.0 on a
+       cluster without the API renders clean and then aborts mid-apply with "no matches for
+       kind ValidatingAdmissionPolicy", leaving the release in a failed state. */}}
+{{- if not (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1") }}
+{{- fail (printf "repmgr.agent.control.restore needs admissionregistration.k8s.io/v1 for the ValidatingAdmissionPolicy that bounds its `create jobs` grant, and this cluster does not expose it -- it is GA from Kubernetes 1.30 (this cluster reports %s), and can also be disabled by --runtime-config (#279). Upgrade or enable the API, or set repmgr.agent.control.restore.admissionPolicy.enabled=false together with acknowledgeUnbounded=true to run the feature with an unbounded grant deliberately" .Capabilities.KubeVersion.Version) }}
 {{- end }}
 {{- $fullname := include "pg.fullname" . }}
 {{- $guard := include "pg.restoreGuardName" . }}
@@ -92,7 +110,14 @@
        already resolved by then), so a rule phrased as "exactly the labels the chart
        renders" would deny every legitimate restore. They are safe to allow: their values
        are server-assigned (the Job's own name and UID), validation #7 keeps
-       manualSelector from turning that off, and nothing in this chart selects on them. */}}
+       manualSelector from turning that off, and nothing in this chart selects on them.
+
+       Note the coupling this creates, because it fails CLOSED: the list is the set
+       Kubernetes stamps today (verified against 1.36). A future version that adds another
+       pod-template label would deny every restore for this release until the list is
+       extended here. That is the deliberate trade of a key allowlist over a subset check --
+       an EXTRA label is the whole attack this rule exists to stop, so "unknown key" has to
+       mean "deny" -- and the failure is loud, naming the exact rule, rather than silent. */}}
 {{- $ctrlLabelKeys := list "batch.kubernetes.io/controller-uid" "batch.kubernetes.io/job-name" "controller-uid" "job-name" }}
 {{- $podLabelRules := list (printf "variables.podLabels.all(k, k in ['%s'])" (join "','" (concat (keys $podLabels | sortAlpha) $ctrlLabelKeys))) }}
 {{- range $k := (keys $podLabels | sortAlpha) }}
@@ -135,11 +160,18 @@
       (include "pg.celScalarPin" (list "c.securityContext.runAsUser" $csc "runAsUser"))
       (include "pg.celScalarPin" (list "c.securityContext.runAsNonRoot" $csc "runAsNonRoot"))
       $addPin $cscSeccomp }}
+{{- /* When the values set NOTHING, the rule is "no securityContext, OR one that sets none of
+       the fields pinned above" -- not a bare !has(). `postgresql.containerSecurityContext:
+       {}` renders `securityContext: {}` on the Job, which is PRESENT as far as has() is
+       concerned, so a bare !has() would deny the release's own restore. The
+       !has(parent) || (...) shape is safe despite the pins dereferencing that parent: CEL's
+       logical operators are commutative, so a true left side wins even when the right side
+       would error. */}}
 {{- $cscRule := "" }}
 {{- if $csc }}
 {{- $cscRule = printf "variables.pod.containers.all(c, has(c.securityContext) && %s)" (join " && " $cscPins) }}
 {{- else }}
-{{- $cscRule = "variables.pod.containers.all(c, !has(c.securityContext))" }}
+{{- $cscRule = printf "variables.pod.containers.all(c, !has(c.securityContext) || (%s))" (join " && " $cscPins) }}
 {{- end }}
 {{- $pscPins := list
       (include "pg.celScalarPin" (list "variables.pod.securityContext.runAsUser" $psc "runAsUser"))
@@ -149,7 +181,19 @@
 {{- if $psc }}
 {{- $pscRule = printf "has(variables.pod.securityContext) && %s" (join " && " $pscPins) }}
 {{- else }}
-{{- $pscRule = "!has(variables.pod.securityContext)" }}
+{{- $pscRule = printf "!has(variables.pod.securityContext) || (%s)" (join " && " $pscPins) }}
+{{- end }}
+{{- /* priorityClassName, pinned to what the restore jobTemplate renders
+       (pgbackrest.cronjob.priorityClassName). This one does NOT belong with nodeSelector and
+       tolerations, which are left unpinned because they can only ever RESTRICT where a pod
+       runs: a priority class does the opposite. Referencing a PriorityClass needs no
+       permission, so a caller could name a high-priority class and let the scheduler PREEMPT
+       this release's own postgresql pods to make room -- and the SA holds delete on the
+       pinned Job name, so it is repeatable. The parallelism/completions cap does not close
+       that, because one pod is enough. */}}
+{{- $pcnPin := "!has(variables.pod.priorityClassName)" }}
+{{- with .Values.pgbackrest.cronjob.priorityClassName }}
+{{- $pcnPin = printf "(has(variables.pod.priorityClassName) && variables.pod.priorityClassName == '%s')" . }}
 {{- end }}
 {{- /* Resources: presence of exactly the request/limit keys the release renders. The
        VALUES are not compared -- a Quantity round-trips as the string it was written as
@@ -180,6 +224,22 @@
 {{- end }}
 {{- range $s := $secretRefs }}
 {{- $literals = append $literals (list "a pgbackrest Secret name (pgbackrest.existingSecret.name / pgbackrest.repoEncryption.existingSecret.name)" $s) }}
+{{- end }}
+{{- /* Every OTHER value that reaches a single-quoted CEL literal. Missing one is not
+       cosmetic: `RuntimeDefault' || true || '` renders a syntactically valid, always-true
+       expression -- == binds tighter than || -- so the pin becomes a tautology that renders
+       and lints clean. values.schema.json constrains none of these. */}}
+{{- with $csc.seccompProfile }}{{- with .type }}
+{{- $literals = append $literals (list "postgresql.containerSecurityContext.seccompProfile.type" .) }}
+{{- end }}{{- end }}
+{{- with $psc.seccompProfile }}{{- with .type }}
+{{- $literals = append $literals (list "postgresql.podSecurityContext.seccompProfile.type" .) }}
+{{- end }}{{- end }}
+{{- range $cap := ($caps.add | default list) }}
+{{- $literals = append $literals (list "a postgresql.containerSecurityContext.capabilities.add entry" $cap) }}
+{{- end }}
+{{- with .Values.pgbackrest.cronjob.priorityClassName }}
+{{- $literals = append $literals (list "pgbackrest.cronjob.priorityClassName" .) }}
 {{- end }}
 {{- include "pg.validateCelLiterals" $literals }}
 apiVersion: admissionregistration.k8s.io/v1
@@ -260,15 +320,16 @@ spec:
     - expression: "has(variables.pod.automountServiceAccountToken) && variables.pod.automountServiceAccountToken == false"
       message: "the pg agent's Jobs must set automountServiceAccountToken: false explicitly (the restore talks to S3 and the PVC, never to the Kubernetes API)"
       reason: Forbidden
-    # 5. Escapes from the pod boundary to the node, plus nodeName. nodeName is here because
-    #    it bypasses the scheduler outright -- it ignores taints, and it is how a caller
-    #    would place this pod on a specific node of its choosing. nodeSelector and
-    #    tolerations are deliberately NOT pinned: they are inherited from
-    #    postgresql.nodeSelector/tolerations (the restore has to be able to land where the
-    #    data volume can attach), they can only ever RESTRICT where the pod runs, and with
-    #    the command and volumes pinned below, placement grants nothing.
-    - expression: "(!has(variables.pod.hostNetwork) || variables.pod.hostNetwork == false) && (!has(variables.pod.hostPID) || variables.pod.hostPID == false) && (!has(variables.pod.hostIPC) || variables.pod.hostIPC == false) && !has(variables.pod.nodeName)"
-      message: "hostNetwork, hostPID, hostIPC and an explicit nodeName are not permitted on the pg agent's Jobs"
+    # 5. Escapes from the pod boundary to the node, plus the two placement knobs a caller
+    #    could turn against the release. nodeName bypasses the scheduler outright -- it
+    #    ignores taints, and it is how a caller would place this pod on a node of its
+    #    choosing. priorityClassName is pinned for the reason in its construction above: it
+    #    can PREEMPT this release's own pods. nodeSelector and tolerations are deliberately
+    #    NOT pinned -- they are inherited from postgresql.nodeSelector/tolerations so the
+    #    restore can land where the data volume attaches, and unlike priority they can only
+    #    ever RESTRICT where the pod runs.
+    - expression: "(!has(variables.pod.hostNetwork) || variables.pod.hostNetwork == false) && (!has(variables.pod.hostPID) || variables.pod.hostPID == false) && (!has(variables.pod.hostIPC) || variables.pod.hostIPC == false) && !has(variables.pod.nodeName) && {{ $pcnPin }}"
+      message: "hostNetwork, hostPID, hostIPC, an explicit nodeName and any priorityClassName other than this release's are not permitted on the pg agent's Jobs"
       reason: Forbidden
     # 6. The pod's OWN labels: an allowlist of keys (this release's restore pod labels plus
     #    the batch controller's own), with the release's values pinned. A key allowlist
@@ -307,10 +368,17 @@ spec:
     #    database's uid, with the live PGDATA mounted", which is a data-destruction
     #    primitive that needs no privilege escalation at all. With it, the Job can only run
     #    the chart's restore.sh (delivered by the pinned ConfigMap volume, which this token
-    #    cannot write) and the only caller-controlled inputs are the literal env values the
-    #    restore already takes.
-    - expression: "variables.pod.containers.all(c, has(c.command) && c.command == {{ include "pg.restoreCommandJSON" . | replace "\"" "'" }} && !has(c.args))"
-      message: "the pg agent's Jobs must run exactly this release's restore command ({{ include "pg.restoreCommandJSON" . | replace "\"" "'" }}) with no args"
+    #    cannot write) plus the literal env values the restore already takes.
+    #
+    #    lifecycle is denied in the same rule because it is the same question: a
+    #    postStart/preStop exec hook runs a caller-chosen program in the pinned container
+    #    without touching command or args, which would make "must run exactly this release's
+    #    restore command" untrue as written. The chart renders no lifecycle hooks, so pinning
+    #    absence costs nothing. It does not close the residual documented at the top of this
+    #    file -- $BASH_ENV reaches the same place -- but there is no reason to leave a second,
+    #    more direct door open.
+    - expression: "variables.pod.containers.all(c, has(c.command) && c.command == {{ include "pg.restoreCommandJSON" . | replace "\"" "'" }} && !has(c.args) && !has(c.lifecycle))"
+      message: "the pg agent's Jobs must run exactly this release's restore command ({{ include "pg.restoreCommandJSON" . | replace "\"" "'" }}) with no args and no lifecycle hooks"
       reason: Forbidden
     # 11+12. Security contexts, pinned to the release's own (see the reasoning above their
     #    construction). Without these the Job is admitted with privileged: true,

--- a/pg/templates/agent-restore-admissionpolicy.yaml
+++ b/pg/templates/agent-restore-admissionpolicy.yaml
@@ -16,7 +16,19 @@
        adds no webhook, no serving certificate and no new failure domain -- unlike a
        webhook, there is nothing here that can be down.
 
-       This is defence in depth ON TOP OF the agent's own bounds (verbatim jobTemplate
+       WHAT THIS DOES AND DOES NOT ACHIEVE. The validations below pin the Job to the shape
+       this release's own restore template renders: one deterministic name, this release's
+       ServiceAccount with no token, this release's image running this release's restore
+       command, this release's volumes, env and security contexts, and a single pod. What
+       is left is therefore "run this release's restore, with attacker-chosen restore
+       PARAMETERS (the literal env values: target, backup set, force)" -- i.e. the
+       operation the feature exists to expose, reachable without going through the control
+       API's mTLS and restore.allowedClientCNs. That residual is inherent to `create jobs`
+       and cannot be closed by admission: a restore over the live PGDATA is what a restore
+       IS. It is documented in README.md rather than papered over, and it is why the
+       feature stays opt-in.
+
+       This is also defence in depth ON TOP OF the agent's own bounds (verbatim jobTemplate
        clone, valueFrom env never overwritten, podOrdinal not an API decision, never
        --force), not a replacement for them: those bound what the AGENT builds, and this
        bounds what anyone else holding the same token can build.
@@ -25,9 +37,16 @@
        (plain `helm template`, and therefore every unit test and the kubeconform gate)
        helm falls back to a capability set containing only core/v1, so a capabilities
        check would silently drop the policy in exactly the render paths that verify it is
-       present. The Kubernetes >= 1.30 requirement is documented instead, and the operator
-       opts out explicitly (admissionPolicy.enabled=false + acknowledgeUnbounded=true),
-       which is a decision that belongs in values rather than in cluster introspection. */}}
+       present. `.Capabilities.KubeVersion` has no such hole -- it always carries a version
+       (the client's own when there is no cluster) -- so THAT is what the >= 1.30 floor
+       below is checked against. */}}
+{{- /* Fail at render time, not at apply time: `admissionregistration.k8s.io/v1` does not
+       exist before 1.30, and without this an upgrade from 1.9.0 on an older cluster would
+       render clean and then abort mid-apply with "no matches for kind
+       ValidatingAdmissionPolicy", leaving the release in a failed state. */}}
+{{- if not (semverCompare ">=1.30.0-0" .Capabilities.KubeVersion.Version) }}
+{{- fail (printf "repmgr.agent.control.restore requires Kubernetes >= 1.30 for the ValidatingAdmissionPolicy that bounds its `create jobs` grant, but this cluster reports %s (#279). Upgrade the cluster, or set repmgr.agent.control.restore.admissionPolicy.enabled=false together with acknowledgeUnbounded=true to run the feature with an unbounded grant deliberately" .Capabilities.KubeVersion.Version) }}
+{{- end }}
 {{- $fullname := include "pg.fullname" . }}
 {{- $guard := include "pg.restoreGuardName" . }}
 {{- /* The Secrets the rendered restore Job legitimately reads through secretKeyRef. Any
@@ -42,17 +61,131 @@
 {{- if .Values.pgbackrest.repoEncryption.enabled }}
 {{- $secretRefs = append $secretRefs .Values.pgbackrest.repoEncryption.existingSecret.name }}
 {{- end }}
-{{- /* With keyType=auto and no repo encryption the release reads no Secret at all, and the
-       rule becomes "no secretKeyRef whatsoever" rather than an empty allowlist -- clearer
-       to read in a denial message, and it avoids leaning on CEL's typing of `x in []`. */}}
-{{- $secretRule := "!has(e.valueFrom.secretKeyRef)" }}
+{{- /* Allowed env valueFrom sources. fieldRef (the downward API, which can read nothing
+       but the pod's own metadata) is always permitted -- the restore's
+       RESTORE_REQUESTED_BY comes from it -- and this release's own Secrets are added when
+       it has any. Everything else (configMapKeyRef, resourceFieldRef, and any Secret that
+       is not the release's own) falls through to a denial.
+
+       Written as an ALLOWLIST of sources rather than "no secretKeyRef": under
+       s3.keyType=auto with repo encryption off the release reads no Secret at all, and a
+       rule phrased as a negation of secretKeyRef would then admit configMapKeyRef -- the
+       opposite of what its message promises, in exactly the keyless configuration a
+       cloud-workload-identity install uses. */}}
+{{- $valueFromRule := "has(e.valueFrom.fieldRef)" }}
 {{- if $secretRefs }}
-{{- $secretRule = printf "(has(e.valueFrom.secretKeyRef) && e.valueFrom.secretKeyRef.name in ['%s'])" (join "','" $secretRefs) }}
+{{- $valueFromRule = printf "has(e.valueFrom.fieldRef) || (has(e.valueFrom.secretKeyRef) && e.valueFrom.secretKeyRef.name in ['%s'])" (join "','" $secretRefs) }}
 {{- end }}
+{{- /* The pod-template labels the restore Job renders, read back from the same helper the
+       Job template uses so the two cannot drift. Pinning these is not cosmetic: the
+       primary and read-only Services select on pg.selectorLabels plus
+       app.kubernetes.io/component, so a Job whose POD carried component=postgresql would
+       be added to the write Service's endpoints -- a pod with no readiness probe becomes
+       Ready immediately, and application traffic (with its credentials) would be
+       load-balanced onto it. validation #2's label check is on the Job object and does
+       nothing about that. */}}
+{{- $podLabels := include "pg.selectorLabels" . | fromYaml }}
+{{- $_ := set $podLabels "app.kubernetes.io/component" "pgbackrest-restore" }}
+{{- /* The four labels the API server itself stamps on a Job's pod template, which are
+       therefore already on the object when this policy sees it: the batch controller's
+       PrepareForCreate runs BEFORE validating admission (the same reason a generateName is
+       already resolved by then), so a rule phrased as "exactly the labels the chart
+       renders" would deny every legitimate restore. They are safe to allow: their values
+       are server-assigned (the Job's own name and UID), validation #7 keeps
+       manualSelector from turning that off, and nothing in this chart selects on them. */}}
+{{- $ctrlLabelKeys := list "batch.kubernetes.io/controller-uid" "batch.kubernetes.io/job-name" "controller-uid" "job-name" }}
+{{- $podLabelRules := list (printf "variables.podLabels.all(k, k in ['%s'])" (join "','" (concat (keys $podLabels | sortAlpha) $ctrlLabelKeys))) }}
+{{- range $k := (keys $podLabels | sortAlpha) }}
+{{- $podLabelRules = append $podLabelRules (printf "('%s' in variables.podLabels && variables.podLabels['%s'] == '%s')" $k $k (index $podLabels $k)) }}
+{{- end }}
+{{- /* Security contexts, resources and the command are pinned to what THIS RELEASE'S
+       values render, not to a hardcoded hardened profile: a fixed profile would deny the
+       release's own restore the moment an operator legitimately changed
+       postgresql.containerSecurityContext, and a chart that denies its own Job is worse
+       than no policy at all. Each field is "present and equal to the rendered value" when
+       the values set it and "absent" when they do not, which is exactly the shape the
+       jobTemplate produces. */}}
+{{- $csc := .Values.postgresql.containerSecurityContext | default dict }}
+{{- $psc := .Values.postgresql.podSecurityContext | default dict }}
+{{- $caps := $csc.capabilities | default dict }}
+{{- $addPin := "(!has(c.securityContext.capabilities) || !has(c.securityContext.capabilities.add) || size(c.securityContext.capabilities.add) == 0)" }}
+{{- if hasKey $caps "add" }}
+{{- $addPin = printf "(has(c.securityContext.capabilities) && has(c.securityContext.capabilities.add) && c.securityContext.capabilities.add == ['%s'])" (join "','" $caps.add) }}
+{{- end }}
+{{- /* seccompProfile is pinned too, and it is not belt-and-braces. The command pin does not
+       make code execution in the restore container impossible: the container reads
+       $BASH_ENV, and an actor who already has code execution in the postgresql container can
+       write a file into PGDATA -- which this Job mounts -- and point BASH_ENV at it. What
+       that buys is uid 101 with no token and only this release's volumes, i.e. exactly the
+       privileges already held, which is the stated bar. Relaxing seccomp to Unconfined would
+       be a real step past it, so the profile is pinned to the release's own. Nested, hence
+       written out rather than going through pg.celScalarPin: has() on a leaf whose parent is
+       absent is an evaluation ERROR, not false. */}}
+{{- $cscSeccomp := "!has(c.securityContext.seccompProfile)" }}
+{{- if and $csc.seccompProfile $csc.seccompProfile.type }}
+{{- $cscSeccomp = printf "(has(c.securityContext.seccompProfile) && has(c.securityContext.seccompProfile.type) && c.securityContext.seccompProfile.type == '%s')" $csc.seccompProfile.type }}
+{{- end }}
+{{- $pscSeccomp := "!has(variables.pod.securityContext.seccompProfile)" }}
+{{- if and $psc.seccompProfile $psc.seccompProfile.type }}
+{{- $pscSeccomp = printf "(has(variables.pod.securityContext.seccompProfile) && has(variables.pod.securityContext.seccompProfile.type) && variables.pod.securityContext.seccompProfile.type == '%s')" $psc.seccompProfile.type }}
+{{- end }}
+{{- $cscPins := list
+      (include "pg.celScalarPin" (list "c.securityContext.privileged" $csc "privileged"))
+      (include "pg.celScalarPin" (list "c.securityContext.allowPrivilegeEscalation" $csc "allowPrivilegeEscalation"))
+      (include "pg.celScalarPin" (list "c.securityContext.runAsUser" $csc "runAsUser"))
+      (include "pg.celScalarPin" (list "c.securityContext.runAsNonRoot" $csc "runAsNonRoot"))
+      $addPin $cscSeccomp }}
+{{- $cscRule := "" }}
+{{- if $csc }}
+{{- $cscRule = printf "variables.pod.containers.all(c, has(c.securityContext) && %s)" (join " && " $cscPins) }}
+{{- else }}
+{{- $cscRule = "variables.pod.containers.all(c, !has(c.securityContext))" }}
+{{- end }}
+{{- $pscPins := list
+      (include "pg.celScalarPin" (list "variables.pod.securityContext.runAsUser" $psc "runAsUser"))
+      (include "pg.celScalarPin" (list "variables.pod.securityContext.runAsNonRoot" $psc "runAsNonRoot"))
+      $pscSeccomp }}
+{{- $pscRule := "" }}
+{{- if $psc }}
+{{- $pscRule = printf "has(variables.pod.securityContext) && %s" (join " && " $pscPins) }}
+{{- else }}
+{{- $pscRule = "!has(variables.pod.securityContext)" }}
+{{- end }}
+{{- /* Resources: presence of exactly the request/limit keys the release renders. The
+       VALUES are not compared -- a Quantity round-trips as the string it was written as
+       ("1" vs "1000m" vs 1), so an equality test on it would be a false-denial generator
+       during an incident. Presence is what matters here anyway: a container with no
+       limits, multiplied by an unbounded parallelism (validation #14), is the resource-
+       exhaustion path against the database's own nodes, and it is the same requests-and-
+       limits rule the chart's kube-linter gate enforces on every other container. */}}
+{{- $rres := .Values.pgbackrest.restore.resources | default dict }}
+{{- $resPins := list }}
+{{- range $section := list "requests" "limits" }}
+{{- $sec := (index $rres $section) | default dict }}
+{{- $keys := list }}
+{{- range $k := list "cpu" "memory" }}
+{{- if hasKey $sec $k }}
+{{- $keys = append $keys (printf "'%s' in c.resources.%s" $k $section) }}
+{{- end }}
+{{- end }}
+{{- if $keys }}
+{{- $resPins = append $resPins (printf "has(c.resources.%s) && %s" $section (join " && " $keys)) }}
+{{- end }}
+{{- end }}
+{{- /* Every value interpolated into a CEL string literal below, checked at render time for
+       characters that would break the expression or turn it into a tautology. */}}
+{{- $literals := list (list "the release namespace" .Release.Namespace) (list "the release fullname" $fullname) (list "repmgr.image (pg.repmgrImage)" (include "pg.repmgrImage" .)) }}
+{{- range $k, $v := $podLabels }}
+{{- $literals = append $literals (list (printf "the restore pod label %s" $k) $v) }}
+{{- end }}
+{{- range $s := $secretRefs }}
+{{- $literals = append $literals (list "a pgbackrest Secret name (pgbackrest.existingSecret.name / pgbackrest.repoEncryption.existingSecret.name)" $s) }}
+{{- end }}
+{{- include "pg.validateCelLiterals" $literals }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
-  # Cluster-scoped: namespace-prefixed so two releases cannot collide (pg.restoreGuardName).
+  # Cluster-scoped: hash-suffixed so two releases cannot collide (pg.restoreGuardName).
   name: {{ $guard }}
   labels:
     {{- include "pg.labels" . | nindent 4 }}
@@ -91,6 +224,11 @@ spec:
     # spec.template is required on a Job, so this cannot fail to evaluate.
     - name: pod
       expression: "object.spec.template.spec"
+    # spec.template.metadata IS optional, hence the ternary rather than a bare access:
+    # an absent metadata must reach validation #6 as an empty map (and be denied there for
+    # having no labels), not error out of the expression.
+    - name: podLabels
+      expression: "has(object.spec.template.metadata) && has(object.spec.template.metadata.labels) ? object.spec.template.metadata.labels : {}"
   validations:
     # 1. The bound RBAC could not express, and the one that collapses the grant: the agent
     #    always creates ONE deterministic Job name (which is why get/delete ARE scopeable
@@ -122,31 +260,91 @@ spec:
     - expression: "has(variables.pod.automountServiceAccountToken) && variables.pod.automountServiceAccountToken == false"
       message: "the pg agent's Jobs must set automountServiceAccountToken: false explicitly (the restore talks to S3 and the PVC, never to the Kubernetes API)"
       reason: Forbidden
-    # 5. Host namespaces: an escape from the pod boundary to the node, and the restore
-    #    needs none of the three.
-    - expression: "(!has(variables.pod.hostNetwork) || variables.pod.hostNetwork == false) && (!has(variables.pod.hostPID) || variables.pod.hostPID == false) && (!has(variables.pod.hostIPC) || variables.pod.hostIPC == false)"
-      message: "hostNetwork, hostPID and hostIPC are not permitted on the pg agent's Jobs"
+    # 5. Escapes from the pod boundary to the node, plus nodeName. nodeName is here because
+    #    it bypasses the scheduler outright -- it ignores taints, and it is how a caller
+    #    would place this pod on a specific node of its choosing. nodeSelector and
+    #    tolerations are deliberately NOT pinned: they are inherited from
+    #    postgresql.nodeSelector/tolerations (the restore has to be able to land where the
+    #    data volume can attach), they can only ever RESTRICT where the pod runs, and with
+    #    the command and volumes pinned below, placement grants nothing.
+    - expression: "(!has(variables.pod.hostNetwork) || variables.pod.hostNetwork == false) && (!has(variables.pod.hostPID) || variables.pod.hostPID == false) && (!has(variables.pod.hostIPC) || variables.pod.hostIPC == false) && !has(variables.pod.nodeName)"
+      message: "hostNetwork, hostPID, hostIPC and an explicit nodeName are not permitted on the pg agent's Jobs"
       reason: Forbidden
-    # 6+7. One container, running the release's own image. The agent already refuses to
+    # 6. The pod's OWN labels: an allowlist of keys (this release's restore pod labels plus
+    #    the batch controller's own), with the release's values pinned. A key allowlist
+    #    rather than a subset check, because an EXTRA label is the whole attack -- it is how
+    #    a pod joins a selector it should not match (see the Service-endpoint reasoning above
+    #    the rule's construction).
+    - expression: >-
+        {{ join " && " $podLabelRules }}
+      message: "the pg agent's Jobs may carry only this release's restore pod labels ({{ range $i, $k := (keys $podLabels | sortAlpha) }}{{ if $i }}, {{ end }}{{ $k }}={{ index $podLabels $k }}{{ end }}) plus the batch controller's own -- extra or altered pod labels would let the restore pod join this release's Service endpoints"
+      reason: Forbidden
+    # 7. manualSelector is what turns OFF the server-side selector generation that #6's key
+    #    allowlist is written around, so it is pinned to what the chart renders (absent).
+    #    Honestly labelled defence in depth rather than a closed hole: built-in Job
+    #    validation already requires spec.selector to be present and to MATCH the pod
+    #    template labels, and #6 pins those, so a manual selector cannot be aimed at this
+    #    release's postgresql pods even without this rule. What it removes is the case where
+    #    a Job's identity labels are caller-supplied rather than server-assigned.
+    - expression: "!has(object.spec.manualSelector) || object.spec.manualSelector == false"
+      message: "the pg agent's Jobs may not set manualSelector: the API server must generate the Job's pod selector and identity labels"
+      reason: Forbidden
+    # 8+9. One container, running the release's own image. The agent already refuses to
     #    clone a jobTemplate with anything other than exactly one container (it will not
     #    guess which container's env to rewrite), so this matches the agent's own rule.
-    #    The image pin bounds what code enters the cluster on this token; it is a weaker
-    #    bound than it looks -- the postgresql container runs the same image with the same
-    #    data volume already -- which is why the container's command is deliberately NOT
-    #    pinned here: it would add no bound the volume and env rules below do not, and a
-    #    command array is exactly the kind of detail that drifts and produces a false
-    #    denial during an incident.
-    - expression: "size(variables.pod.containers) == 1 && (!has(variables.pod.initContainers) || size(variables.pod.initContainers) == 0)"
-      message: "the pg agent's Jobs must have exactly one container and no init containers"
+    #    ephemeralContainers cannot be set through a pod template at all, but denying it
+    #    here costs one clause and removes the question.
+    - expression: "size(variables.pod.containers) == 1 && (!has(variables.pod.initContainers) || size(variables.pod.initContainers) == 0) && (!has(variables.pod.ephemeralContainers) || size(variables.pod.ephemeralContainers) == 0)"
+      message: "the pg agent's Jobs must have exactly one container and no init or ephemeral containers"
       reason: Forbidden
     - expression: "variables.pod.containers.all(c, c.image == '{{ include "pg.repmgrImage" . }}')"
       message: "the pg agent's Jobs may only run this release's repmgr image ({{ include "pg.repmgrImage" . }})"
       reason: Forbidden
-    # 8. Volumes, and after the ServiceAccount pin this is the check that matters most.
+    # 10. The command, pinned to the release's own restore entrypoint (pg.restoreCommandJSON,
+    #    the same definition the jobTemplate renders, converted to CEL quoting). The image
+    #    pin alone is a weak bound -- the postgresql container already runs this image with
+    #    this data volume -- so without this the Job is "run anything you like as the
+    #    database's uid, with the live PGDATA mounted", which is a data-destruction
+    #    primitive that needs no privilege escalation at all. With it, the Job can only run
+    #    the chart's restore.sh (delivered by the pinned ConfigMap volume, which this token
+    #    cannot write) and the only caller-controlled inputs are the literal env values the
+    #    restore already takes.
+    - expression: "variables.pod.containers.all(c, has(c.command) && c.command == {{ include "pg.restoreCommandJSON" . | replace "\"" "'" }} && !has(c.args))"
+      message: "the pg agent's Jobs must run exactly this release's restore command ({{ include "pg.restoreCommandJSON" . | replace "\"" "'" }}) with no args"
+      reason: Forbidden
+    # 11+12. Security contexts, pinned to the release's own (see the reasoning above their
+    #    construction). Without these the Job is admitted with privileged: true,
+    #    runAsUser: 0 and CAP_SYS_ADMIN -- a root container on a node of the caller's
+    #    choosing, which is a strictly larger privilege set than the token started with and
+    #    would make "same privileges I already hold" false.
+    - expression: "{{ $cscRule }}"
+      message: "the pg agent's Jobs must run with this release's container security context (postgresql.containerSecurityContext) -- privileged, added capabilities, a different runAsUser or a relaxed allowPrivilegeEscalation are denied"
+      reason: Forbidden
+    - expression: "{{ $pscRule }}"
+      message: "the pg agent's Jobs must run with this release's pod security context (postgresql.podSecurityContext)"
+      reason: Forbidden
+    {{- if $resPins }}
+    # 13. Requests and limits, present as the release renders them (values deliberately not
+    #    compared -- see the reasoning above).
+    - expression: "variables.pod.containers.all(c, has(c.resources) && {{ join " && " $resPins }})"
+      message: "the pg agent's Jobs must declare the CPU and memory requests and limits this release renders (pgbackrest.restore.resources)"
+      reason: Forbidden
+    {{- end }}
+    # 14. One pod, once. The API server DEFAULTS both fields to 1 before admission runs, so
+    #    this is written as "<= 1" rather than "absent": the rendered Job sets neither, and
+    #    requiring absence would deny every legitimate restore. Unbounded parallelism is
+    #    what turns one permitted Job name into a repeatable way to fill the namespace's
+    #    ResourceQuota and evict the database's own pods.
+    - expression: "(!has(object.spec.parallelism) || object.spec.parallelism <= 1) && (!has(object.spec.completions) || object.spec.completions <= 1)"
+      message: "the pg agent's Jobs must run a single pod (parallelism and completions <= 1)"
+      reason: Forbidden
+    # 15. Volumes, and after the ServiceAccount pin this is the check that matters most.
     #    With the token gone, mounting somebody else's Secret is the remaining way to reach
     #    outside this release -- so the sources are pinned to exactly the three the restore
     #    template renders. hostPath, projected service-account tokens, arbitrary Secrets
     #    and arbitrary PVCs all fall out of this as denials rather than needing a rule each.
+    #    volumeMounts (paths, subPath) are not pinned: with the command fixed and the set of
+    #    volumes closed, remapping a mount can only break the restore, not widen it.
     - expression: >-
         !has(variables.pod.volumes) || variables.pod.volumes.all(v,
         has(v.emptyDir)
@@ -154,14 +352,13 @@ spec:
         || (has(v.persistentVolumeClaim) && v.persistentVolumeClaim.claimName == 'data-{{ $fullname }}-{{ .Values.pgbackrest.restore.podOrdinal }}'))
       message: "the pg agent's Jobs may mount only this release's restore volumes: emptyDir, configMap {{ $fullname }}-pgbackrest, and PVC data-{{ $fullname }}-{{ .Values.pgbackrest.restore.podOrdinal }}"
       reason: Forbidden
-    # 9. The same bound for env: envFrom pulls a whole Secret or ConfigMap, and
-    #    secretKeyRef/configMapKeyRef pull a key from any of them. Only fieldRef (the
-    #    downward API, which can read nothing but the pod's own metadata) and the
-    #    release's own Secrets are allowed through.
+    # 16. The same bound for env: envFrom pulls a whole Secret or ConfigMap, and
+    #    secretKeyRef/configMapKeyRef pull a key from any of them. Only the downward API
+    #    and the release's own Secrets are allowed through (see $valueFromRule above).
     - expression: >-
         variables.pod.containers.all(c, !has(c.envFrom) && (!has(c.env) || c.env.all(e,
-        !has(e.valueFrom) || has(e.valueFrom.fieldRef) || {{ $secretRule }})))
-      message: "the pg agent's Jobs may not use envFrom, and may reference only the downward API or this release's own Secrets{{ with $secretRefs }} ({{ join ", " . }}){{ end }} through env valueFrom"
+        !has(e.valueFrom) || ({{ $valueFromRule }}))))
+      message: "the pg agent's Jobs may not use envFrom, and may reference only the downward API{{ with $secretRefs }} or this release's own Secrets ({{ join ", " . }}){{ end }} through env valueFrom"
       reason: Forbidden
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/pg/templates/pgbackrest-restore-job.yaml
+++ b/pg/templates/pgbackrest-restore-job.yaml
@@ -204,6 +204,20 @@ spec:
   successfulJobsHistoryLimit: {{ .Values.pgbackrest.cronjob.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.pgbackrest.cronjob.failedJobsHistoryLimit }}
   jobTemplate:
+    {{- /* Labels on the jobTemplate, not only on the CronJob itself: both `kubectl create
+           job --from=cronjob/...` and the control API's clone copy THESE onto the Job they
+           create, and nothing else does -- before #279 the jobTemplate carried no metadata
+           at all, so a cloned Job had no labels whatsoever.
+
+           Deliberately just this one label rather than the standard pg.labels set: a Job
+           the agent creates is not Helm-managed, and stamping it with
+           app.kubernetes.io/managed-by=Helm plus app.kubernetes.io/instance would make it
+           look like release content to a GitOps controller, which may then prune it
+           mid-restore. pg.fullname is release-unique, so one label is enough to select
+           them: kubectl get jobs -l pg-ha/restore=<fullname>. */}}
+    metadata:
+      labels:
+        pg-ha/restore: {{ include "pg.fullname" . }}
     spec:
       {{- include "pg.pgbackrestRestoreJobSpec" . | nindent 6 }}
 {{- else }}

--- a/pg/templates/pgbackrest-restore-job.yaml
+++ b/pg/templates/pgbackrest-restore-job.yaml
@@ -84,8 +84,9 @@ template:
           {{- toYaml .Values.postgresql.containerSecurityContext | nindent 10 }}
         # The restore program lives in the pgbackrest ConfigMap (restore.sh), mounted
         # below -- mirrors the #38 validation rather than inlining shell here. All inputs
-        # arrive via env.
-        command: ["/bin/bash", "/scripts/restore.sh"]
+        # arrive via env. Shared with the admission policy that pins it (#279), so the pin
+        # and the command cannot drift.
+        command: {{ include "pg.restoreCommandJSON" . }}
         env:
           - name: PGBACKREST_STANZA
             value: {{ .Values.pgbackrest.stanza | quote }}

--- a/pg/templates/rbac.yaml
+++ b/pg/templates/rbac.yaml
@@ -66,24 +66,31 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["create"]
-{{- if .Values.repmgr.agent.control.restore.enabled }}
+{{- if eq (include "pg.controlRestoreEnabled" .) "true" }}
   # Control-API restore triggering (#276). READ THIS BEFORE ENABLING IT.
   #
   # `create` on jobs CANNOT be restricted by resourceName -- the API server does not
-  # know an object's name at authorization time for a create -- so this grant lets
-  # anything holding the postgresql pods' ServiceAccount token create ARBITRARY Jobs
+  # know an object's name at authorization time for a create -- so this grant BY ITSELF
+  # lets anything holding the postgresql pods' ServiceAccount token create ARBITRARY Jobs
   # in this namespace. A Job's pod may name any ServiceAccount, and Kubernetes does no
   # separate permission check for that, which makes this a namespace-wide
   # privilege-escalation primitive. The token is mounted next to a PostgreSQL that
   # executes user-supplied SQL, i.e. the chart's largest attack surface.
   #
-  # What narrows it: the grant is rendered ONLY under
+  # What actually bounds it is NOT in this file, because the restriction has to happen at
+  # a layer RBAC does not reach: the ValidatingAdmissionPolicy in
+  # agent-restore-admissionpolicy.yaml (#279) restricts these creates by CONTENT -- one
+  # permitted Job name, this release's ServiceAccount, no mounted token, this release's
+  # volumes and Secrets only. It renders under the same pg.controlRestoreEnabled condition
+  # as this grant, and a values combination that would drop it fails the render, so a Role
+  # carrying this rule without that policy is not a state the chart can produce.
+  #
+  # Narrowing it further: the grant is rendered ONLY under
   # repmgr.agent.control.restore.enabled (default false, so a normal install's Role is
   # unchanged), the API additionally requires a client certificate whose CN is on
   # repmgr.agent.control.restore.allowedClientCNs, and the Job the agent creates is a
   # verbatim clone of the CronJob below rather than a spec it composes. The equivalent
-  # kubectl path (`kubectl create job --from=cronjob/...`) needs none of this, so leave
-  # this off unless API-driven restore is worth the trade.
+  # kubectl path (`kubectl create job --from=cronjob/...`) needs none of this.
   #
   # get on the CronJob: the jobTemplate the agent clones.
   - apiGroups: ["batch"]

--- a/pg/templates/rbac.yaml
+++ b/pg/templates/rbac.yaml
@@ -80,10 +80,19 @@ rules:
   # What actually bounds it is NOT in this file, because the restriction has to happen at
   # a layer RBAC does not reach: the ValidatingAdmissionPolicy in
   # agent-restore-admissionpolicy.yaml (#279) restricts these creates by CONTENT -- one
-  # permitted Job name, this release's ServiceAccount, no mounted token, this release's
-  # volumes and Secrets only. It renders under the same pg.controlRestoreEnabled condition
-  # as this grant, and a values combination that would drop it fails the render, so a Role
-  # carrying this rule without that policy is not a state the chart can produce.
+  # permitted Job name, this release's ServiceAccount with no mounted token, this
+  # release's image running this release's restore command, its security contexts, volumes
+  # and Secrets, and a single pod. It renders under the same pg.controlRestoreEnabled
+  # condition as this grant, and dropping it requires setting
+  # repmgr.agent.control.restore.admissionPolicy.acknowledgeUnbounded=true, which the
+  # render otherwise refuses.
+  #
+  # So this rule CAN still exist without that policy -- deliberately, for clusters below
+  # Kubernetes 1.30 and for namespace-limited installers -- and in that configuration the
+  # 1.9.0 warning applies unchanged: the grant is unbounded, and it is worth having only
+  # if API-driven restore is worth that trade. Check which state you are in with
+  # `kubectl get validatingadmissionpolicybinding -l app.kubernetes.io/instance=<release>`;
+  # do not infer it from the presence of this rule.
   #
   # Narrowing it further: the grant is rendered ONLY under
   # repmgr.agent.control.restore.enabled (default false, so a normal install's Role is

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -74,6 +74,15 @@
 {{- if not $control.restore.allowedClientCNs }}
 {{- fail "repmgr.agent.control.restore.enabled requires a non-empty repmgr.agent.control.restore.allowedClientCNs: restore is a separate authz verb from pause/switchover, and an empty allowlist denies every client -- name the certificate CNs permitted to overwrite the data directory" }}
 {{- end }}
+{{- /* The grant and its bound render together or not at all (#279). Refusing here rather
+       than warning is the point: `create jobs` cannot be resourceName-scoped, so a Role
+       rendered without the admission policy carries a namespace-wide privilege-escalation
+       primitive on a token that sits next to user-supplied SQL. Opting out stays possible
+       -- a cluster below 1.30, a namespace-limited installer, a platform-managed policy --
+       but it has to be said out loud in values, where it is reviewable. */}}
+{{- if and (not $control.restore.admissionPolicy.enabled) (not $control.restore.admissionPolicy.acknowledgeUnbounded) }}
+{{- fail "repmgr.agent.control.restore.admissionPolicy.enabled=false leaves the restore feature's `create jobs` grant unbounded: RBAC cannot restrict create by resourceName, so anything holding the database pods' ServiceAccount token could create arbitrary Jobs in this namespace and name any ServiceAccount in them. Either leave admissionPolicy.enabled=true (it needs Kubernetes >= 1.30 and cluster-scoped create on ValidatingAdmissionPolicy), or set repmgr.agent.control.restore.admissionPolicy.acknowledgeUnbounded=true to accept that trade deliberately" }}
+{{- end }}
 {{- end }}
 {{- if and $control.restore.readPodLogs (not $control.restore.enabled) }}
 {{- fail "repmgr.agent.control.restore.readPodLogs requires repmgr.agent.control.restore.enabled (it only affects reading a restore Job's log)" }}

--- a/pg/tests/helpers.sh
+++ b/pg/tests/helpers.sh
@@ -45,6 +45,22 @@ assert_eq() {
   fi
 }
 
+# Both sides must be non-empty: "two things differ" is a vacuous assertion when either is
+# the empty string, which is exactly how a renamed template or a moved value turns a
+# uniqueness check into a no-op (#279).
+assert_not_eq() {
+  local description="$1"
+  local a="$2"
+  local b="$3"
+  if [[ -z "${a}" || -z "${b}" ]]; then
+    fail "${description}" "both values must be non-empty (a='${a}' b='${b}')"
+  elif [[ "${a}" != "${b}" ]]; then
+    pass "${description}"
+  else
+    fail "${description}" "both values are '${a}'"
+  fi
+}
+
 assert_contains() {
   local description="$1"
   local haystack="$2"

--- a/pg/tests/test-agent-control-restore.sh
+++ b/pg/tests/test-agent-control-restore.sh
@@ -11,7 +11,10 @@
 #     as lastRestore AFTER the scale-down/up cycle -- the whole point of that file, since
 #     by then the Job may be gone;
 #   * WAL-replay progress is visible on GET /v1/status once the cluster is back, which is
-#     the progress signal that survives scaling to 0.
+#     the progress signal that survives scaling to 0;
+#   * the ValidatingAdmissionPolicy that bounds the unscopeable `create jobs` grant (#279)
+#     admits the agent's own Job and denies every tampered one -- content-based admission
+#     exists only in the apiserver, so there is no cheaper layer that could test it.
 #
 # It also documents the honest shape of the flow: the API removes the `kubectl create job
 # --from` step and nothing else. Scaling to 0 deletes every agent, so the API cannot do it
@@ -117,6 +120,111 @@ assert_eq "RBAC: cannot read another CronJob" "no" "$(can get "cronjobs/${FULLNA
 assert_eq "RBAC: cannot list Jobs" "no" "$(can list jobs)"
 assert_eq "RBAC: no pods/log without restore.readPodLogs" "no" "$(can get pods/log)"
 assert_eq "RBAC: still cannot read Secrets" "no" "$(can get secrets)"
+
+# --- and the bound on the one grant RBAC could not scope (#279) ---
+#
+# `create jobs` above is unscopeable, so what limits it is a ValidatingAdmissionPolicy:
+# RBAC restricts by verb and resource, admission restricts by CONTENT. Only a live
+# apiserver can test that, and it has to be tested in BOTH directions -- a policy that
+# denied the agent's own restore would break the feature, and one that policed every
+# creator would break every other controller in the namespace.
+#
+# Each case submits the Job `kubectl create job --from=cronjob/...` builds -- the same
+# clone the agent builds -- as the pods' ServiceAccount, with one field tampered.
+# --dry-run=server runs the full admission chain and creates nothing.
+GUARD="${NAMESPACE}-${FULLNAME}-restore-guard"
+assert_eq "VAP: the policy is installed" "${GUARD}" \
+  "$(kubectl get validatingadmissionpolicy "${GUARD}" -o jsonpath='{.metadata.name}' 2>/dev/null || true)"
+assert_eq "VAP: the binding is installed" "${GUARD}" \
+  "$(kubectl get validatingadmissionpolicybinding "${GUARD}" -o jsonpath='{.metadata.name}' 2>/dev/null || true)"
+assert_eq "VAP: fails closed (Ignore would silently re-open the hole)" "Fail" \
+  "$(kubectl get validatingadmissionpolicy "${GUARD}" -o jsonpath='{.spec.failurePolicy}' 2>/dev/null || true)"
+# The apiserver type-checks every expression against batch/v1 Job and reports what does not
+# resolve. A warning here means a validation that can never do its job -- and under
+# failurePolicy: Fail, one that may deny every restore instead.
+vap_warnings=$(kubectl get validatingadmissionpolicy "${GUARD}" \
+  -o jsonpath='{.status.typeChecking.expressionWarnings}' 2>/dev/null || true)
+[ -n "${vap_warnings}" ] && echo "  note: apiserver type-check warnings: ${vap_warnings}"
+assert_eq "VAP: the apiserver type-checks every expression cleanly" "" "${vap_warnings}"
+
+# clone_job <jq filter> -- the Job the agent would create, with the filter applied.
+clone_job() {
+  kubectl create job "${API_JOB}" --from=cronjob/"${FULLNAME}-pgbackrest-restore" \
+    -n "${NAMESPACE}" --dry-run=client -o json 2>/dev/null | jq "$1"
+}
+# admit <jq filter> [<impersonated user>|human] -> "allowed" | the apiserver's denial message
+# The literal "human" means "do not impersonate", i.e. submit as whoever is running the
+# suite. A sentinel rather than an empty second argument, because ${2:-${SA}} would silently
+# substitute the ServiceAccount for one and turn the control case into a duplicate.
+admit() {
+  local filter="$1" who="${2:-${SA}}" out rc=0 args=(-f - -n "${NAMESPACE}" --dry-run=server -o name)
+  [[ "${who}" != "human" ]] && args+=(--as="${who}")
+  out=$(clone_job "${filter}" | kubectl create "${args[@]}" 2>&1) || rc=$?
+  if [ "${rc}" -eq 0 ]; then echo "allowed"; else echo "${out}"; fi
+}
+
+# The direction that is easy to forget: the legitimate restore must still go through, and a
+# human or any other controller must be unaffected by the policy existing.
+assert_eq "VAP: the agent's own restore Job is admitted" "allowed" "$(admit '.')"
+unrelated='.metadata.name="vap-unrelated-job" | .metadata.labels={} | .spec.template.spec.serviceAccountName="default" | .spec.template.spec.automountServiceAccountToken=true'
+assert_eq "VAP: a Job created by a human is untouched" "allowed" "$(admit "${unrelated}" human)"
+
+# The escalation primitive itself: a Job's pod may name any ServiceAccount, with no separate
+# permission check. This is the denial the whole feature's safety rests on.
+assert_contains "VAP: naming another ServiceAccount is denied" \
+  "$(admit '.spec.template.spec.serviceAccountName="privileged-sa"')" \
+  "may only create Jobs running as ServiceAccount"
+# ...and why it would not help even if it were not: no token is mounted.
+assert_contains "VAP: mounting the ServiceAccount token is denied" \
+  "$(admit '.spec.template.spec.automountServiceAccountToken=true')" \
+  "automountServiceAccountToken: false"
+assert_contains "VAP: omitting automountServiceAccountToken is denied (absent is not a pass)" \
+  "$(admit 'del(.spec.template.spec.automountServiceAccountToken)')" \
+  "automountServiceAccountToken: false"
+# The bound RBAC could not express: create collapses to ONE permitted object name.
+assert_contains "VAP: any other Job name is denied" \
+  "$(admit '.metadata.name="evil"')" "may create only the Job"
+# generateName cannot slip past it: name generation happens before VALIDATING admission, so
+# the policy sees the final name. Worth proving rather than reasoning about.
+assert_contains "VAP: generateName cannot dodge the name pin" \
+  "$(admit 'del(.metadata.name) | .metadata.generateName="evil-"')" "may create only the Job"
+assert_contains "VAP: a Job without the pg-ha/restore label is denied" \
+  "$(admit '.metadata.labels={}')" "must carry pg-ha/restore"
+assert_contains "VAP: hostNetwork is denied" \
+  "$(admit '.spec.template.spec.hostNetwork=true')" "hostNetwork, hostPID and hostIPC are not permitted"
+assert_contains "VAP: hostPID is denied" \
+  "$(admit '.spec.template.spec.hostPID=true')" "hostNetwork, hostPID and hostIPC are not permitted"
+assert_contains "VAP: another image is denied" \
+  "$(admit '.spec.template.spec.containers[0].image="attacker/img:1"')" "may only run this release's repmgr image"
+assert_contains "VAP: a second container is denied" \
+  "$(admit '.spec.template.spec.containers += [{"name":"x","image":"busybox"}]')" "exactly one container"
+assert_contains "VAP: an init container is denied" \
+  "$(admit '.spec.template.spec.initContainers=[{"name":"i","image":"busybox"}]')" "exactly one container"
+# With the token gone, mounting somebody else's Secret is the remaining route out of this
+# release -- so the volume sources are pinned to the three the restore template renders.
+assert_contains "VAP: mounting an arbitrary Secret is denied" \
+  "$(admit '.spec.template.spec.volumes += [{"name":"steal","secret":{"secretName":"pg-control-restore-tls"}}]')" \
+  "may mount only this release's restore volumes"
+assert_contains "VAP: a hostPath mount is denied" \
+  "$(admit '.spec.template.spec.volumes += [{"name":"node","hostPath":{"path":"/"}}]')" \
+  "may mount only this release's restore volumes"
+assert_contains "VAP: a projected ServiceAccount token is denied" \
+  "$(admit '.spec.template.spec.volumes += [{"name":"tok","projected":{"sources":[{"serviceAccountToken":{"path":"t"}}]}}]')" \
+  "may mount only this release's restore volumes"
+assert_contains "VAP: an unrelated PVC is denied" \
+  "$(admit '.spec.template.spec.volumes += [{"name":"other","persistentVolumeClaim":{"claimName":"data-other-0"}}]')" \
+  "may mount only this release's restore volumes"
+# The same bound for env: envFrom pulls a whole Secret, secretKeyRef/configMapKeyRef a key
+# from any of them. Only the downward API and this release's own Secrets get through.
+assert_contains "VAP: reading another Secret through secretKeyRef is denied" \
+  "$(admit '.spec.template.spec.containers[0].env += [{"name":"X","valueFrom":{"secretKeyRef":{"name":"pg-control-restore-tls","key":"tls.key"}}}]')" \
+  "may not use envFrom"
+assert_contains "VAP: envFrom is denied" \
+  "$(admit '.spec.template.spec.containers[0].envFrom=[{"secretRef":{"name":"pg-control-restore-tls"}}]')" \
+  "may not use envFrom"
+assert_contains "VAP: reading a ConfigMap through configMapKeyRef is denied" \
+  "$(admit '.spec.template.spec.containers[0].env += [{"name":"X","valueFrom":{"configMapKeyRef":{"name":"kube-root-ca.crt","key":"ca.crt"}}}]')" \
+  "may not use envFrom"
 
 # --- data + a backup to restore from ---
 

--- a/pg/tests/test-agent-control-restore.sh
+++ b/pg/tests/test-agent-control-restore.sh
@@ -132,16 +132,27 @@ assert_eq "RBAC: still cannot read Secrets" "no" "$(can get secrets)"
 # Each case submits the Job `kubectl create job --from=cronjob/...` builds -- the same
 # clone the agent builds -- as the pods' ServiceAccount, with one field tampered.
 # --dry-run=server runs the full admission chain and creates nothing.
-GUARD="${NAMESPACE}-${FULLNAME}-restore-guard"
-assert_eq "VAP: the policy is installed" "${GUARD}" \
-  "$(kubectl get validatingadmissionpolicy "${GUARD}" -o jsonpath='{.metadata.name}' 2>/dev/null || true)"
-assert_eq "VAP: the binding is installed" "${GUARD}" \
+# The name is hash-suffixed (pg.restoreGuardName), so it is looked up by the release labels
+# rather than reconstructed here -- reconstructing it would make this suite drift from the
+# helper the moment the naming changed.
+GUARD=$(kubectl get validatingadmissionpolicy \
+  -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=pg" \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+assert_contains "VAP: the policy is installed, hash-discriminated per namespace and release" \
+  "${GUARD}" "^${NAMESPACE}-${FULLNAME}-restore-guard-[0-9a-f]\{8\}$"
+assert_eq "VAP: the binding is installed under the same name" "${GUARD}" \
   "$(kubectl get validatingadmissionpolicybinding "${GUARD}" -o jsonpath='{.metadata.name}' 2>/dev/null || true)"
 assert_eq "VAP: fails closed (Ignore would silently re-open the hole)" "Fail" \
   "$(kubectl get validatingadmissionpolicy "${GUARD}" -o jsonpath='{.spec.failurePolicy}' 2>/dev/null || true)"
 # The apiserver type-checks every expression against batch/v1 Job and reports what does not
 # resolve. A warning here means a validation that can never do its job -- and under
 # failurePolicy: Fail, one that may deny every restore instead.
+# Checked in two steps on purpose: comparing the warnings list against "" alone would pass
+# identically whether the apiserver found nothing or had not populated .status yet, so the
+# presence of the status block is asserted first.
+vap_status=$(kubectl get validatingadmissionpolicy "${GUARD}" \
+  -o jsonpath='{.status.typeChecking}' 2>/dev/null || true)
+assert_contains "VAP: the apiserver has type-checked the policy at all" "${vap_status}" "."
 vap_warnings=$(kubectl get validatingadmissionpolicy "${GUARD}" \
   -o jsonpath='{.status.typeChecking.expressionWarnings}' 2>/dev/null || true)
 [ -n "${vap_warnings}" ] && echo "  note: apiserver type-check warnings: ${vap_warnings}"
@@ -191,9 +202,9 @@ assert_contains "VAP: generateName cannot dodge the name pin" \
 assert_contains "VAP: a Job without the pg-ha/restore label is denied" \
   "$(admit '.metadata.labels={}')" "must carry pg-ha/restore"
 assert_contains "VAP: hostNetwork is denied" \
-  "$(admit '.spec.template.spec.hostNetwork=true')" "hostNetwork, hostPID and hostIPC are not permitted"
+  "$(admit '.spec.template.spec.hostNetwork=true')" "hostNetwork, hostPID, hostIPC and an explicit nodeName are not permitted"
 assert_contains "VAP: hostPID is denied" \
-  "$(admit '.spec.template.spec.hostPID=true')" "hostNetwork, hostPID and hostIPC are not permitted"
+  "$(admit '.spec.template.spec.hostPID=true')" "hostNetwork, hostPID, hostIPC and an explicit nodeName are not permitted"
 assert_contains "VAP: another image is denied" \
   "$(admit '.spec.template.spec.containers[0].image="attacker/img:1"')" "may only run this release's repmgr image"
 assert_contains "VAP: a second container is denied" \
@@ -225,6 +236,99 @@ assert_contains "VAP: envFrom is denied" \
 assert_contains "VAP: reading a ConfigMap through configMapKeyRef is denied" \
   "$(admit '.spec.template.spec.containers[0].env += [{"name":"X","valueFrom":{"configMapKeyRef":{"name":"kube-root-ca.crt","key":"ca.crt"}}}]')" \
   "may not use envFrom"
+assert_contains "VAP: a resourceFieldRef is denied (only the downward API's own metadata)" \
+  "$(admit '.spec.template.spec.containers[0].env += [{"name":"X","valueFrom":{"resourceFieldRef":{"resource":"limits.cpu"}}}]')" \
+  "may not use envFrom"
+
+# The command pin, and why it is the difference between "one permitted Job" and "run anything
+# you like as the database's uid with the live PGDATA mounted". Destroying the data directory
+# needs no privilege escalation at all, so this is asserted first among the hardening cases.
+assert_contains "VAP: an arbitrary command over the live PGDATA is denied" \
+  "$(admit '.spec.template.spec.containers[0].command=["bash","-c","rm -rf /var/lib/postgresql/data/pgdata/*"]')" \
+  "must run exactly this release's restore command"
+assert_contains "VAP: appending args to the pinned command is denied" \
+  "$(admit '.spec.template.spec.containers[0].args=["-c","id"]')" \
+  "must run exactly this release's restore command"
+assert_contains "VAP: omitting the command is denied" \
+  "$(admit 'del(.spec.template.spec.containers[0].command)')" \
+  "must run exactly this release's restore command"
+
+# Security contexts. Without these the Job is admitted as a root container with CAP_SYS_ADMIN
+# -- which reads every other pod's projected token off the kubelet, and is a strictly LARGER
+# privilege set than the token started with, making "same privileges I already hold" false.
+# privileged:true alongside allowPrivilegeEscalation:false is rejected by the apiserver's own
+# validation, so the realistic payload relaxes both.
+assert_contains "VAP: a privileged container is denied" \
+  "$(admit '.spec.template.spec.containers[0].securityContext.privileged=true | .spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation=true')" \
+  "must run with this release's container security context"
+assert_contains "VAP: running as uid 0 is denied" \
+  "$(admit '.spec.template.spec.containers[0].securityContext.runAsUser=0')" \
+  "must run with this release's container security context"
+assert_contains "VAP: adding capabilities is denied" \
+  "$(admit '.spec.template.spec.containers[0].securityContext.capabilities.add=["SYS_ADMIN"]')" \
+  "must run with this release's container security context"
+assert_contains "VAP: relaxing allowPrivilegeEscalation is denied" \
+  "$(admit '.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation=true')" \
+  "must run with this release's container security context"
+assert_contains "VAP: dropping the container securityContext entirely is denied" \
+  "$(admit 'del(.spec.template.spec.containers[0].securityContext)')" \
+  "must run with this release's container security context"
+assert_contains "VAP: overriding runAsNonRoot per-container is denied" \
+  "$(admit '.spec.template.spec.containers[0].securityContext.runAsNonRoot=false')" \
+  "must run with this release's container security context"
+assert_contains "VAP: relaxing the pod securityContext is denied" \
+  "$(admit '.spec.template.spec.securityContext.runAsNonRoot=false')" \
+  "must run with this release's pod security context"
+# seccomp is pinned because the command pin does NOT make code execution in this container
+# impossible: bash reads $BASH_ENV, and an actor who already runs code in the postgresql
+# container can write a file into PGDATA -- which this Job mounts -- and point at it. That
+# buys only the privileges already held; Unconfined would be a step past them.
+assert_contains "VAP: relaxing the pod seccomp profile to Unconfined is denied" \
+  "$(admit '.spec.template.spec.securityContext.seccompProfile.type="Unconfined"')" \
+  "must run with this release's pod security context"
+assert_contains "VAP: setting a container seccomp profile the release does not is denied" \
+  "$(admit '.spec.template.spec.containers[0].securityContext.seccompProfile.type="Unconfined"')" \
+  "must run with this release's container security context"
+
+# The pod's OWN labels. The Job object's label (asserted above) says nothing about the pod,
+# and the primary Service selects pg.selectorLabels + component=postgresql: a restore pod
+# wearing those joins the write Service's endpoints, is Ready at once (it has no readiness
+# probe), and receives application traffic and its credentials.
+assert_contains "VAP: relabelling the pod onto the primary Service is denied" \
+  "$(admit '.spec.template.metadata.labels."app.kubernetes.io/component"="postgresql"')" \
+  "may carry only this release's restore pod labels"
+assert_contains "VAP: an extra Service-selector label on the pod is denied" \
+  "$(admit '.spec.template.metadata.labels."statefulset.kubernetes.io/pod-name"="'"${FULLNAME}"'-0"')" \
+  "may carry only this release's restore pod labels"
+assert_contains "VAP: stripping the pod labels is denied" \
+  "$(admit 'del(.spec.template.metadata.labels)')" \
+  "may carry only this release's restore pod labels"
+# ...and the four labels the APISERVER stamps on a Job's pod template must NOT trip that rule:
+# the batch strategy runs before validating admission, so they are already on the object. This
+# is the direction that breaks the feature if the allowlist forgets them.
+assert_eq "VAP: the server-stamped batch controller labels do not trip the pod-label rule" \
+  "allowed" "$(admit '.')"
+
+# manualSelector turns off the server-side selector and identity labels the rule above is
+# written around. Built-in Job validation requires spec.selector to match the pod template
+# labels, so the only payload that reaches the policy is one mirroring the pinned labels.
+assert_contains "VAP: manualSelector is denied" \
+  "$(admit '.spec.manualSelector=true | .spec.selector={"matchLabels":{"app.kubernetes.io/name":"pg","app.kubernetes.io/instance":"'"${RELEASE}"'","app.kubernetes.io/component":"pgbackrest-restore"}}')" \
+  "may not set manualSelector"
+
+# Placement and scale. nodeName bypasses the scheduler and its taints outright; unbounded
+# parallelism over a limitless container turns the one permitted Job name into a repeatable
+# way to fill the namespace quota and evict the database's own pods.
+assert_contains "VAP: an explicit nodeName is denied" \
+  "$(admit '.spec.template.spec.nodeName="'"$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')"'"')" \
+  "an explicit nodeName are not permitted"
+assert_contains "VAP: parallelism above one is denied" \
+  "$(admit '.spec.parallelism=200')" "must run a single pod"
+assert_contains "VAP: completions above one is denied" \
+  "$(admit '.spec.completions=200')" "must run a single pod"
+assert_contains "VAP: a container with no requests or limits is denied" \
+  "$(admit '.spec.template.spec.containers[0].resources={}')" \
+  "must declare the CPU and memory requests and limits"
 
 # --- data + a backup to restore from ---
 

--- a/pg/tests/test-agent-control-restore.sh
+++ b/pg/tests/test-agent-control-restore.sh
@@ -140,6 +140,13 @@ GUARD=$(kubectl get validatingadmissionpolicy \
   -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
 assert_contains "VAP: the policy is installed, hash-discriminated per namespace and release" \
   "${GUARD}" "^${NAMESPACE}-${FULLNAME}-restore-guard-[0-9a-f]\{8\}$"
+# Stop here if the lookup found nothing. Every assertion below compares against the output of
+# a kubectl call that takes GUARD as an argument, and `kubectl get vap ""` fails with empty
+# output -- so "" == "" would report PASS for a cluster that has no policy at all. Same
+# vacuity assert_not_eq exists to prevent.
+if [ -z "${GUARD}" ]; then
+  fail "VAP: no policy found for release ${RELEASE}" "the rest of the #279 assertions cannot mean anything"
+else
 assert_eq "VAP: the binding is installed under the same name" "${GUARD}" \
   "$(kubectl get validatingadmissionpolicybinding "${GUARD}" -o jsonpath='{.metadata.name}' 2>/dev/null || true)"
 assert_eq "VAP: fails closed (Ignore would silently re-open the hole)" "Fail" \
@@ -202,9 +209,9 @@ assert_contains "VAP: generateName cannot dodge the name pin" \
 assert_contains "VAP: a Job without the pg-ha/restore label is denied" \
   "$(admit '.metadata.labels={}')" "must carry pg-ha/restore"
 assert_contains "VAP: hostNetwork is denied" \
-  "$(admit '.spec.template.spec.hostNetwork=true')" "hostNetwork, hostPID, hostIPC and an explicit nodeName are not permitted"
+  "$(admit '.spec.template.spec.hostNetwork=true')" "hostNetwork, hostPID, hostIPC"
 assert_contains "VAP: hostPID is denied" \
-  "$(admit '.spec.template.spec.hostPID=true')" "hostNetwork, hostPID, hostIPC and an explicit nodeName are not permitted"
+  "$(admit '.spec.template.spec.hostPID=true')" "hostNetwork, hostPID, hostIPC"
 assert_contains "VAP: another image is denied" \
   "$(admit '.spec.template.spec.containers[0].image="attacker/img:1"')" "may only run this release's repmgr image"
 assert_contains "VAP: a second container is denied" \
@@ -321,7 +328,7 @@ assert_contains "VAP: manualSelector is denied" \
 # way to fill the namespace quota and evict the database's own pods.
 assert_contains "VAP: an explicit nodeName is denied" \
   "$(admit '.spec.template.spec.nodeName="'"$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')"'"')" \
-  "an explicit nodeName are not permitted"
+  "an explicit nodeName"
 assert_contains "VAP: parallelism above one is denied" \
   "$(admit '.spec.parallelism=200')" "must run a single pod"
 assert_contains "VAP: completions above one is denied" \
@@ -329,6 +336,27 @@ assert_contains "VAP: completions above one is denied" \
 assert_contains "VAP: a container with no requests or limits is denied" \
   "$(admit '.spec.template.spec.containers[0].resources={}')" \
   "must declare the CPU and memory requests and limits"
+
+# priorityClassName is the placement knob that does not merely restrict: referencing a
+# PriorityClass needs no permission, so a high-priority restore pod lets the scheduler PREEMPT
+# this release's own postgresql pods -- and the SA holds delete on this Job name, so it repeats.
+kubectl get priorityclass vap-probe-high >/dev/null 2>&1 || kubectl create -f - >/dev/null <<'PC'
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: vap-probe-high
+value: 1000000
+description: "test-only: proves the restore Job cannot claim a priority class (#279)"
+PC
+assert_contains "VAP: claiming a priority class is denied" \
+  "$(admit '.spec.template.spec.priorityClassName="vap-probe-high"')" \
+  "priorityClassName other than this release"
+# A lifecycle hook runs a caller-chosen program in the pinned container without touching
+# command or args, which would make the command pin's promise untrue as written.
+assert_contains "VAP: a postStart lifecycle hook is denied" \
+  "$(admit '.spec.template.spec.containers[0].lifecycle={"postStart":{"exec":{"command":["bash","-c","id"]}}}')" \
+  "no lifecycle hooks"
+fi
 
 # --- data + a backup to restore from ---
 

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -3505,13 +3505,19 @@ assert_contains "#279: emptied security contexts tolerate a present-but-empty se
 # Every value reaching a single-quoted CEL literal is charset-checked, not just the obvious
 # ones: `RuntimeDefault'"'"' || true || '"'"'` renders a valid always-true expression.
 for crafted in "postgresql.podSecurityContext.seccompProfile.type=x' || true || '" \
+               "postgresql.containerSecurityContext.seccompProfile.type=x' || true || '" \
                "postgresql.containerSecurityContext.capabilities.add={SYS_ADMIN' || true || '}" \
                "pgbackrest.cronjob.priorityClassName=p' || true || '"; do
   rc=0
-  helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
-    --set "${crafted}" >/dev/null 2>&1 || rc=$?
+  crafted_out=$(helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
+    --set "${crafted}" 2>&1) || rc=$?
   assert_eq "#279: a CEL tautology through ${crafted%%=*} fails the render" "1" \
     "$([ "${rc}" -ne 0 ] && echo 1 || echo 0)"
+  # Non-zero alone is not enough: a render that failed for an unrelated reason (a future
+  # schema constraint on these values, say) would keep this passing while the charset guard
+  # stopped being exercised.
+  assert_contains "#279: ...and it is the CEL-literal guard that rejected it" "${crafted_out}" \
+    "cannot be embedded in the restore admission policy"
 done
 
 # The security-context pins must MOVE with the values rather than being a fixed profile: a

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -3366,6 +3366,84 @@ for key in attemptedTargetType attemptedTarget attemptedBackupSet; do
   assert_contains "#276 restore.sh: records ${key} on failure" "${ctl_restore_sh}" "${key}="
 done
 
+# --- #279: the job-create grant and its admission-policy bound ---
+#
+# The cross-render invariant, which helm-unittest cannot express because it asserts one
+# template at a time: any render carrying the unscopeable `create jobs` rule must also
+# carry the ValidatingAdmissionPolicy that bounds it. A Role with the escalation primitive
+# and no policy is the exact state #279 exists to make unreachable.
+assert_contains "#279: the policy renders alongside the grant" "${ctl_restore}" "kind: ValidatingAdmissionPolicy"
+assert_contains "#279: so does its binding" "${ctl_restore}" "kind: ValidatingAdmissionPolicyBinding"
+assert_contains "#279: fails closed -- Ignore would silently re-open the hole" "${ctl_restore}" "failurePolicy: Fail"
+assert_contains "#279: the binding denies rather than warns" "${ctl_restore}" 'validationActions: \["Deny"\]'
+# Cluster-scoped objects, so the name carries the namespace: two releases of this chart in
+# different namespaces must not contend for one policy object.
+assert_contains "#279: the cluster-scoped name is namespace-prefixed" "${ctl_restore}" "name: default-test-pg-restore-guard"
+# Exactly one subject is policed. Every other creator of Jobs in the cluster -- humans,
+# GitOps controllers, the CronJob controller -- must be untouched.
+assert_contains "#279: policed subject is pinned exactly" "${ctl_restore}" \
+  "request.userInfo.username == 'system:serviceaccount:default:test-pg-repmgr'"
+assert_not_contains "#279: not a prefix/suffix match on the username" \
+  "$(grep -o 'expression: "request.userInfo.username[^"]*"' <<< "${ctl_restore}")" "endsWith("
+# The binding must NOT narrow by objectSelector: a Job created without the pg-ha/restore
+# label would then simply not match the binding, and would be admitted -- making the label
+# validation self-defeating. What the caller controls is checked by a validation, never by
+# a match rule.
+assert_not_contains "#279: the binding has no objectSelector" "${ctl_restore}" "objectSelector"
+
+# The grant cannot be rendered without the bound unless the trade is stated in values.
+ctl_vap_rc=0
+helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
+  --set repmgr.agent.control.restore.admissionPolicy.enabled=false >/dev/null 2>&1 || ctl_vap_rc=$?
+assert_eq "#279 guard: disabling the policy without acknowledging it fails to render" "1" \
+  "$([ "${ctl_vap_rc}" -ne 0 ] && echo 1 || echo 0)"
+ctl_vap_ack=$(helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
+  --set repmgr.agent.control.restore.admissionPolicy.enabled=false \
+  --set repmgr.agent.control.restore.admissionPolicy.acknowledgeUnbounded=true 2>&1)
+assert_not_contains "#279 opt-out: acknowledged, so no policy is rendered" "${ctl_vap_ack}" "kind: ValidatingAdmissionPolicy"
+assert_contains "#279 opt-out: the grant itself is unchanged" "${ctl_vap_ack}" 'resources: \["jobs"\]'
+
+# Default install: the chart's only cluster-scoped objects stay absent, so a namespace-
+# limited installer is unaffected by this feature existing.
+assert_not_contains "#279 default: no cluster-scoped policy" "${minimal}" "ValidatingAdmissionPolicy"
+
+# Drift guard, and the reason it earns a place here: the policy pins literal values that
+# the restore CronJob renders independently. If the two ever disagree, failurePolicy: Fail
+# turns that into every API-driven restore being denied -- a hard outage of the feature,
+# discovered during an incident. Compare them directly instead.
+ctl_vap=$(helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
+  --show-only templates/agent-restore-admissionpolicy.yaml 2>&1)
+ctl_vap_cj=$(helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
+  --show-only templates/pgbackrest-restore-job.yaml 2>&1)
+pinned() { grep -o "$1 == '[^']*'" <<< "${ctl_vap}" | head -1 | sed "s/.*'\(.*\)'/\1/"; }
+rendered() { grep -o "$1: [\"']\?[^\"']*" <<< "${ctl_vap_cj}" | head -1 | sed "s/^[^:]*: [\"']\?//"; }
+assert_eq "#279 drift: pinned ServiceAccount is the one the Job renders" \
+  "$(rendered serviceAccountName)" "$(pinned 'variables.pod.serviceAccountName')"
+assert_eq "#279 drift: pinned image is the one the Job renders" \
+  "$(rendered image)" "$(pinned 'c.image')"
+assert_eq "#279 drift: pinned data PVC is the one the Job mounts" \
+  "$(rendered claimName)" "$(pinned 'v.persistentVolumeClaim.claimName')"
+assert_eq "#279 drift: pinned label is the one the jobTemplate carries" \
+  "$(rendered 'pg-ha/restore')" "$(pinned "object.metadata.labels\['pg-ha/restore'\]")"
+# The label lives on the jobTemplate, not only on the CronJob: `kubectl create job --from`
+# and the agent's clone copy THOSE, and nothing else puts labels on the created Job.
+assert_contains "#279: the jobTemplate carries the label the policy requires" "${ctl_vap_cj}" "pg-ha/restore: test-pg"
+
+# With cloud workload identity the release reads no Secret at all, so the env rule becomes
+# "no secretKeyRef whatsoever" rather than an allowlist that happens to be empty.
+assert_contains "#279 keyType=auto: no Secret reference is permitted" "${ctl_vap}" '!has(e.valueFrom.secretKeyRef)'
+# Shared keys mean exactly one legitimate Secret; an encryption passphrase adds a second.
+ctl_vap_shared=$(helm template test-pg "${CHART_DIR}" "${ctl_base[@]}" \
+  --set repmgr.agent.control.enabled=true --set repmgr.agent.control.tls.existingSecret=ctl-tls \
+  --set repmgr.agent.control.restore.enabled=true \
+  --set 'repmgr.agent.control.restore.allowedClientCNs={dba}' \
+  --set pgbackrest.enabled=true --set pgbackrest.s3.endpoint=https://s3 --set pgbackrest.s3.bucket=b \
+  --set pgbackrest.s3.keyType=shared --set pgbackrest.existingSecret.name=s3creds \
+  --set pgbackrest.repoEncryption.enabled=true --set pgbackrest.repoEncryption.existingSecret.name=cipher \
+  --set pgbackrest.restore.enabled=true --show-only templates/agent-restore-admissionpolicy.yaml 2>&1)
+assert_contains "#279 shared keys: only this release's own Secrets are reachable" "${ctl_vap_shared}" \
+  "in \['s3creds','cipher'\]"
+
 # --- NetworkPolicy: deny-by-default on the control port ---
 
 ctl_np=$(helm template test-pg "${CHART_DIR}" "${ctl_base[@]}" \

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -3393,8 +3393,11 @@ assert_not_eq "#279: a hyphen-ambiguous namespace/release pair does not collide"
 # GitOps controllers, the CronJob controller -- must be untouched.
 assert_contains "#279: policed subject is pinned exactly" "${ctl_restore}" \
   "request.userInfo.username == 'system:serviceaccount:default:test-pg-repmgr'"
-assert_not_contains "#279: not a prefix/suffix match on the username" \
-  "$(grep -o 'expression: "request.userInfo.username[^"]*"' <<< "${ctl_restore}")" "endsWith("
+ctl_vap_subject=$(grep -o 'expression: "request.userInfo.username[^"]*"' <<< "${ctl_restore}")
+# Non-empty first: assert_not_contains passes on an empty haystack, so without this the check
+# below stops testing anything the moment the template emits that scalar differently.
+assert_contains "#279: the subject expression was actually extracted" "${ctl_vap_subject}" "userInfo"
+assert_not_contains "#279: not a prefix/suffix match on the username" "${ctl_vap_subject}" "endsWith("
 # The binding must NOT narrow by objectSelector: a Job created without the pg-ha/restore
 # label would then simply not match the binding, and would be admitted -- making the label
 # validation self-defeating. What the caller controls is checked by a validation, never by
@@ -3481,6 +3484,35 @@ assert_contains "#279: the pod seccomp profile is pinned to the release's own" "
   "variables.pod.securityContext.seccompProfile.type == 'RuntimeDefault'"
 assert_contains "#279: a single pod only" "${ctl_vap}" 'object.spec.parallelism <= 1'
 assert_contains "#279: requests and limits are required" "${ctl_vap}" "'cpu' in c.resources.limits"
+# priorityClassName is pinned, unlike nodeSelector/tolerations: a priority class does not
+# restrict placement, it lets the scheduler PREEMPT this release's own postgresql pods.
+assert_contains "#279: priorityClassName is pinned, not just node placement" "${ctl_vap}" \
+  '!has(variables.pod.priorityClassName)'
+ctl_vap_pcn=$(helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
+  --set pgbackrest.cronjob.priorityClassName=db-critical --show-only templates/agent-restore-admissionpolicy.yaml 2>&1)
+assert_contains "#279: a values-set priority class widens the pin to exactly it" "${ctl_vap_pcn}" \
+  "variables.pod.priorityClassName == 'db-critical'"
+# A lifecycle hook runs caller-chosen code in the pinned container without touching command.
+assert_contains "#279: lifecycle hooks are denied alongside the command pin" "${ctl_vap}" '!has(c.lifecycle)'
+# An operator who empties the security contexts must not have their own restore denied:
+# `containerSecurityContext: {}` renders `securityContext: {}`, which has() sees as PRESENT,
+# so the no-values branch has to be "absent OR sets none of the pinned fields".
+ctl_vap_emptysc=$(helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
+  --set postgresql.containerSecurityContext=null --set postgresql.podSecurityContext=null \
+  --show-only templates/agent-restore-admissionpolicy.yaml 2>&1)
+assert_contains "#279: emptied security contexts tolerate a present-but-empty securityContext" \
+  "${ctl_vap_emptysc}" '!has(c.securityContext) || (!has(c.securityContext.privileged)'
+# Every value reaching a single-quoted CEL literal is charset-checked, not just the obvious
+# ones: `RuntimeDefault'"'"' || true || '"'"'` renders a valid always-true expression.
+for crafted in "postgresql.podSecurityContext.seccompProfile.type=x' || true || '" \
+               "postgresql.containerSecurityContext.capabilities.add={SYS_ADMIN' || true || '}" \
+               "pgbackrest.cronjob.priorityClassName=p' || true || '"; do
+  rc=0
+  helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
+    --set "${crafted}" >/dev/null 2>&1 || rc=$?
+  assert_eq "#279: a CEL tautology through ${crafted%%=*} fails the render" "1" \
+    "$([ "${rc}" -ne 0 ] && echo 1 || echo 0)"
+done
 
 # The security-context pins must MOVE with the values rather than being a fixed profile: a
 # hardcoded hardened profile would deny the release's own restore Job the moment an operator
@@ -3500,19 +3532,22 @@ assert_contains "#279 keyType=auto: only the downward API is permitted" "${ctl_v
 assert_not_contains "#279 keyType=auto: configMapKeyRef is not admitted by a bare negation" \
   "${ctl_vap}" '!has(e.valueFrom.secretKeyRef)'
 
-# Kubernetes >= 1.30 is a render-time failure, not an apply-time one: without this an upgrade
-# from 1.9.0 on an older cluster renders clean and aborts mid-apply with "no matches for kind".
-ctl_vap_129_rc=0
-helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
-  --kube-version 1.29.0 >/dev/null 2>&1 || ctl_vap_129_rc=$?
-assert_eq "#279: a cluster below 1.30 fails the render" "1" \
-  "$([ "${ctl_vap_129_rc}" -ne 0 ] && echo 1 || echo 0)"
-# ...and the acknowledged opt-out is what lets such a cluster run the feature at all.
-ctl_vap_129_ack_rc=0
-helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
-  --kube-version 1.29.0 --set repmgr.agent.control.restore.admissionPolicy.enabled=false \
-  --set repmgr.agent.control.restore.admissionPolicy.acknowledgeUnbounded=true >/dev/null 2>&1 || ctl_vap_129_ack_rc=$?
-assert_eq "#279: acknowledging the trade lets a pre-1.30 cluster render" "0" "${ctl_vap_129_ack_rc}"
+# The >= 1.30 requirement is enforced by asking whether admissionregistration.k8s.io/v1
+# EXISTS, not by comparing .Capabilities.KubeVersion: with no cluster that reports the HELM
+# CLIENT's version (helm 3.14 says v1.29), so a semver floor fails every `helm template` run
+# by an older helm regardless of the target cluster. Assert the accurate shape here; the
+# negative case cannot be produced from the CLI, because --api-versions only ADDS to the
+# default set, so it lives in tests/unit/restore_admissionpolicy_nocapability_test.yaml.
+assert_contains "#279: the API-group precondition is what gates the policy" "$(cat "${CHART_DIR}/templates/agent-restore-admissionpolicy.yaml")" \
+  'APIVersions.Has "admissionregistration.k8s.io/v1"'
+assert_not_contains "#279: the client's own kube version does not gate the render" \
+  "$(cat "${CHART_DIR}/templates/agent-restore-admissionpolicy.yaml")" 'semverCompare ">=1.30'
+# An old helm renders it fine, which is the regression this replaced: no cluster, client
+# version below the floor, policy still rendered.
+ctl_vap_oldkube=$(helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
+  --kube-version 1.29.0 --show-only templates/agent-restore-admissionpolicy.yaml 2>&1)
+assert_contains "#279: a client reporting 1.29 with no cluster still renders the policy" \
+  "${ctl_vap_oldkube}" "kind: ValidatingAdmissionPolicy"
 
 # A value with a quote would produce a broken CEL expression -- or, crafted, a tautological
 # one that looks installed and enforces nothing. Both must fail the render, not the apply.

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -3376,9 +3376,19 @@ assert_contains "#279: the policy renders alongside the grant" "${ctl_restore}" 
 assert_contains "#279: so does its binding" "${ctl_restore}" "kind: ValidatingAdmissionPolicyBinding"
 assert_contains "#279: fails closed -- Ignore would silently re-open the hole" "${ctl_restore}" "failurePolicy: Fail"
 assert_contains "#279: the binding denies rather than warns" "${ctl_restore}" 'validationActions: \["Deny"\]'
-# Cluster-scoped objects, so the name carries the namespace: two releases of this chart in
-# different namespaces must not contend for one policy object.
-assert_contains "#279: the cluster-scoped name is namespace-prefixed" "${ctl_restore}" "name: default-test-pg-restore-guard"
+# Cluster-scoped objects, so the name must be unique per (namespace, release). The namespace
+# and fullname are there to be read; the trailing hash of the "<namespace>/<fullname>" pair is
+# what actually discriminates, because a bare hyphen join maps distinct pairs onto one name
+# ("db" in "pg-prod" and "prod-db" in "pg"). Asserted as a shape, not a literal, so the
+# assertion cannot pass on a name that dropped the hash.
+assert_contains "#279: the cluster-scoped name carries a discriminating hash" "${ctl_restore}" \
+  "name: default-test-pg-restore-guard-[0-9a-f]\{8\}$"
+# The ambiguity itself: the two colliding (namespace, release) pairs must not produce one name.
+vap_name() { helm template "$2" "${CHART_DIR}" "${ctl_restore_args[@]}" -n "$1" \
+  --set pgbackrest.restore.enabled=true --show-only templates/agent-restore-admissionpolicy.yaml 2>/dev/null \
+  | awk '/^kind: ValidatingAdmissionPolicy$/{f=1} f&&/^  name:/{print $2; exit}'; }
+assert_not_eq "#279: a hyphen-ambiguous namespace/release pair does not collide" \
+  "$(vap_name pg-prod db)" "$(vap_name pg prod-db)"
 # Exactly one subject is policed. Every other creator of Jobs in the cluster -- humans,
 # GitOps controllers, the CronJob controller -- must be untouched.
 assert_contains "#279: policed subject is pinned exactly" "${ctl_restore}" \
@@ -3416,22 +3426,102 @@ ctl_vap=$(helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pg
 ctl_vap_cj=$(helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
   --show-only templates/pgbackrest-restore-job.yaml 2>&1)
 pinned() { grep -o "$1 == '[^']*'" <<< "${ctl_vap}" | head -1 | sed "s/.*'\(.*\)'/\1/"; }
+# Numbers and booleans are interpolated into CEL unquoted, so they need their own extractor.
+pinned_bare() { grep -o "$1 == [A-Za-z0-9]*" <<< "${ctl_vap}" | head -1 | sed "s/.* == //"; }
 rendered() { grep -o "$1: [\"']\?[^\"']*" <<< "${ctl_vap_cj}" | head -1 | sed "s/^[^:]*: [\"']\?//"; }
-assert_eq "#279 drift: pinned ServiceAccount is the one the Job renders" \
+# Each drift pair asserts non-emptiness first, so a renamed template or a moved expression
+# fails loudly instead of comparing "" with "".
+drift() {
+  local what="$1" have="$2" want="$3"
+  if [[ -z "${have}" || -z "${want}" ]]; then
+    assert_eq "#279 drift: ${what} (both sides must be non-empty)" "non-empty/non-empty" "${have}/${want}"
+  else
+    assert_eq "#279 drift: ${what}" "${have}" "${want}"
+  fi
+}
+drift "pinned ServiceAccount is the one the Job renders" \
   "$(rendered serviceAccountName)" "$(pinned 'variables.pod.serviceAccountName')"
-assert_eq "#279 drift: pinned image is the one the Job renders" \
+drift "pinned image is the one the Job renders" \
   "$(rendered image)" "$(pinned 'c.image')"
-assert_eq "#279 drift: pinned data PVC is the one the Job mounts" \
+drift "pinned data PVC is the one the Job mounts" \
   "$(rendered claimName)" "$(pinned 'v.persistentVolumeClaim.claimName')"
-assert_eq "#279 drift: pinned label is the one the jobTemplate carries" \
+drift "pinned label is the one the jobTemplate carries" \
   "$(rendered 'pg-ha/restore')" "$(pinned "object.metadata.labels\['pg-ha/restore'\]")"
+# The command, the securityContext values and the pod labels are pinned from the release's
+# own values too, and a mismatch there denies every restore just as hard. Compared against
+# the CronJob's independently rendered text rather than against a literal.
+drift "pinned command is the one the Job runs" \
+  "$(grep -o 'command: \[.*\]' <<< "${ctl_vap_cj}" | head -1 | sed 's/command: //')" \
+  "$(grep -o "c.command == \[[^]]*\]" <<< "${ctl_vap}" | head -1 | sed "s/c.command == //;s/'/\"/g;s/,\"/, \"/g")"
+drift "pinned container runAsUser is the one the Job runs as" \
+  "$(grep -o 'runAsUser: [0-9]*' <<< "${ctl_vap_cj}" | head -1 | sed 's/runAsUser: //')" \
+  "$(pinned_bare 'c.securityContext.runAsUser')"
+drift "pinned pod component label is the one the pod template carries" \
+  "$(grep -o 'app.kubernetes.io/component: pgbackrest-restore' <<< "${ctl_vap_cj}" | head -1 | sed 's/.*: //')" \
+  "$(pinned "variables.podLabels\['app.kubernetes.io/component'\]")"
 # The label lives on the jobTemplate, not only on the CronJob: `kubectl create job --from`
 # and the agent's clone copy THOSE, and nothing else puts labels on the created Job.
 assert_contains "#279: the jobTemplate carries the label the policy requires" "${ctl_vap_cj}" "pg-ha/restore: test-pg"
+# The four labels the API SERVER stamps on a Job's pod template before validating admission
+# runs. They must stay in the key allowlist: without them the pod-label rule denies every
+# legitimate restore, which is how this rule was caught in the first place.
+for k in batch.kubernetes.io/controller-uid batch.kubernetes.io/job-name controller-uid job-name; do
+  assert_contains "#279: the pod-label allowlist tolerates the server-stamped ${k}" "${ctl_vap}" "'${k}'"
+done
+# Pins that exist to stop the Job being "run anything as the database's uid with the live
+# PGDATA mounted", or a strictly larger privilege set than the token started with.
+assert_contains "#279: nodeName is denied outright" "${ctl_vap}" '!has(variables.pod.nodeName)'
+assert_contains "#279: manualSelector is denied" "${ctl_vap}" '!has(object.spec.manualSelector)'
+assert_contains "#279: args are denied alongside the pinned command" "${ctl_vap}" '!has(c.args)'
+assert_contains "#279: added capabilities are bounded" "${ctl_vap}" 'c.securityContext.capabilities.add'
+# seccomp is pinned to the release's own: the command pin does not make code execution in the
+# restore container impossible (bash reads $BASH_ENV, and PGDATA is mounted), so Unconfined
+# would widen past "the privileges the token already holds".
+assert_contains "#279: the pod seccomp profile is pinned to the release's own" "${ctl_vap}" \
+  "variables.pod.securityContext.seccompProfile.type == 'RuntimeDefault'"
+assert_contains "#279: a single pod only" "${ctl_vap}" 'object.spec.parallelism <= 1'
+assert_contains "#279: requests and limits are required" "${ctl_vap}" "'cpu' in c.resources.limits"
 
-# With cloud workload identity the release reads no Secret at all, so the env rule becomes
-# "no secretKeyRef whatsoever" rather than an allowlist that happens to be empty.
-assert_contains "#279 keyType=auto: no Secret reference is permitted" "${ctl_vap}" '!has(e.valueFrom.secretKeyRef)'
+# The security-context pins must MOVE with the values rather than being a fixed profile: a
+# hardcoded hardened profile would deny the release's own restore Job the moment an operator
+# legitimately changed the context, which is worse than no policy at all.
+ctl_vap_priv=$(helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
+  --set postgresql.containerSecurityContext.privileged=true \
+  --show-only templates/agent-restore-admissionpolicy.yaml 2>&1)
+assert_contains "#279: a values-set privileged container widens the pin, not denies the release" \
+  "${ctl_vap_priv}" 'c.securityContext.privileged == true'
+
+# With cloud workload identity the release reads no Secret at all. The rule must stay an
+# ALLOWLIST of sources (fieldRef only) rather than degrading into "no secretKeyRef", which
+# would ADMIT configMapKeyRef in exactly the keyless configuration -- the opposite of what
+# its own message promises, and the branch CI never used to render.
+assert_contains "#279 keyType=auto: only the downward API is permitted" "${ctl_vap}" \
+  '!has(e.valueFrom) || (has(e.valueFrom.fieldRef))'
+assert_not_contains "#279 keyType=auto: configMapKeyRef is not admitted by a bare negation" \
+  "${ctl_vap}" '!has(e.valueFrom.secretKeyRef)'
+
+# Kubernetes >= 1.30 is a render-time failure, not an apply-time one: without this an upgrade
+# from 1.9.0 on an older cluster renders clean and aborts mid-apply with "no matches for kind".
+ctl_vap_129_rc=0
+helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
+  --kube-version 1.29.0 >/dev/null 2>&1 || ctl_vap_129_rc=$?
+assert_eq "#279: a cluster below 1.30 fails the render" "1" \
+  "$([ "${ctl_vap_129_rc}" -ne 0 ] && echo 1 || echo 0)"
+# ...and the acknowledged opt-out is what lets such a cluster run the feature at all.
+ctl_vap_129_ack_rc=0
+helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
+  --kube-version 1.29.0 --set repmgr.agent.control.restore.admissionPolicy.enabled=false \
+  --set repmgr.agent.control.restore.admissionPolicy.acknowledgeUnbounded=true >/dev/null 2>&1 || ctl_vap_129_ack_rc=$?
+assert_eq "#279: acknowledging the trade lets a pre-1.30 cluster render" "0" "${ctl_vap_129_ack_rc}"
+
+# A value with a quote would produce a broken CEL expression -- or, crafted, a tautological
+# one that looks installed and enforces nothing. Both must fail the render, not the apply.
+ctl_vap_quote_rc=0
+helm template test-pg "${CHART_DIR}" "${ctl_restore_args[@]}" --set pgbackrest.restore.enabled=true \
+  --set pgbackrest.repoEncryption.enabled=true \
+  --set "pgbackrest.repoEncryption.existingSecret.name=dba's-key" >/dev/null 2>&1 || ctl_vap_quote_rc=$?
+assert_eq "#279: a value that cannot be embedded in a CEL literal fails the render" "1" \
+  "$([ "${ctl_vap_quote_rc}" -ne 0 ] && echo 1 || echo 0)"
 # Shared keys mean exactly one legitimate Secret; an encryption passphrase adds a second.
 ctl_vap_shared=$(helm template test-pg "${CHART_DIR}" "${ctl_base[@]}" \
   --set repmgr.agent.control.enabled=true --set repmgr.agent.control.tls.existingSecret=ctl-tls \

--- a/pg/tests/unit/restore_admissionpolicy_nocapability_test.yaml
+++ b/pg/tests/unit/restore_admissionpolicy_nocapability_test.yaml
@@ -1,0 +1,57 @@
+# The render-time precondition for the #279 admission policy, in its own suite because
+# helm-unittest's suite-level `capabilities.apiVersions` cannot be un-declared by a per-test
+# override -- and this is the one case that needs it ABSENT.
+#
+# helm-unittest's default capability set does not include admissionregistration.k8s.io/v1, so
+# simply not declaring it here reproduces a cluster that cannot host the policy. (helm's own
+# no-cluster default DOES include the group, which is why `helm template` and the kubeconform
+# gate render the policy without a cluster and cannot express this case at all.)
+suite: restore admission policy without the API group (#279)
+release:
+  name: test-pg
+  namespace: pg-ns
+tests:
+  # Failing the RENDER is the point. Without it, an upgrade from 1.9.0 on a cluster below
+  # 1.30 -- or one where --runtime-config disabled the group -- renders clean and then aborts
+  # mid-apply with "no matches for kind ValidatingAdmissionPolicy", leaving the release failed.
+  - it: a cluster without admissionregistration.k8s.io/v1 fails the render
+    values:
+      - ../values-agent-control-restore.yaml
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "repmgr.agent.control.restore needs admissionregistration.k8s.io/v1 for the ValidatingAdmissionPolicy that bounds its `create jobs` grant, and this cluster does not expose it -- it is GA from Kubernetes 1.30 (this cluster reports v1.20.0), and can also be disabled by --runtime-config (#279). Upgrade or enable the API, or set repmgr.agent.control.restore.admissionPolicy.enabled=false together with acknowledgeUnbounded=true to run the feature with an unbounded grant deliberately"
+
+  # ...and acknowledging the trade is what lets such a cluster run the feature at all. This is
+  # the documented path for a pre-1.30 cluster and for a namespace-limited installer.
+  - it: acknowledging the trade lets a cluster without the API render the grant
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      repmgr.agent.control.restore.admissionPolicy.enabled: false
+      repmgr.agent.control.restore.admissionPolicy.acknowledgeUnbounded: true
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # The grant itself is untouched by that opt-out -- which is exactly why rbac.yaml's comment
+  # says the unbounded state IS reachable and tells the reader to check for the binding.
+  - it: the grant is still rendered when the trade is acknowledged
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      repmgr.agent.control.restore.admissionPolicy.enabled: false
+      repmgr.agent.control.restore.admissionPolicy.acknowledgeUnbounded: true
+    templates:
+      - templates/rbac.yaml
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["batch"]
+            resources: ["jobs"]
+            verbs: ["create"]

--- a/pg/tests/unit/restore_admissionpolicy_nocapability_test.yaml
+++ b/pg/tests/unit/restore_admissionpolicy_nocapability_test.yaml
@@ -10,6 +10,12 @@ suite: restore admission policy without the API group (#279)
 release:
   name: test-pg
   namespace: pg-ns
+# majorVersion/minorVersion are pinned only because the message quotes the reported version;
+# they are NOT what the guard checks. apiVersions is deliberately left undeclared -- the absent
+# API group is the case under test, and helm-unittest's default set does not include it.
+capabilities:
+  majorVersion: 1
+  minorVersion: 29
 tests:
   # Failing the RENDER is the point. Without it, an upgrade from 1.9.0 on a cluster below
   # 1.30 -- or one where --runtime-config disabled the group -- renders clean and then aborts
@@ -21,7 +27,7 @@ tests:
       - templates/agent-restore-admissionpolicy.yaml
     asserts:
       - failedTemplate:
-          errorMessage: "repmgr.agent.control.restore needs admissionregistration.k8s.io/v1 for the ValidatingAdmissionPolicy that bounds its `create jobs` grant, and this cluster does not expose it -- it is GA from Kubernetes 1.30 (this cluster reports v1.20.0), and can also be disabled by --runtime-config (#279). Upgrade or enable the API, or set repmgr.agent.control.restore.admissionPolicy.enabled=false together with acknowledgeUnbounded=true to run the feature with an unbounded grant deliberately"
+          errorMessage: "repmgr.agent.control.restore needs admissionregistration.k8s.io/v1 for the ValidatingAdmissionPolicy that bounds its `create jobs` grant, and this cluster does not expose it -- it is GA from Kubernetes 1.30 (this cluster reports v1.29.0), and can also be disabled by --runtime-config (#279). Upgrade or enable the API, or set repmgr.agent.control.restore.admissionPolicy.enabled=false together with acknowledgeUnbounded=true to run the feature with an unbounded grant deliberately"
 
   # ...and acknowledging the trade is what lets such a cluster run the feature at all. This is
   # the documented path for a pre-1.30 cluster and for a namespace-limited installer.

--- a/pg/tests/unit/restore_admissionpolicy_test.yaml
+++ b/pg/tests/unit/restore_admissionpolicy_test.yaml
@@ -1,0 +1,291 @@
+suite: restore job-create admission policy (#279)
+release:
+  name: test-pg
+  namespace: pg-ns
+tests:
+  # --- the default install is untouched ---
+  #
+  # control.restore is off by default, so neither the grant nor its bound exists. Asserting
+  # this is not ceremony: the policy and its binding are the chart's only CLUSTER-scoped
+  # objects, and a default install that suddenly needed cluster-scoped RBAC would break
+  # every namespace-limited installer on upgrade.
+  - it: no admission policy on a default install
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: no admission policy in agent mode without restore triggering
+    values:
+      - ../values-agent.yaml
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # --- rendered with the grant ---
+  - it: the policy and its binding render when restore triggering is enabled
+    values:
+      - ../values-agent-control-restore.yaml
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ValidatingAdmissionPolicy
+        documentIndex: 0
+      - isKind:
+          of: ValidatingAdmissionPolicyBinding
+        documentIndex: 1
+      # v1, not v1beta1: the beta shape is not the same object, and pinning the GA version
+      # is what makes "Kubernetes >= 1.30" the stated requirement.
+      - equal:
+          path: apiVersion
+          value: admissionregistration.k8s.io/v1
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: pg-ns-test-pg-restore-guard
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: pg-ns-test-pg-restore-guard
+        documentIndex: 1
+
+  # The cluster-scoped name carries the namespace: pg.fullname alone is only unique WITHIN
+  # a namespace, so two releases of this chart would otherwise contend for one policy.
+  - it: the cluster-scoped names are namespace-prefixed
+    values:
+      - ../values-agent-control-restore.yaml
+    release:
+      name: test-pg
+      namespace: other-ns
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.name
+          value: other-ns-test-pg-restore-guard
+
+  # Ignore, not Fail, would silently re-open the hole on any evaluation failure -- the grant
+  # rendered, the bound quietly absent. This assertion is the one that must never regress.
+  - it: the policy fails closed
+    values:
+      - ../values-agent-control-restore.yaml
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.failurePolicy
+          value: Fail
+      - equal:
+          path: spec.matchConstraints.resourceRules[0].resources[0]
+          value: jobs
+      - equal:
+          path: spec.matchConstraints.resourceRules[0].operations[0]
+          value: CREATE
+
+  # Exact equality on the username, including the namespace: a startsWith/endsWith match
+  # would also police an identically-named ServiceAccount in an unrelated namespace.
+  - it: the policy polices only this release's ServiceAccount
+    values:
+      - ../values-agent-control-restore.yaml
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.matchConditions[0].expression
+          value: "request.userInfo.username == 'system:serviceaccount:pg-ns:test-pg-repmgr'"
+
+  - it: the validations pin name, label, identity, token, host namespaces, image, volumes and env
+    values:
+      - ../values-agent-control-restore.yaml
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      # The bound RBAC could not express: create collapses to ONE object name.
+      - equal:
+          path: spec.validations[0].expression
+          value: "object.metadata.name == 'test-pg-pgbackrest-restore-api'"
+      - matchRegex:
+          path: spec.validations[1].expression
+          pattern: "object\\.metadata\\.labels\\['pg-ha/restore'\\] == 'test-pg'"
+      # The escalation primitive itself, and the reason it does not matter even if a caller
+      # somehow named another SA: no token is mounted.
+      - matchRegex:
+          path: spec.validations[2].expression
+          pattern: "variables\\.pod\\.serviceAccountName == 'test-pg-repmgr'"
+      - matchRegex:
+          path: spec.validations[3].expression
+          pattern: "automountServiceAccountToken == false"
+      - matchRegex:
+          path: spec.validations[4].expression
+          pattern: "hostNetwork == false"
+      - matchRegex:
+          path: spec.validations[4].expression
+          pattern: "hostPID == false"
+      - matchRegex:
+          path: spec.validations[4].expression
+          pattern: "hostIPC == false"
+      - matchRegex:
+          path: spec.validations[6].expression
+          pattern: "c\\.image == 'cagriekin/repmgr:trixie-5\\.5\\.0-29'"
+      # Volumes: the sources the restore template actually renders, nothing else -- this is
+      # what keeps another workload's Secret out of a Job created on this token.
+      - matchRegex:
+          path: spec.validations[7].expression
+          pattern: "v\\.configMap\\.name == 'test-pg-pgbackrest'"
+      - matchRegex:
+          path: spec.validations[7].expression
+          pattern: "v\\.persistentVolumeClaim\\.claimName == 'data-test-pg-0'"
+      - matchRegex:
+          path: spec.validations[7].expression
+          pattern: "has\\(v\\.emptyDir\\)"
+      # Every validation denies rather than warns, and says what was wrong.
+      - equal:
+          path: spec.validations[0].reason
+          value: Forbidden
+
+  # The Secret allowlist is built from the same values the Job's env is built from. With
+  # shared S3 keys that is the credential Secret; nothing else in the namespace.
+  - it: the env rule allows only this release's own Secrets
+    values:
+      - ../values-agent-control-restore.yaml
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.validations[8].expression
+          pattern: "e\\.valueFrom\\.secretKeyRef\\.name in \\['s3-backup-creds'\\]"
+      - matchRegex:
+          path: spec.validations[8].expression
+          pattern: "!has\\(c\\.envFrom\\)"
+
+  # A repo-encryption passphrase adds a second legitimate Secret; the rule has to widen
+  # with it or every restore on an encrypted repo would be denied.
+  - it: repo encryption adds its passphrase Secret to the allowlist
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      pgbackrest.repoEncryption.enabled: true
+      pgbackrest.repoEncryption.existingSecret.name: pgbr-cipher
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.validations[8].expression
+          pattern: "in \\['s3-backup-creds','pgbr-cipher'\\]"
+
+  # Workload identity (keyType=auto) means the release reads no Secret at all, so the rule
+  # becomes "no secretKeyRef whatsoever" rather than an allowlist that happens to be empty.
+  - it: with no Secret of its own the env rule forbids secretKeyRef outright
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      pgbackrest.s3.keyType: auto
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.validations[8].expression
+          pattern: "!has\\(e\\.valueFrom\\.secretKeyRef\\)"
+      - notMatchRegex:
+          path: spec.validations[8].expression
+          pattern: "secretKeyRef\\.name in"
+
+  # --- the binding ---
+  #
+  # Scoped to the release namespace by the label the API SERVER sets on every namespace, so
+  # it cannot be left off the way a chart-requested label could. And deliberately with no
+  # objectSelector: narrowing the binding by pg-ha/restore would make the label validation
+  # self-defeating (an unlabelled Job would not match, and would be admitted).
+  - it: the binding denies, is namespace-scoped, and does not select on the object
+    values:
+      - ../values-agent-control-restore.yaml
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.policyName
+          value: pg-ns-test-pg-restore-guard
+      - equal:
+          path: spec.validationActions[0]
+          value: Deny
+      - equal:
+          path: spec.matchResources.namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: pg-ns
+      - isNull:
+          path: spec.matchResources.objectSelector
+
+  # --- the label the policy requires must actually be on the template it clones ---
+  #
+  # The agent copies the CronJob's jobTemplate labels onto the Job it creates, and nothing
+  # else puts labels there. If this ever regresses, validation #2 denies every API-driven
+  # restore -- so it is asserted next to the policy rather than with the backup tests.
+  - it: the restore CronJob's jobTemplate carries the label the policy requires
+    values:
+      - ../values-agent-control-restore.yaml
+    templates:
+      - templates/pgbackrest-restore-job.yaml
+    asserts:
+      - equal:
+          path: spec.jobTemplate.metadata.labels["pg-ha/restore"]
+          value: test-pg
+      # Not the full label set: a Job the agent creates is not Helm-managed, and claiming
+      # otherwise invites a GitOps controller to prune it mid-restore.
+      - isNull:
+          path: spec.jobTemplate.metadata.labels["app.kubernetes.io/managed-by"]
+
+  # --- the grant and the bound cannot be separated ---
+  - it: disabling the policy without acknowledging the trade fails the render
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      repmgr.agent.control.restore.admissionPolicy.enabled: false
+    templates:
+      - templates/statefulset.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "repmgr.agent.control.restore.admissionPolicy.enabled=false leaves the restore feature's `create jobs` grant unbounded: RBAC cannot restrict create by resourceName, so anything holding the database pods' ServiceAccount token could create arbitrary Jobs in this namespace and name any ServiceAccount in them. Either leave admissionPolicy.enabled=true (it needs Kubernetes >= 1.30 and cluster-scoped create on ValidatingAdmissionPolicy), or set repmgr.agent.control.restore.admissionPolicy.acknowledgeUnbounded=true to accept that trade deliberately"
+
+  # The opt-out is honoured -- a cluster below 1.30, a namespace-limited installer, or a
+  # platform-managed policy are all real -- it just has to be stated in values.
+  - it: acknowledging the trade renders the grant with no policy
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      repmgr.agent.control.restore.admissionPolicy.enabled: false
+      repmgr.agent.control.restore.admissionPolicy.acknowledgeUnbounded: true
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: the grant itself is unchanged when the trade is acknowledged
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      repmgr.agent.control.restore.admissionPolicy.enabled: false
+      repmgr.agent.control.restore.admissionPolicy.acknowledgeUnbounded: true
+    templates:
+      - templates/rbac.yaml
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["batch"]
+            resources: ["jobs"]
+            verbs: ["create"]

--- a/pg/tests/unit/restore_admissionpolicy_test.yaml
+++ b/pg/tests/unit/restore_admissionpolicy_test.yaml
@@ -2,6 +2,14 @@ suite: restore job-create admission policy (#279)
 release:
   name: test-pg
   namespace: pg-ns
+# The policy pins admissionregistration.k8s.io/v1, and the template FAILS the render below
+# Kubernetes 1.30 rather than letting the apply abort halfway. helm-unittest's default
+# capability set reports v1.20.0, so every test that renders the policy has to declare a
+# cluster that could actually run it -- which doubles as documentation of the floor. The
+# guard itself is asserted with a per-test override at the bottom of this file.
+capabilities:
+  majorVersion: 1
+  minorVersion: 30
 tests:
   # --- the default install is untouched ---
   #
@@ -48,16 +56,18 @@ tests:
         documentIndex: 0
       - equal:
           path: metadata.name
-          value: pg-ns-test-pg-restore-guard
+          value: pg-ns-test-pg-restore-guard-ce1606a5
         documentIndex: 0
       - equal:
           path: metadata.name
-          value: pg-ns-test-pg-restore-guard
+          value: pg-ns-test-pg-restore-guard-ce1606a5
         documentIndex: 1
 
-  # The cluster-scoped name carries the namespace: pg.fullname alone is only unique WITHIN
-  # a namespace, so two releases of this chart would otherwise contend for one policy.
-  - it: the cluster-scoped names are namespace-prefixed
+  # The cluster-scoped name carries the namespace and the release for readability, but what
+  # makes it unique is the trailing hash of the "<namespace>/<fullname>" pair: a bare hyphen
+  # join is ambiguous when either segment contains hyphens, and two releases colliding on
+  # one policy is how a release ends up with its grant and no bound (see the helper).
+  - it: the cluster-scoped name is discriminated by a hash of namespace and fullname
     values:
       - ../values-agent-control-restore.yaml
     release:
@@ -67,9 +77,14 @@ tests:
       - templates/agent-restore-admissionpolicy.yaml
     documentIndex: 0
     asserts:
-      - equal:
+      - matchRegex:
           path: metadata.name
-          value: other-ns-test-pg-restore-guard
+          pattern: "^other-ns-test-pg-restore-guard-[0-9a-f]{8}$"
+      # Same namespace+fullname text, different split -- the pair that a hyphen join maps
+      # onto one name. The hash must differ.
+      - notMatchRegex:
+          path: metadata.name
+          pattern: "-ce1606a5$"
 
   # Ignore, not Fail, would silently re-open the hole on any evaluation failure -- the grant
   # rendered, the bound quietly absent. This assertion is the one that must never regress.
@@ -103,7 +118,7 @@ tests:
           path: spec.matchConditions[0].expression
           value: "request.userInfo.username == 'system:serviceaccount:pg-ns:test-pg-repmgr'"
 
-  - it: the validations pin name, label, identity, token, host namespaces, image, volumes and env
+  - it: the validations pin name, label, identity, placement and containers
     values:
       - ../values-agent-control-restore.yaml
     templates:
@@ -134,28 +149,30 @@ tests:
       - matchRegex:
           path: spec.validations[4].expression
           pattern: "hostIPC == false"
+      # nodeName bypasses the scheduler outright, so it is denied rather than pinned.
+      - matchRegex:
+          path: spec.validations[4].expression
+          pattern: "!has\\(variables\\.pod\\.nodeName\\)"
       - matchRegex:
           path: spec.validations[6].expression
+          pattern: "!has\\(object\\.spec\\.manualSelector\\)"
+      - matchRegex:
+          path: spec.validations[7].expression
+          pattern: "size\\(variables\\.pod\\.containers\\) == 1"
+      - matchRegex:
+          path: spec.validations[7].expression
+          pattern: "ephemeralContainers"
+      - matchRegex:
+          path: spec.validations[8].expression
           pattern: "c\\.image == 'cagriekin/repmgr:trixie-5\\.5\\.0-29'"
-      # Volumes: the sources the restore template actually renders, nothing else -- this is
-      # what keeps another workload's Secret out of a Job created on this token.
-      - matchRegex:
-          path: spec.validations[7].expression
-          pattern: "v\\.configMap\\.name == 'test-pg-pgbackrest'"
-      - matchRegex:
-          path: spec.validations[7].expression
-          pattern: "v\\.persistentVolumeClaim\\.claimName == 'data-test-pg-0'"
-      - matchRegex:
-          path: spec.validations[7].expression
-          pattern: "has\\(v\\.emptyDir\\)"
-      # Every validation denies rather than warns, and says what was wrong.
-      - equal:
-          path: spec.validations[0].reason
-          value: Forbidden
 
-  # The Secret allowlist is built from the same values the Job's env is built from. With
-  # shared S3 keys that is the credential Secret; nothing else in the namespace.
-  - it: the env rule allows only this release's own Secrets
+  # The pod's OWN labels, which validation #2 (the Job object's label) says nothing about.
+  # A restore pod carrying component=postgresql joins the write Service's endpoints, and a
+  # pod with no readiness probe is Ready at once -- so this is a credential-theft path, not
+  # a tidiness rule. The four batch.kubernetes.io/controller keys are in the allowlist
+  # because the API server stamps them BEFORE validating admission runs; a rule demanding
+  # exactly the chart's three labels would deny every legitimate restore.
+  - it: the pod-template labels are an allowlist of keys with this release's values pinned
     values:
       - ../values-agent-control-restore.yaml
     templates:
@@ -163,10 +180,165 @@ tests:
     documentIndex: 0
     asserts:
       - matchRegex:
-          path: spec.validations[8].expression
+          path: spec.validations[5].expression
+          pattern: "variables\\.podLabels\\.all\\(k, k in \\['app.kubernetes.io/component','app.kubernetes.io/instance','app.kubernetes.io/name','batch.kubernetes.io/controller-uid','batch.kubernetes.io/job-name','controller-uid','job-name'\\]\\)"
+      - matchRegex:
+          path: spec.validations[5].expression
+          pattern: "variables\\.podLabels\\['app.kubernetes.io/component'\\] == 'pgbackrest-restore'"
+      - matchRegex:
+          path: spec.validations[5].expression
+          pattern: "variables\\.podLabels\\['app.kubernetes.io/instance'\\] == 'test-pg'"
+      # The variable must survive an absent spec.template.metadata rather than erroring out
+      # of the expression, so the denial is the label rule's message and not a CEL fault.
+      - matchRegex:
+          path: spec.variables[1].expression
+          pattern: "has\\(object\\.spec\\.template\\.metadata\\) &&"
+
+  # The command pin is what stops "one permitted Job" from meaning "run anything you like as
+  # the database's uid with the live PGDATA mounted". Rendered from pg.restoreCommandJSON,
+  # the same definition the jobTemplate uses.
+  - it: the command is pinned to this release's restore entrypoint, with no args
+    values:
+      - ../values-agent-control-restore.yaml
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.validations[9].expression
+          value: "variables.pod.containers.all(c, has(c.command) && c.command == ['/bin/bash', '/scripts/restore.sh'] && !has(c.args))"
+
+  # Security contexts are pinned to what THIS RELEASE renders, not to a fixed profile: the
+  # default values set allowPrivilegeEscalation and runAsUser but not privileged, so the
+  # policy requires those present-and-equal and privileged absent.
+  - it: the security-context pins mirror the release's own values
+    values:
+      - ../values-agent-control-restore.yaml
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.validations[10].expression
+          pattern: "!has\\(c\\.securityContext\\.privileged\\)"
+      - matchRegex:
+          path: spec.validations[10].expression
+          pattern: "c\\.securityContext\\.allowPrivilegeEscalation == false"
+      - matchRegex:
+          path: spec.validations[10].expression
+          pattern: "c\\.securityContext\\.runAsUser == 101"
+      - matchRegex:
+          path: spec.validations[10].expression
+          pattern: "size\\(c\\.securityContext\\.capabilities\\.add\\) == 0"
+      - matchRegex:
+          path: spec.validations[11].expression
+          pattern: "variables\\.pod\\.securityContext\\.runAsNonRoot == true"
+      # seccomp is pinned because the command pin does not make code execution in the restore
+      # container impossible (bash reads $BASH_ENV, and PGDATA is mounted and already writable
+      # by the actor in the threat model) -- so Unconfined would be a real step past "the
+      # privileges I already hold". Nested, so written out: has() on a leaf whose parent is
+      # absent is an evaluation error, not false.
+      - matchRegex:
+          path: spec.validations[11].expression
+          pattern: "variables\\.pod\\.securityContext\\.seccompProfile\\.type == 'RuntimeDefault'"
+      - matchRegex:
+          path: spec.validations[10].expression
+          pattern: "!has\\(c\\.securityContext\\.seccompProfile\\)"
+
+  # ...and they MOVE with the values. A hardcoded hardened profile would deny the release's
+  # own restore Job the moment an operator legitimately changed the context, which is worse
+  # than no policy at all.
+  - it: a values-set privileged container widens the pin instead of denying the release
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      postgresql.containerSecurityContext.privileged: true
+      postgresql.containerSecurityContext.capabilities.add: [SYS_ADMIN]
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.validations[10].expression
+          pattern: "c\\.securityContext\\.privileged == true"
+      - matchRegex:
+          path: spec.validations[10].expression
+          pattern: "c\\.securityContext\\.capabilities\\.add == \\['SYS_ADMIN'\\]"
+
+  # Resources and scale: unbounded parallelism over a limitless container is the
+  # exhaustion path against the database's own nodes. The API server defaults both fields
+  # to 1 before admission, so "<= 1" is required -- "absent" would deny every restore.
+  - it: requests, limits and a single pod are required
+    values:
+      - ../values-agent-control-restore.yaml
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.validations[12].expression
+          pattern: "'cpu' in c\\.resources\\.requests"
+      - matchRegex:
+          path: spec.validations[12].expression
+          pattern: "'memory' in c\\.resources\\.limits"
+      - equal:
+          path: spec.validations[13].expression
+          value: "(!has(object.spec.parallelism) || object.spec.parallelism <= 1) && (!has(object.spec.completions) || object.spec.completions <= 1)"
+
+  # An operator who empties restore.resources must not have their own restore denied: the
+  # rule is derived from the values, so it drops out with them.
+  - it: emptying restore.resources drops the resources rule rather than denying the restore
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      pgbackrest.restore.resources: null
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - notMatchRegex:
+          path: spec.validations[12].expression
+          pattern: "c\\.resources"
+      # ...and the scale rule takes its place at that index, so nothing is silently lost.
+      - matchRegex:
+          path: spec.validations[12].expression
+          pattern: "object\\.spec\\.parallelism <= 1"
+
+  - it: the volume rule allows only the three sources the restore template renders
+    values:
+      - ../values-agent-control-restore.yaml
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.validations[14].expression
+          pattern: "v\\.configMap\\.name == 'test-pg-pgbackrest'"
+      - matchRegex:
+          path: spec.validations[14].expression
+          pattern: "v\\.persistentVolumeClaim\\.claimName == 'data-test-pg-0'"
+      - matchRegex:
+          path: spec.validations[14].expression
+          pattern: "has\\(v\\.emptyDir\\)"
+      # Every validation denies rather than warns, and says what was wrong.
+      - equal:
+          path: spec.validations[14].reason
+          value: Forbidden
+
+  # The Secret allowlist is built from the same values the Job's env is built from. With
+  # shared S3 keys that is the credential Secret; nothing else in the namespace.
+  - it: the env rule allows only the downward API and this release's own Secrets
+    values:
+      - ../values-agent-control-restore.yaml
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.validations[15].expression
           pattern: "e\\.valueFrom\\.secretKeyRef\\.name in \\['s3-backup-creds'\\]"
       - matchRegex:
-          path: spec.validations[8].expression
+          path: spec.validations[15].expression
           pattern: "!has\\(c\\.envFrom\\)"
 
   # A repo-encryption passphrase adds a second legitimate Secret; the rule has to widen
@@ -182,12 +354,14 @@ tests:
     documentIndex: 0
     asserts:
       - matchRegex:
-          path: spec.validations[8].expression
+          path: spec.validations[15].expression
           pattern: "in \\['s3-backup-creds','pgbr-cipher'\\]"
 
-  # Workload identity (keyType=auto) means the release reads no Secret at all, so the rule
-  # becomes "no secretKeyRef whatsoever" rather than an allowlist that happens to be empty.
-  - it: with no Secret of its own the env rule forbids secretKeyRef outright
+  # Workload identity (keyType=auto) means the release reads no Secret at all. The rule must
+  # stay an ALLOWLIST of sources -- fieldRef only -- and NOT degrade into "no secretKeyRef",
+  # which would admit configMapKeyRef and turn the keyless install into the one
+  # configuration where a ConfigMap in the namespace is readable.
+  - it: with no Secret of its own the env rule permits only the downward API
     values:
       - ../values-agent-control-restore.yaml
     set:
@@ -196,11 +370,14 @@ tests:
       - templates/agent-restore-admissionpolicy.yaml
     documentIndex: 0
     asserts:
-      - matchRegex:
-          path: spec.validations[8].expression
+      - equal:
+          path: spec.validations[15].expression
+          value: "variables.pod.containers.all(c, !has(c.envFrom) && (!has(c.env) || c.env.all(e, !has(e.valueFrom) || (has(e.valueFrom.fieldRef)))))"
+      - notMatchRegex:
+          path: spec.validations[15].expression
           pattern: "!has\\(e\\.valueFrom\\.secretKeyRef\\)"
       - notMatchRegex:
-          path: spec.validations[8].expression
+          path: spec.validations[15].expression
           pattern: "secretKeyRef\\.name in"
 
   # --- the binding ---
@@ -218,7 +395,7 @@ tests:
     asserts:
       - equal:
           path: spec.policyName
-          value: pg-ns-test-pg-restore-guard
+          value: pg-ns-test-pg-restore-guard-ce1606a5
       - equal:
           path: spec.validationActions[0]
           value: Deny
@@ -228,12 +405,12 @@ tests:
       - isNull:
           path: spec.matchResources.objectSelector
 
-  # --- the label the policy requires must actually be on the template it clones ---
+  # --- the label and the command the policy requires must be what the CronJob renders ---
   #
   # The agent copies the CronJob's jobTemplate labels onto the Job it creates, and nothing
   # else puts labels there. If this ever regresses, validation #2 denies every API-driven
   # restore -- so it is asserted next to the policy rather than with the backup tests.
-  - it: the restore CronJob's jobTemplate carries the label the policy requires
+  - it: the restore CronJob renders the label and command the policy pins
     values:
       - ../values-agent-control-restore.yaml
     templates:
@@ -246,6 +423,62 @@ tests:
       # otherwise invites a GitOps controller to prune it mid-restore.
       - isNull:
           path: spec.jobTemplate.metadata.labels["app.kubernetes.io/managed-by"]
+      # The pod-template labels validation #6 pins, as the CronJob really renders them.
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: pgbackrest-restore
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          value: ["/bin/bash", "/scripts/restore.sh"]
+
+  # --- render-time validation ---
+  #
+  # A value with an apostrophe would produce a broken CEL expression that renders, lints and
+  # unit-tests clean and only fails when the API server parses the policy; `x' || true || '`
+  # would produce a TAUTOLOGY that looks installed and enforces nothing. Both are the
+  # apply-time failure the chart's render-time-validation rule exists to prevent.
+  - it: a value that cannot be embedded in a CEL literal fails the render
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      pgbackrest.repoEncryption.enabled: true
+      pgbackrest.repoEncryption.existingSecret.name: "dba's-key"
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "a pgbackrest Secret name (pgbackrest.existingSecret.name / pgbackrest.repoEncryption.existingSecret.name) is \"dba's-key\", which cannot be embedded in the restore admission policy's CEL expressions (#279): it must match ^[A-Za-z0-9][A-Za-z0-9._:/@-]*$ (alphanumerics and . _ - / : @). Quotes, whitespace and backslashes would either break the policy at apply time or silently turn a validation into a tautology. Fix the value, or disable the policy deliberately with repmgr.agent.control.restore.admissionPolicy.enabled=false plus acknowledgeUnbounded=true"
+
+  # admissionregistration.k8s.io/v1 does not exist before 1.30. Failing the RENDER is the
+  # point: without it, an upgrade from 1.9.0 on an older cluster renders clean and then
+  # aborts mid-apply with "no matches for kind", leaving the release failed.
+  - it: a cluster below 1.30 fails the render rather than the apply
+    values:
+      - ../values-agent-control-restore.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 29
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "repmgr.agent.control.restore requires Kubernetes >= 1.30 for the ValidatingAdmissionPolicy that bounds its `create jobs` grant, but this cluster reports v1.29.0 (#279). Upgrade the cluster, or set repmgr.agent.control.restore.admissionPolicy.enabled=false together with acknowledgeUnbounded=true to run the feature with an unbounded grant deliberately"
+
+  # ...and acknowledging the trade is what lets a pre-1.30 cluster run the feature at all.
+  - it: acknowledging the trade lets a pre-1.30 cluster render the grant
+    values:
+      - ../values-agent-control-restore.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 29
+    set:
+      repmgr.agent.control.restore.admissionPolicy.enabled: false
+      repmgr.agent.control.restore.admissionPolicy.acknowledgeUnbounded: true
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
 
   # --- the grant and the bound cannot be separated ---
   - it: disabling the policy without acknowledging the trade fails the render

--- a/pg/tests/unit/restore_admissionpolicy_test.yaml
+++ b/pg/tests/unit/restore_admissionpolicy_test.yaml
@@ -2,14 +2,16 @@ suite: restore job-create admission policy (#279)
 release:
   name: test-pg
   namespace: pg-ns
-# The policy pins admissionregistration.k8s.io/v1, and the template FAILS the render below
-# Kubernetes 1.30 rather than letting the apply abort halfway. helm-unittest's default
-# capability set reports v1.20.0, so every test that renders the policy has to declare a
-# cluster that could actually run it -- which doubles as documentation of the floor. The
-# guard itself is asserted with a per-test override at the bottom of this file.
+# The template FAILS the render when the cluster does not expose
+# admissionregistration.k8s.io/v1, rather than letting the apply abort halfway. helm's own
+# no-cluster default capability set already contains that group, so `helm template` and the
+# kubeconform gate need nothing -- but helm-unittest's default set does NOT, so the suite
+# declares it here. That doubles as documentation of the precondition, and the guard's own
+# test is a separate suite (restore_admissionpolicy_nocapability_test.yaml) that declines to
+# declare it: suite-level apiVersions cannot be un-declared by a per-test override.
 capabilities:
-  majorVersion: 1
-  minorVersion: 30
+  apiVersions:
+    - admissionregistration.k8s.io/v1
 tests:
   # --- the default install is untouched ---
   #
@@ -80,8 +82,10 @@ tests:
       - matchRegex:
           path: metadata.name
           pattern: "^other-ns-test-pg-restore-guard-[0-9a-f]{8}$"
-      # Same namespace+fullname text, different split -- the pair that a hyphen join maps
-      # onto one name. The hash must differ.
+      # A different namespace must land on a different hash. This is NOT the ambiguous pair
+      # itself (other-ns/test-pg and pg-ns/test-pg differ under a plain hyphen join too);
+      # the actual collision -- db/pg-prod vs prod-db/pg -- is asserted in test-template.sh,
+      # which can render two releases in one run.
       - notMatchRegex:
           path: metadata.name
           pattern: "-ce1606a5$"
@@ -206,7 +210,7 @@ tests:
     asserts:
       - equal:
           path: spec.validations[9].expression
-          value: "variables.pod.containers.all(c, has(c.command) && c.command == ['/bin/bash', '/scripts/restore.sh'] && !has(c.args))"
+          value: "variables.pod.containers.all(c, has(c.command) && c.command == ['/bin/bash', '/scripts/restore.sh'] && !has(c.args) && !has(c.lifecycle))"
 
   # Security contexts are pinned to what THIS RELEASE renders, not to a fixed profile: the
   # default values set allowPrivilegeEscalation and runAsUser but not privileged, so the
@@ -449,36 +453,106 @@ tests:
       - failedTemplate:
           errorMessage: "a pgbackrest Secret name (pgbackrest.existingSecret.name / pgbackrest.repoEncryption.existingSecret.name) is \"dba's-key\", which cannot be embedded in the restore admission policy's CEL expressions (#279): it must match ^[A-Za-z0-9][A-Za-z0-9._:/@-]*$ (alphanumerics and . _ - / : @). Quotes, whitespace and backslashes would either break the policy at apply time or silently turn a validation into a tautology. Fix the value, or disable the policy deliberately with repmgr.agent.control.restore.admissionPolicy.enabled=false plus acknowledgeUnbounded=true"
 
-  # admissionregistration.k8s.io/v1 does not exist before 1.30. Failing the RENDER is the
-  # point: without it, an upgrade from 1.9.0 on an older cluster renders clean and then
-  # aborts mid-apply with "no matches for kind", leaving the release failed.
-  - it: a cluster below 1.30 fails the render rather than the apply
+  # priorityClassName is pinned, and it is deliberately NOT lumped in with
+  # nodeSelector/tolerations: those can only restrict where a pod runs, while a priority class
+  # lets the scheduler PREEMPT this release's own postgresql pods, and referencing one needs no
+  # permission. The parallelism cap does not help -- one pod is enough.
+  - it: priorityClassName is pinned to what the release renders
     values:
       - ../values-agent-control-restore.yaml
-    capabilities:
-      majorVersion: 1
-      minorVersion: 29
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.validations[4].expression
+          pattern: "!has\\(variables\\.pod\\.priorityClassName\\)"
+
+  - it: a values-set priority class widens the pin to exactly that class
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      pgbackrest.cronjob.priorityClassName: db-critical
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.validations[4].expression
+          pattern: "variables\\.pod\\.priorityClassName == 'db-critical'"
+
+  # A postStart/preStop exec hook runs a caller-chosen program in the pinned container without
+  # touching command or args, so the command pin's promise needs it denied too.
+  - it: lifecycle hooks are denied alongside the command pin
+    values:
+      - ../values-agent-control-restore.yaml
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.validations[9].expression
+          pattern: "!has\\(c\\.lifecycle\\)"
+
+  # An operator who empties the security contexts must not have their own restore denied.
+  # `postgresql.containerSecurityContext: {}` renders `securityContext: {}` on the Job, which
+  # has() sees as PRESENT -- so the no-values branch must be "absent OR sets none of the
+  # pinned fields", not a bare !has(). The !has(parent) || (...) shape is safe because CEL's
+  # logical operators are commutative: a true left side wins even when the right would error.
+  - it: emptied security contexts tolerate a present-but-empty securityContext
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      postgresql.containerSecurityContext: null
+      postgresql.podSecurityContext: null
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.validations[10].expression
+          pattern: "!has\\(c\\.securityContext\\) \\|\\|"
+      - matchRegex:
+          path: spec.validations[11].expression
+          pattern: "!has\\(variables\\.pod\\.securityContext\\) \\|\\|"
+
+  # Every value reaching a single-quoted CEL literal is charset-checked, not only the obvious
+  # ones. `RuntimeDefault' || true || '` renders a syntactically valid, ALWAYS-TRUE expression
+  # (== binds tighter than ||), so the pin silently becomes a tautology that renders and lints
+  # clean, and values.schema.json constrains none of these.
+  - it: a crafted seccomp profile type cannot turn its pin into a tautology
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      postgresql.podSecurityContext.seccompProfile.type: "x' || true || '"
     templates:
       - templates/agent-restore-admissionpolicy.yaml
     asserts:
       - failedTemplate:
-          errorMessage: "repmgr.agent.control.restore requires Kubernetes >= 1.30 for the ValidatingAdmissionPolicy that bounds its `create jobs` grant, but this cluster reports v1.29.0 (#279). Upgrade the cluster, or set repmgr.agent.control.restore.admissionPolicy.enabled=false together with acknowledgeUnbounded=true to run the feature with an unbounded grant deliberately"
+          errorMessage: "postgresql.podSecurityContext.seccompProfile.type is \"x' || true || '\", which cannot be embedded in the restore admission policy's CEL expressions (#279): it must match ^[A-Za-z0-9][A-Za-z0-9._:/@-]*$ (alphanumerics and . _ - / : @). Quotes, whitespace and backslashes would either break the policy at apply time or silently turn a validation into a tautology. Fix the value, or disable the policy deliberately with repmgr.agent.control.restore.admissionPolicy.enabled=false plus acknowledgeUnbounded=true"
 
-  # ...and acknowledging the trade is what lets a pre-1.30 cluster run the feature at all.
-  - it: acknowledging the trade lets a pre-1.30 cluster render the grant
+  - it: a crafted added capability cannot turn its pin into a tautology
     values:
       - ../values-agent-control-restore.yaml
-    capabilities:
-      majorVersion: 1
-      minorVersion: 29
     set:
-      repmgr.agent.control.restore.admissionPolicy.enabled: false
-      repmgr.agent.control.restore.admissionPolicy.acknowledgeUnbounded: true
+      postgresql.containerSecurityContext.capabilities.add:
+        - "SYS_ADMIN' || true || '"
     templates:
       - templates/agent-restore-admissionpolicy.yaml
     asserts:
-      - hasDocuments:
-          count: 0
+      - failedTemplate:
+          errorMessage: "a postgresql.containerSecurityContext.capabilities.add entry is \"SYS_ADMIN' || true || '\", which cannot be embedded in the restore admission policy's CEL expressions (#279): it must match ^[A-Za-z0-9][A-Za-z0-9._:/@-]*$ (alphanumerics and . _ - / : @). Quotes, whitespace and backslashes would either break the policy at apply time or silently turn a validation into a tautology. Fix the value, or disable the policy deliberately with repmgr.agent.control.restore.admissionPolicy.enabled=false plus acknowledgeUnbounded=true"
+
+  - it: a crafted priority class name cannot turn its pin into a tautology
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      pgbackrest.cronjob.priorityClassName: "p' || true || '"
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "pgbackrest.cronjob.priorityClassName is \"p' || true || '\", which cannot be embedded in the restore admission policy's CEL expressions (#279): it must match ^[A-Za-z0-9][A-Za-z0-9._:/@-]*$ (alphanumerics and . _ - / : @). Quotes, whitespace and backslashes would either break the policy at apply time or silently turn a validation into a tautology. Fix the value, or disable the policy deliberately with repmgr.agent.control.restore.admissionPolicy.enabled=false plus acknowledgeUnbounded=true"
 
   # --- the grant and the bound cannot be separated ---
   - it: disabling the policy without acknowledging the trade fails the render

--- a/pg/tests/unit/restore_admissionpolicy_test.yaml
+++ b/pg/tests/unit/restore_admissionpolicy_test.yaml
@@ -531,6 +531,17 @@ tests:
       - failedTemplate:
           errorMessage: "postgresql.podSecurityContext.seccompProfile.type is \"x' || true || '\", which cannot be embedded in the restore admission policy's CEL expressions (#279): it must match ^[A-Za-z0-9][A-Za-z0-9._:/@-]*$ (alphanumerics and . _ - / : @). Quotes, whitespace and backslashes would either break the policy at apply time or silently turn a validation into a tautology. Fix the value, or disable the policy deliberately with repmgr.agent.control.restore.admissionPolicy.enabled=false plus acknowledgeUnbounded=true"
 
+  - it: a crafted container seccomp profile type cannot turn its pin into a tautology
+    values:
+      - ../values-agent-control-restore.yaml
+    set:
+      postgresql.containerSecurityContext.seccompProfile.type: "x' || true || '"
+    templates:
+      - templates/agent-restore-admissionpolicy.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "postgresql.containerSecurityContext.seccompProfile.type is \"x' || true || '\", which cannot be embedded in the restore admission policy's CEL expressions (#279): it must match ^[A-Za-z0-9][A-Za-z0-9._:/@-]*$ (alphanumerics and . _ - / : @). Quotes, whitespace and backslashes would either break the policy at apply time or silently turn a validation into a tautology. Fix the value, or disable the policy deliberately with repmgr.agent.control.restore.admissionPolicy.enabled=false plus acknowledgeUnbounded=true"
+
   - it: a crafted added capability cannot turn its pin into a tautology
     values:
       - ../values-agent-control-restore.yaml

--- a/pg/values.schema.json
+++ b/pg/values.schema.json
@@ -110,7 +110,18 @@
                       "items": { "type": "string" },
                       "description": "Restore-specific authz verb. An empty list denies every client."
                     },
-                    "readPodLogs": { "type": "boolean" }
+                    "readPodLogs": { "type": "boolean" },
+                    "admissionPolicy": {
+                      "type": "object",
+                      "description": "ValidatingAdmissionPolicy bounding the restore feature's `create jobs` grant by content (#279). Requires Kubernetes >= 1.30 and cluster-scoped create on admissionregistration.k8s.io. Disabling it requires acknowledgeUnbounded=true -- a template guard, not schema if/then.",
+                      "properties": {
+                        "enabled": { "type": "boolean" },
+                        "acknowledgeUnbounded": {
+                          "type": "boolean",
+                          "description": "Accept the unbounded namespace-wide job-create grant when the policy is disabled."
+                        }
+                      }
+                    }
                   }
                 }
               }

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -477,10 +477,12 @@ repmgr:
         #
         # What it checks: the Job's name (the deterministic one the agent uses, which is the
         # resourceName restriction RBAC refused to give), its pg-ha/restore label, its
-        # ServiceAccount, automountServiceAccountToken=false, no host namespaces and no
-        # explicit nodeName, the pod's own labels (so the restore pod cannot join this
-        # release's Service endpoints), no manualSelector, one container running this
-        # release's image and this release's restore command with no args, this release's
+        # ServiceAccount, automountServiceAccountToken=false, no host namespaces, no
+        # explicit nodeName and only this release's priorityClassName (a higher-priority class
+        # would let the scheduler preempt this release's own pods), the pod's own labels (so
+        # the restore pod cannot join this release's Service endpoints), no manualSelector, one
+        # container running this release's image and this release's restore command with no
+        # args and no lifecycle hooks, this release's
         # pod and container security contexts (so no privileged / root / added-capability
         # container), CPU and memory requests and limits, a single pod (parallelism and
         # completions <= 1), volumes limited to the three the restore template renders, and
@@ -497,8 +499,10 @@ repmgr:
         #   * The installing identity needs cluster-scoped create on
         #     admissionregistration.k8s.io ValidatingAdmissionPolicy/-Binding. A namespace-
         #     limited installer cannot render this (see acknowledgeUnbounded below).
-        #   * Kubernetes >= 1.30 is required, and the render FAILS below that rather than
-        #     letting the apply fail halfway.
+        #   * Kubernetes >= 1.30 is required, and the render FAILS when the cluster does not
+        #     expose admissionregistration.k8s.io/v1 rather than letting the apply fail
+        #     halfway. The check is on the API group, not the reported version: with no
+        #     cluster, .Capabilities.KubeVersion is the helm CLIENT's own version.
         #   * A cluster whose mutating admission rewrites JOB objects (not pod specs --
         #     sidecar injectors act on Pods and are unaffected) can make the rendered Job
         #     stop matching, which shows up as a denial naming the exact field.

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -477,14 +477,28 @@ repmgr:
         #
         # What it checks: the Job's name (the deterministic one the agent uses, which is the
         # resourceName restriction RBAC refused to give), its pg-ha/restore label, its
-        # ServiceAccount, automountServiceAccountToken=false, no host namespaces, one
-        # container running this release's image, volumes limited to the three the restore
-        # template renders, and no envFrom / no Secret references beyond this release's own.
+        # ServiceAccount, automountServiceAccountToken=false, no host namespaces and no
+        # explicit nodeName, the pod's own labels (so the restore pod cannot join this
+        # release's Service endpoints), no manualSelector, one container running this
+        # release's image and this release's restore command with no args, this release's
+        # pod and container security contexts (so no privileged / root / added-capability
+        # container), CPU and memory requests and limits, a single pod (parallelism and
+        # completions <= 1), volumes limited to the three the restore template renders, and
+        # no envFrom / no valueFrom beyond the downward API and this release's own Secrets.
         #
-        # Two consequences worth knowing before you install:
+        # What it does NOT bound, because a restore cannot be expressed without it: the
+        # restore PARAMETERS. Anything holding the token can still run this release's own
+        # restore against a target of its choosing, over the live PGDATA, without passing
+        # the control API's mTLS. That is the operation the feature exposes; see the
+        # "Bounding the job-create grant" section of README.md before enabling it on a
+        # cluster running untrusted SQL.
+        #
+        # Three consequences worth knowing before you install:
         #   * The installing identity needs cluster-scoped create on
         #     admissionregistration.k8s.io ValidatingAdmissionPolicy/-Binding. A namespace-
         #     limited installer cannot render this (see acknowledgeUnbounded below).
+        #   * Kubernetes >= 1.30 is required, and the render FAILS below that rather than
+        #     letting the apply fail halfway.
         #   * A cluster whose mutating admission rewrites JOB objects (not pod specs --
         #     sidecar injectors act on Pods and are unaffected) can make the rendered Job
         #     stop matching, which shows up as a denial naming the exact field.

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -465,6 +465,41 @@ repmgr:
         # Required when restore.enabled -- an empty list denies everyone, so forgetting
         # it cannot open the most destructive verb in the API.
         allowedClientCNs: []
+        # The bound on the `create jobs` grant above (#279). RBAC restricts by VERB and
+        # RESOURCE; this restricts by CONTENT, which is the primitive RBAC does not have --
+        # so with it on, "create arbitrary Jobs in this namespace" becomes "create this one
+        # restore Job, as this release's ServiceAccount, with this release's volumes".
+        #
+        # A ValidatingAdmissionPolicy + binding, both CLUSTER-SCOPED objects: in-tree and
+        # GA since Kubernetes 1.30, so no webhook, no serving certificate and nothing that
+        # can be down. It polices ONLY this release's ServiceAccount -- humans, GitOps
+        # controllers and every other workload create Jobs untouched.
+        #
+        # What it checks: the Job's name (the deterministic one the agent uses, which is the
+        # resourceName restriction RBAC refused to give), its pg-ha/restore label, its
+        # ServiceAccount, automountServiceAccountToken=false, no host namespaces, one
+        # container running this release's image, volumes limited to the three the restore
+        # template renders, and no envFrom / no Secret references beyond this release's own.
+        #
+        # Two consequences worth knowing before you install:
+        #   * The installing identity needs cluster-scoped create on
+        #     admissionregistration.k8s.io ValidatingAdmissionPolicy/-Binding. A namespace-
+        #     limited installer cannot render this (see acknowledgeUnbounded below).
+        #   * A cluster whose mutating admission rewrites JOB objects (not pod specs --
+        #     sidecar injectors act on Pods and are unaffected) can make the rendered Job
+        #     stop matching, which shows up as a denial naming the exact field.
+        admissionPolicy:
+          enabled: true
+          # The escape hatch, and it is deliberately awkward: with admissionPolicy.enabled
+          # false the RENDER FAILS unless this is also true. Turning the bound off silently
+          # would leave the Role carrying a namespace-wide privilege-escalation primitive
+          # with nothing recording that anyone chose that -- which is the exact shape #279
+          # set out to remove. Set both only when you mean it:
+          #   * the cluster is below Kubernetes 1.30;
+          #   * you install the policy out of band (a namespace-limited installer, or one
+          #     cluster-wide policy managed by the platform team);
+          #   * or you accept the unbounded grant, as 1.9.0 required everyone to.
+          acknowledgeUnbounded: false
         # Live file-copy progress (progress.percent on GET /v1/restore) by tailing the
         # restore pod's log. Off by default because it needs `get pods/log` across the
         # namespace -- the Job's pod name is generated, so it cannot be scoped -- and

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,31 @@
 # pgvector chart changelog
 
+## 1.10.0 - 2026-08-02
+
+Inherited from pg's symlinked templates and the shared repmgr image. See the
+[pg 1.10.0 changelog](../pg/CHANGELOG.md) for the full detail.
+
+### Added
+
+- **A `ValidatingAdmissionPolicy` bounding `repmgr.agent.control.restore`'s job-create
+  grant** (#279), rendered by default when that feature is enabled. `create` on `jobs`
+  cannot be scoped by `resourceName`, so 1.9.0's grant was a namespace-wide
+  privilege-escalation primitive on a token that sits beside user-supplied SQL. The policy
+  restricts by **content** instead — one permitted Job name, this release's ServiceAccount,
+  no mounted token, no host namespaces, this release's image, volumes and Secrets only —
+  and polices only this release's ServiceAccount, leaving every other Job creator untouched.
+  `failurePolicy: Fail`, and rendering the grant without the policy fails the render unless
+  `admissionPolicy.acknowledgeUnbounded: true` says so deliberately.
+- The restore CronJob's `jobTemplate` now carries `pg-ha/restore=<fullname>`, so a cloned
+  restore Job is selectable where before it carried no labels.
+
+### Upgrading
+
+- Enabling `repmgr.agent.control.restore` now requires **Kubernetes ≥ 1.30** and
+  cluster-scoped `create` on `admissionregistration.k8s.io`. A default install renders no
+  cluster-scoped objects, so nothing else changes. To keep 1.9.0's behaviour, set
+  `admissionPolicy.enabled: false` **and** `acknowledgeUnbounded: true`.
+
 ## 1.9.0 - 2026-08-01
 
 Inherited from pg's symlinked templates and the shared repmgr image. See the

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -12,9 +12,11 @@ Inherited from pg's symlinked templates and the shared repmgr image. See the
   cannot be scoped by `resourceName`, so 1.9.0's grant was a namespace-wide
   privilege-escalation primitive on a token that sits beside user-supplied SQL. The policy
   restricts by **content** instead — one permitted Job name, this release's ServiceAccount
-  with no mounted token, no host namespaces and no `nodeName`, the pod's own labels (so the
-  restore pod cannot join this release's Service endpoints), one container on this release's
-  image running this release's restore command with no args, this release's pod and container
+  with no mounted token, no host namespaces, no `nodeName` and only this release's
+  `priorityClassName` (a higher-priority class would let the scheduler preempt this release's
+  own pods), the pod's own labels (so the restore pod cannot join this release's Service
+  endpoints), one container on this release's image running this release's restore command with
+  no args and no lifecycle hooks, this release's pod and container
   security contexts (no privileged / root / added-capability container), requests and limits,
   a single pod, and only this release's volumes and Secrets — and polices only this release's
   ServiceAccount, leaving every other Job creator untouched. `failurePolicy: Fail`, and
@@ -33,8 +35,10 @@ Inherited from pg's symlinked templates and the shared repmgr image. See the
 
 - Enabling `repmgr.agent.control.restore` now requires **Kubernetes ≥ 1.30** and
   cluster-scoped `create` on `admissionregistration.k8s.io`. A default install renders no
-  cluster-scoped objects, so nothing else changes. Below 1.30 the **render** fails with the
-  version it detected, rather than the apply aborting halfway. To keep 1.9.0's behaviour, set
+  cluster-scoped objects, so nothing else changes. Without the API the **render** fails,
+  rather than the apply aborting halfway; the precondition checked is the presence of
+  `admissionregistration.k8s.io/v1`, not the reported version, because with no cluster to
+  query `.Capabilities.KubeVersion` is the helm client's own. To keep 1.9.0's behaviour, set
   `admissionPolicy.enabled: false` **and** `acknowledgeUnbounded: true`.
 - Secret names and image references interpolated into the policy's CEL expressions are now
   charset-validated at render time, so a name containing a quote fails the render with the

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -11,11 +11,21 @@ Inherited from pg's symlinked templates and the shared repmgr image. See the
   grant** (#279), rendered by default when that feature is enabled. `create` on `jobs`
   cannot be scoped by `resourceName`, so 1.9.0's grant was a namespace-wide
   privilege-escalation primitive on a token that sits beside user-supplied SQL. The policy
-  restricts by **content** instead — one permitted Job name, this release's ServiceAccount,
-  no mounted token, no host namespaces, this release's image, volumes and Secrets only —
-  and polices only this release's ServiceAccount, leaving every other Job creator untouched.
-  `failurePolicy: Fail`, and rendering the grant without the policy fails the render unless
+  restricts by **content** instead — one permitted Job name, this release's ServiceAccount
+  with no mounted token, no host namespaces and no `nodeName`, the pod's own labels (so the
+  restore pod cannot join this release's Service endpoints), one container on this release's
+  image running this release's restore command with no args, this release's pod and container
+  security contexts (no privileged / root / added-capability container), requests and limits,
+  a single pod, and only this release's volumes and Secrets — and polices only this release's
+  ServiceAccount, leaving every other Job creator untouched. `failurePolicy: Fail`, and
+  rendering the grant without the policy fails the render unless
   `admissionPolicy.acknowledgeUnbounded: true` says so deliberately.
+
+  What it does **not** bound, stated plainly: the restore *parameters*. Anything holding the
+  token can still run this release's own restore over the live PGDATA without presenting a
+  certificate to the control API — that is the operation being exposed. Where untrusted SQL
+  runs and an unscheduled restore would itself be an incident, leaving `control.restore` off
+  remains the right answer.
 - The restore CronJob's `jobTemplate` now carries `pg-ha/restore=<fullname>`, so a cloned
   restore Job is selectable where before it carried no labels.
 
@@ -23,8 +33,13 @@ Inherited from pg's symlinked templates and the shared repmgr image. See the
 
 - Enabling `repmgr.agent.control.restore` now requires **Kubernetes ≥ 1.30** and
   cluster-scoped `create` on `admissionregistration.k8s.io`. A default install renders no
-  cluster-scoped objects, so nothing else changes. To keep 1.9.0's behaviour, set
+  cluster-scoped objects, so nothing else changes. Below 1.30 the **render** fails with the
+  version it detected, rather than the apply aborting halfway. To keep 1.9.0's behaviour, set
   `admissionPolicy.enabled: false` **and** `acknowledgeUnbounded: true`.
+- Secret names and image references interpolated into the policy's CEL expressions are now
+  charset-validated at render time, so a name containing a quote fails the render with the
+  value named instead of producing a policy the API server rejects — or one whose validation
+  is a tautology.
 
 ## 1.9.0 - 2026-08-01
 

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus repmgr replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 1.9.0
+version: 1.10.0
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/templates/agent-restore-admissionpolicy.yaml
+++ b/pgvector/templates/agent-restore-admissionpolicy.yaml
@@ -1,0 +1,1 @@
+../../pg/templates/agent-restore-admissionpolicy.yaml

--- a/pgvector/values.schema.json
+++ b/pgvector/values.schema.json
@@ -110,7 +110,18 @@
                       "items": { "type": "string" },
                       "description": "Restore-specific authz verb. An empty list denies every client."
                     },
-                    "readPodLogs": { "type": "boolean" }
+                    "readPodLogs": { "type": "boolean" },
+                    "admissionPolicy": {
+                      "type": "object",
+                      "description": "ValidatingAdmissionPolicy bounding the restore feature's `create jobs` grant by content (#279). Requires Kubernetes >= 1.30 and cluster-scoped create on admissionregistration.k8s.io. Disabling it requires acknowledgeUnbounded=true -- a template guard, not schema if/then.",
+                      "properties": {
+                        "enabled": { "type": "boolean" },
+                        "acknowledgeUnbounded": {
+                          "type": "boolean",
+                          "description": "Accept the unbounded namespace-wide job-create grant when the policy is disabled."
+                        }
+                      }
+                    }
                   }
                 }
               }

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -417,6 +417,23 @@ repmgr:
         # Required when restore.enabled -- an empty list denies everyone, so forgetting
         # it cannot open the most destructive verb in the API.
         allowedClientCNs: []
+        # The bound on the `create jobs` grant restore needs (#279). RBAC restricts by verb
+        # and resource; this restricts by CONTENT, which RBAC cannot -- so "create arbitrary
+        # Jobs in this namespace" becomes "create this one restore Job, as this release's
+        # ServiceAccount, with this release's volumes".
+        #
+        # A ValidatingAdmissionPolicy + binding, both CLUSTER-SCOPED: in-tree and GA since
+        # Kubernetes 1.30, so no webhook and nothing that can be down. It polices only this
+        # release's ServiceAccount; every other creator of Jobs is untouched. The installing
+        # identity needs cluster-scoped create on admissionregistration.k8s.io.
+        admissionPolicy:
+          enabled: true
+          # With admissionPolicy.enabled false the RENDER FAILS unless this is also true:
+          # dropping the bound silently would leave the Role carrying a namespace-wide
+          # privilege-escalation primitive with nothing recording that anyone chose it. Set
+          # both for a cluster below 1.30, a policy installed out of band, or to accept the
+          # unbounded grant as 1.9.0 required.
+          acknowledgeUnbounded: false
         # Live file-copy progress (progress.percent on GET /v1/restore) by tailing the
         # restore pod's log. Off by default because it needs `get pods/log` across the
         # namespace -- the Job's pod name is generated, so it cannot be scoped -- and

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -426,13 +426,16 @@ repmgr:
         # Kubernetes 1.30, so no webhook and nothing that can be down. It polices only this
         # release's ServiceAccount; every other creator of Jobs is untouched. The installing
         # identity needs cluster-scoped create on admissionregistration.k8s.io, and the
-        # render FAILS below Kubernetes 1.30 rather than letting the apply fail halfway.
+        # render FAILS when the cluster does not expose admissionregistration.k8s.io/v1 (GA in
+        # 1.30) rather than letting the apply fail halfway. The check is on the API group, not
+        # the reported version: with no cluster, .Capabilities.KubeVersion is the helm client's.
         #
         # Pinned: the Job's name and pg-ha/restore label, its ServiceAccount with
-        # automountServiceAccountToken=false, no host namespaces and no nodeName, the pod's
-        # own labels (so it cannot join this release's Service endpoints), no manualSelector,
-        # one container on this release's image running this release's restore command with
-        # no args, this release's pod and container security contexts (no privileged / root /
+        # automountServiceAccountToken=false, no host namespaces, no nodeName and only this
+        # release's priorityClassName, the pod's own labels (so it cannot join this release's
+        # Service endpoints), no manualSelector, one container on this release's image running
+        # this release's restore command with no args and no lifecycle hooks, this release's
+        # pod and container security contexts (no privileged / root /
         # added capabilities), requests and limits, a single pod, the three volumes the
         # restore renders, and no envFrom / no valueFrom beyond the downward API and this
         # release's own Secrets.

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -425,7 +425,21 @@ repmgr:
         # A ValidatingAdmissionPolicy + binding, both CLUSTER-SCOPED: in-tree and GA since
         # Kubernetes 1.30, so no webhook and nothing that can be down. It polices only this
         # release's ServiceAccount; every other creator of Jobs is untouched. The installing
-        # identity needs cluster-scoped create on admissionregistration.k8s.io.
+        # identity needs cluster-scoped create on admissionregistration.k8s.io, and the
+        # render FAILS below Kubernetes 1.30 rather than letting the apply fail halfway.
+        #
+        # Pinned: the Job's name and pg-ha/restore label, its ServiceAccount with
+        # automountServiceAccountToken=false, no host namespaces and no nodeName, the pod's
+        # own labels (so it cannot join this release's Service endpoints), no manualSelector,
+        # one container on this release's image running this release's restore command with
+        # no args, this release's pod and container security contexts (no privileged / root /
+        # added capabilities), requests and limits, a single pod, the three volumes the
+        # restore renders, and no envFrom / no valueFrom beyond the downward API and this
+        # release's own Secrets.
+        #
+        # NOT bounded, because a restore cannot be expressed without it: the restore
+        # PARAMETERS. Anything holding the token can still run this release's own restore
+        # over the live PGDATA without passing the control API's mTLS. See pg/README.md.
         admissionPolicy:
           enabled: true
           # With admissionPolicy.enabled false the RENDER FAILS unless this is also true:


### PR DESCRIPTION
Closes #279.

`repmgr.agent.control.restore` (#276, 1.9.0) needs `create` on `batch/jobs`, and RBAC cannot restrict a create by `resourceName` — the API server does not know the object's name at authorization time. So that grant alone let anything holding the database pods' ServiceAccount token create **arbitrary** Jobs in the namespace, and a Job's pod may name any ServiceAccount with no separate permission check. On a token mounted beside a PostgreSQL that runs user-supplied SQL, that is a namespace-wide privilege-escalation primitive, which is why 1.9.0 shipped the feature with "leave it off unless the trade is worth it" rather than a fix.

The missing restriction is content-based, which is a layer RBAC does not reach. `ValidatingAdmissionPolicy` is exactly that layer — in-tree and GA since Kubernetes 1.30, so no webhook, no serving certificate, and nothing here that can be *down*.

## What the policy pins

It polices **one subject** (`request.userInfo.username` equal to this release's SA, exact equality — a suffix match would police same-named SAs in other namespaces) and requires of every Job that subject creates:

| Pinned | What it takes away |
|---|---|
| `metadata.name` == the agent's one deterministic Job name | the `resourceName` restriction RBAC refused to give: `create` collapses to one object. `generateName` cannot dodge it — validating admission sees the resolved name |
| `pg-ha/restore=<fullname>` label | provenance; fails closed if chart and policy drift |
| `serviceAccountName` == the release's own, `automountServiceAccountToken: false` **explicitly** (absent is a denial) | the escalation itself, and it makes SA-naming moot — the pod gets no token |
| no `hostNetwork`/`hostPID`/`hostIPC`, no explicit `nodeName` | node escape, and placing the pod by hand instead of through the scheduler |
| the **pod's own labels** (allowlist of keys) | joining this release's Service endpoints. A restore pod labelled `component=postgresql` is added to the write Service — Ready at once, it has no readiness probe — and receives application traffic and credentials |
| no `manualSelector` | the Job's selector and identity labels stay server-assigned |
| one container, no init/ephemeral containers, this release's image | what code enters the cluster on this token |
| `command` == this release's restore entrypoint, no `args` | the image pin alone is weak (the postgresql container already runs this image against this volume). Without it the Job is "run anything as the database's uid with the live PGDATA mounted" — data destruction with no escalation at all |
| this release's pod + container `securityContext` (`privileged`, `allowPrivilegeEscalation`, `runAsUser`, `runAsNonRoot`, added capabilities, `seccompProfile`) | a root container with `CAP_SYS_ADMIN`, which reads every other pod's token off the kubelet — strictly *more* than the token started with |
| requests and limits present; `parallelism`/`completions` ≤ 1 | one permitted Job name as a repeatable way to fill the namespace quota and evict the database's own pods |
| volumes limited to the three the restore renders | arbitrary Secret mounts, `hostPath`, projected service-account tokens |
| no `envFrom`; `valueFrom` limited to the downward API and this release's own Secrets | a key from any other Secret or ConfigMap |

Every pin is derived from **the same values the `jobTemplate` is** — not a fixed hardened profile. Change `postgresql.containerSecurityContext` and the pin moves with it; a chart that denied its own restore Job would be worse than no policy.

## What it does *not* bound

The restore **parameters**. Anything holding the token can still create the one permitted Job with its own `TARGET`/`BACKUP_SET`/`FORCE` — this release's own restore, over the live PGDATA, without presenting a certificate to the control API. A restore over the live data directory *is* the operation being exposed, so admission has nothing left to reject.

So this turns "namespace-wide privilege escalation from a SQL injection" into "an unauthenticated trigger for this release's own restore". That is a large reduction and what makes the feature defensible — but where untrusted SQL runs and an unscheduled restore would itself be an incident, **leaving `control.restore` off remains the right answer**, and the README and CHANGELOG now say so rather than implying the grant is fully bounded.

## Everyone else is untouched

Humans, GitOps controllers, the CronJob controller and every other workload create Jobs exactly as before. That direction is asserted in the KinD suite next to the denials, because a policy that broke every other controller in the namespace would be worse than the hole it closes. The binding deliberately has **no `objectSelector`** — narrowing it by `pg-ha/restore` would make the label validation self-defeating, since an unlabelled Job would not match and would be admitted.

## Fail at render time

- **Kubernetes < 1.30** fails the *render* with the version it detected, via `.Capabilities.KubeVersion` (not `.Capabilities.APIVersions`, which degrades to core/v1-only under `helm template` and would silently drop the policy in every path that verifies it). Without this, an upgrade from 1.9.0 on an older cluster renders clean and aborts mid-apply with `no matches for kind ValidatingAdmissionPolicy`.
- **Values interpolated into CEL string literals** are charset-validated. A name with an apostrophe would otherwise render, lint and unit-test clean and only fail when the API server parses the policy; a crafted `x' || true || '` would produce a *tautological* validation — a policy that looks installed and enforces nothing.
- **The grant and its bound cannot separate silently**: `admissionPolicy.enabled: false` fails the render unless `acknowledgeUnbounded: true`. Both templates gate on one helper (`pg.controlRestoreEnabled`) so they cannot drift.
- The cluster-scoped names carry the namespace and release for readability plus **a hash of the pair for uniqueness** — a plain hyphen join is ambiguous when either segment contains hyphens (`db`/`pg-prod` vs `prod-db`/`pg`), and losing that race can leave a release's grant with no policy at all.

## Also fixed here

- The restore CronJob's `jobTemplate` had **no `metadata` at all**, so a cloned Job carried zero labels — the label validation would have denied every restore. It now carries just `pg-ha/restore`; deliberately not the full `app.kubernetes.io` set, since a Job the agent creates is not Helm-managed and claiming otherwise invites a GitOps controller to prune it mid-restore.
- The restore `command` is now defined once (`pg.restoreCommandJSON`) and consumed by both the `jobTemplate` and the policy that pins it. Byte-neutral in the rendered CronJob.

## Verification

CEL cannot be checked offline, so the policy was exercised against a real API server (kind, v1.36.1) — **47 allow/deny cases green, zero `status.typeChecking.expressionWarnings`**, run using the KinD suite's own extracted code rather than a parallel harness.

That found two things reasoning alone did not:

1. **`PrepareForCreate` runs *before* validating admission.** The API server has already stamped `batch.kubernetes.io/job-name`, `batch.kubernetes.io/controller-uid` and the two legacy forms onto the pod template (7 labels, not 3) and defaulted `parallelism`/`completions` to 1. A pod-label rule demanding "exactly the chart's labels", or a scale rule demanding those fields be *absent*, denies every legitimate restore. Hence a key allowlist and `<= 1`.
2. A `manualSelector` payload cannot actually be aimed at the postgresql pods — built-in Job validation requires `spec.selector` to match the pod template labels, which are pinned. The rule stays as defence in depth and its comment now says so instead of overstating it.

Local gates: `pg/templates` ≡ `pgvector/templates`, test-template 1079/1079, helm-unittest 316/316 (25 new), kubeconform valid (including a restore-enabled render at k8s 1.30 — the path the default-values gate never sees), kube-linter clean, vendored subcharts OK, `helm lint` both, and `byte-stable` shows **zero** non-version-label differences against `master`.

pg and pgvector both go to **1.10.0**; templates are symlinked so pgvector inherits the policy unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added default admission controls for restore Jobs, restricting identity, metadata, images, commands, security settings, resources, volumes, and environment sources.
  * Added configuration to enable or disable restore admission controls, with explicit acknowledgment required for unrestricted Job creation.
  * Added restore Job labeling for improved identification.
* **Bug Fixes**
  * Added render-time validation for unsafe configuration values and unsupported Kubernetes admission APIs.
* **Documentation**
  * Documented Kubernetes 1.30+ and cluster-permission requirements, policy behavior, limitations, and opt-out risks.
* **Chores**
  * Updated Helm chart versions to 1.10.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->