### PR TITLE
fix(ci): scope release notes to the chart being released (#281)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,9 +102,16 @@ jobs:
             echo "Release ${tag} already exists, uploading asset"
             gh release upload "$tag" "$pkg" --clobber
           else
+            # NOT --generate-notes: chart tags interleave (pg-1.5.0, redis-1.5.1, pg-1.9.0),
+            # and that flag diffs against the previous tag in the WHOLE REPO and cannot filter
+            # by path -- so pg-1.9.0 shipped notes listing six kafka PRs and comparing itself
+            # against redis-1.5.1. scripts/release-notes.sh takes the range from the previous
+            # tag of THIS chart and keeps only commits touching its own files.
+            bash scripts/release-notes.sh "$chart" "$tag" > "$workdir/notes.md"
+            cat "$workdir/notes.md"
             gh release create "$tag" "$pkg" \
               --title "$tag" \
-              --generate-notes
+              --notes-file "$workdir/notes.md"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Build a chart's release notes from the commits that actually touch that chart.
+#
+# Why this exists rather than `gh release create --generate-notes`: chart tags in this repo
+# interleave (pg-1.5.0, redis-1.5.1, pg-1.9.0, ...), and --generate-notes diffs against the
+# previous tag IN THE WHOLE REPO. That gets both halves wrong at once -- it picks the wrong
+# range, and even with the right range it cannot filter by path, so a pg release listed six
+# kafka PRs and compared itself against redis-1.5.1. Every release note published before this
+# script was in some way about the wrong chart.
+#
+# So the range comes from the previous tag OF THE SAME CHART, and the entries are filtered to
+# commits touching that chart's own files -- its directory plus what it vendors (common/, the
+# etcd subchart) and, for pg/pgvector, the repmgr image whose tag they pin.
+#
+# Usage: scripts/release-notes.sh <chart> <tag>
+#   e.g. scripts/release-notes.sh pg pg-1.10.0
+# Writes the notes to stdout. Needs full history (fetch-depth: 0 in CI). `gh` is used only to
+# resolve PR author logins; without it the notes are still correct, just unattributed.
+set -euo pipefail
+
+chart="${1:?usage: release-notes.sh <chart> <tag>}"
+tag="${2:?usage: release-notes.sh <chart> <tag>}"
+repo="${GITHUB_REPOSITORY:-cagriekin/charts}"
+
+# Paths whose changes belong in this chart's notes. Kept in step with Chart.yaml dependencies
+# and with images/repmgr, which pg/pgvector pin by tag rather than vendor.
+paths=("${chart}/" "common/")
+case "${chart}" in
+  pg|pgvector) paths+=("etcd/" "images/repmgr/") ;;
+esac
+
+# The previous tag for THIS chart, by commit date. Tags are matched as <chart>-<semver> so
+# that pg-* never matches pgvector-*.
+prev=$(git for-each-ref --sort=creatordate --format='%(refname:short)' refs/tags \
+  | grep -E "^${chart}-[0-9]+\.[0-9]+\.[0-9]+$" \
+  | awk -v t="${tag}" '$0 == t {exit} {print}' \
+  | tail -1)
+
+# The tag may not exist yet: the workflow_dispatch path derives it from Chart.yaml and lets
+# `gh release create` create it. Fall back to HEAD there. Without this the range would be
+# unresolvable and `git log` would exit non-zero into an EMPTY notes body -- a silent wrong
+# answer, which is the failure mode this whole script exists to remove.
+endpoint="${tag}"
+if ! git rev-parse -q --verify "${tag}^{commit}" >/dev/null; then
+  echo "note: tag ${tag} does not exist yet; describing changes up to HEAD" >&2
+  endpoint="HEAD"
+fi
+
+if [ -n "${prev}" ]; then
+  range="${prev}..${endpoint}"
+else
+  range="${endpoint}"   # first release of this chart: everything up to the endpoint
+fi
+
+# One line per commit that touched any of this chart's paths. --no-merges because the history
+# is squash-merged: the squash commit is the unit of change, and a merge commit would double
+# up anything that did arrive as a true merge.
+mapfile -t commits < <(git log --no-merges --format='%H' "${range}" -- "${paths[@]}")
+
+bullets=""
+for sha in "${commits[@]}"; do
+  [ -n "${sha}" ] || continue
+  subject=$(git log -1 --format='%s' "${sha}")
+  # Squash-merge subjects end in (#<pr>); that number is the PR, not the issue the title cites.
+  pr=$(sed -nE 's/.*\(#([0-9]+)\)[[:space:]]*$/\1/p' <<< "${subject}")
+  entry="* ${subject}"
+  if [ -n "${pr}" ]; then
+    login=""
+    if command -v gh >/dev/null 2>&1; then
+      login=$(gh pr view "${pr}" --repo "${repo}" --json author --jq .author.login 2>/dev/null || true)
+    fi
+    [ -n "${login}" ] && entry="${entry} by @${login}"
+    entry="${entry} in https://github.com/${repo}/pull/${pr}"
+  fi
+  bullets+="${entry}"$'\n'
+done
+
+# The hand-written CHANGELOG is the authority on what a version means, and it is already
+# chart-scoped. Link it rather than reproducing it, so the notes cannot drift from it.
+changelog_link=""
+if [ -f "${chart}/CHANGELOG.md" ]; then
+  changelog_link="See [${chart}/CHANGELOG.md](https://github.com/${repo}/blob/${tag}/${chart}/CHANGELOG.md) for the reasoning behind each change."
+fi
+
+echo "## What's Changed"
+echo
+if [ -n "${bullets}" ]; then
+  printf '%s' "${bullets}"
+else
+  # Possible and not an error: a release cut to publish a re-packaged artifact, or a chart
+  # version bumped by a change that lives entirely outside the paths above. Say so rather
+  # than emitting an empty section that reads like a failure.
+  echo "_No changes to \`${chart}\` since ${prev:-the start of the repository}; this release republishes the packaged chart._"
+fi
+if [ -n "${changelog_link}" ]; then
+  echo
+  echo "${changelog_link}"
+fi
+if [ -n "${prev}" ]; then
+  echo
+  echo "**Full Changelog**: https://github.com/${repo}/compare/${prev}...${tag}"
+fi

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -31,8 +31,14 @@ esac
 
 # The previous tag for THIS chart, by commit date. Tags are matched as <chart>-<semver> so
 # that pg-* never matches pgvector-*.
+#
+# The `|| [ $? -eq 1 ]` is load-bearing under `set -o pipefail`: a chart being released for
+# the FIRST time has no matching tag, grep exits 1, pipefail propagates that through the
+# pipeline, and errexit would kill the script here -- leaving the first-release branch below
+# as dead code and publishing an empty notes body. "No match" has to mean "no previous tag",
+# while grep's exit 2 (a real error) must still fail loudly.
 prev=$(git for-each-ref --sort=creatordate --format='%(refname:short)' refs/tags \
-  | grep -E "^${chart}-[0-9]+\.[0-9]+\.[0-9]+$" \
+  | { grep -E "^${chart}-[0-9]+\.[0-9]+\.[0-9]+$" || [ "$?" -eq 1 ]; } \
   | awk -v t="${tag}" '$0 == t {exit} {print}' \
   | tail -1)
 


### PR DESCRIPTION
Closes #281.

`release.yaml` published every release with `gh release create --generate-notes`, which diffs against the previous tag **in the whole repository**. Chart tags here interleave, so a `pg` release was compared against `redis-1.5.1` and — because that flag cannot filter by path — listed the six kafka PRs that happened to land in the span. Notes that describe the wrong chart.

## The fix

`scripts/release-notes.sh <chart> <tag>` builds the body itself:

- **Range** from the previous tag of the *same chart* (`^<chart>-<semver>$`, so `pg-*` never matches `pgvector-*`).
- **Entries** filtered to commits touching that chart's own paths — its directory, `common/` (the library chart every consumer vendors), and for pg/pgvector the vendored `etcd/` plus `images/repmgr/`, whose tag they pin in values.
- `--no-merges`, because the history is squash-merged and the squash commit is the unit of change.
- A link to the chart's hand-written `CHANGELOG.md`, which is the authority on what a version means and is already chart-scoped, rather than reproducing it (so the two cannot drift).
- A correct `Full Changelog` compare link.

`release.yaml` now passes `--notes-file` instead of `--generate-notes`, and echoes the notes into the job log so a bad body is visible in the run rather than only on the release page.

## Verification

Run against tags whose correct content is known independently:

| Command | Result |
|---|---|
| `release-notes.sh pg pg-1.9.0` | the 6 pg PRs, no kafka, base `pg-1.5.0` |
| `release-notes.sh redis redis-1.5.1` | redis #257 only, base `redis-1.5.0` |
| `release-notes.sh pg pg-1.4.3` | unchanged from the auto-notes, which were already correct here |

Edge cases covered: a chart with no previous tag (no compare link), a chart with no `CHANGELOG.md` (kafka, etcd — no link), a range with no chart-touching commits (says so explicitly instead of emitting an empty section), and a tag that **does not exist yet** — the `workflow_dispatch` path derives the tag from `Chart.yaml` and lets `gh release create` create it, so the script falls back to `HEAD` and warns on stderr. Without that fallback `git log <prev>..<missing tag>` fails into an empty body, which is the same class of silent-wrong-answer this change exists to remove.

## Not in scope

The 10 already-published releases from the last month have been corrected in place with `gh release edit`. Assets and the `gh-pages` index were never affected — this was notes-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release notes now include chart-specific changes based on relevant commits.
  * Notes include links to pull requests, contributors, and chart changelogs when available.
  * Releases with no matching changes are clearly identified.
  * Full changelog comparison links are included when a previous chart release exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->