### PR TITLE
fix(redis): standalone exporter honors exporter.podAnnotations (1.5.2)

### DIFF
--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.5.2 - 2026-08-03
+
+Bugfix: the standalone exporter Deployment can now carry pod annotations (additive; default
+`{}` renders no new manifest fields, so existing installs are unchanged).
+
+### Fixed
+- **`architecture: standalone` had no way to annotate the exporter pod.** The exporter runs
+  as its own Deployment there, and the template passed no `podAnnotations` to
+  `common.exporterDeployment` — `redis.podAnnotations` only reaches the StatefulSet. Agents
+  that discover targets from pod annotations (Grafana Alloy, Prometheus
+  `kubernetes_sd_configs` with a `prometheus.io/scrape` keep rule) therefore never scraped a
+  standalone install's exporter, and `exporter.serviceMonitor.enabled` is no help without a
+  Prometheus Operator. `redis_up` was absent entirely, which surfaces as "no data" rather
+  than as a down signal.
+
+### Added
+- `exporter.podAnnotations` (default `{}`) — annotations for the standalone exporter
+  Deployment's pod template. No-op in replication, where the exporter is a sidecar and
+  `redis.podAnnotations` already applies.
+- README "Annotation-based scrapers" section: when a ServiceMonitor is not enough, and the
+  annotation snippet for each architecture.
+
 ## 1.5.0 - 2026-07-01
 
 PVC lifecycle documentation and a retention knob (additive; `redis.persistence.retain`

--- a/redis/Chart.yaml
+++ b/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: Redis standalone or Sentinel-managed HA replication, with ACLs, TLS, AOF persistence, and a Prometheus metrics exporter
 type: application
-version: 1.5.1
+version: 1.5.2
 appVersion: "8.8.1"
 home: https://github.com/cagriekin/charts/tree/master/redis
 icon: https://www.vectorlogo.zone/logos/redis/redis-icon.svg

--- a/redis/README.md
+++ b/redis/README.md
@@ -222,6 +222,7 @@ window.
 | `redis.config.maxmemory` / `maxmemory-policy` | Memory cap / eviction | `200mb` / `allkeys-lru` |
 | `redis.config.appendfsync` | AOF sync (`always`/`everysec`/`no`) | `everysec` |
 | `exporter.enabled` | Prometheus exporter (sidecar in replication) | `true` |
+| `exporter.podAnnotations` | Annotations on the standalone exporter pod (e.g. `prometheus.io/scrape`); use `redis.podAnnotations` in replication | `{}` |
 | `exporter.serviceMonitor.enabled` / `exporter.prometheusRule.enabled` | ServiceMonitor / alerts | `true` / `false` |
 | `exporter.serviceMonitor.interval` / `scrapeTimeout` | Prometheus scrape interval / timeout | `30s` / `10s` |
 | `exporter.connectionTimeout` | Go-duration connect timeout to Redis (empty = exporter default 15s) | `""` |
@@ -243,6 +244,33 @@ role and replication metrics are scraped. Enabling `exporter.prometheusRule.enab
 HA alerts: `RedisDown`/`RedisNoMaster`, `RedisMultipleMasters` (split-brain),
 `RedisReplicaDown`, `RedisReplicationLinkDown`, and `RedisWritesBlocked` (the
 `min-replicas-to-write` tripwire). Standalone keeps the original single-instance alerts.
+
+### Annotation-based scrapers
+
+`exporter.serviceMonitor.enabled` only helps if a Prometheus Operator is watching (and its
+`serviceMonitorSelector` matches — pass `exporter.serviceMonitor.additionalLabels` such as
+`release: <prometheus-release>` when it does not). Agents that discover targets from pod
+annotations instead (Grafana Alloy, plain Prometheus `kubernetes_sd_configs` with a
+`prometheus.io/scrape` keep rule) need the annotations on the pod:
+
+```yaml
+# standalone: the exporter is its own Deployment
+exporter:
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9121"
+    prometheus.io/path: "/metrics"
+
+# replication: the exporter is a sidecar, so annotate the redis pods
+redis:
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9121"
+    prometheus.io/path: "/metrics"
+```
+
+Without them such an agent sees no `redis_up` at all, which reads as "no data" on dashboards
+rather than as a failure.
 
 ### Exporter tuning
 

--- a/redis/templates/exporter-deployment.yaml
+++ b/redis/templates/exporter-deployment.yaml
@@ -7,6 +7,7 @@
   "nameSuffix"      "exporter"
   "labels"          "redis.labels"
   "selectorLabels"  "redis.selectorLabels"
+  "podAnnotations"  .Values.exporter.podAnnotations
   "podSpec"         "redis.exporterPodSpec"
 ) }}
 {{- end }}

--- a/redis/tests/unit/exporter_test.yaml
+++ b/redis/tests/unit/exporter_test.yaml
@@ -172,3 +172,29 @@ tests:
               secretKeyRef:
                 name: my-extra-secret
                 key: token
+
+  - it: podAnnotations land on the exporter pod template
+    values:
+      - ../values-full-test.yaml
+    set:
+      exporter.podAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9121"
+        prometheus.io/path: /metrics
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "9121"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/path"]
+          value: /metrics
+
+  - it: no podAnnotations - exporter pod template has no annotations
+    values:
+      - ../values-full-test.yaml
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations

--- a/redis/values.schema.json
+++ b/redis/values.schema.json
@@ -159,6 +159,10 @@
           }
         },
         "connectionTimeout": { "type": "string" },
+        "podAnnotations": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
         "logFormat": {
           "enum": ["", "txt", "json"]
         },

--- a/redis/values.yaml
+++ b/redis/values.yaml
@@ -237,6 +237,14 @@ tls:
 exporter:
   enabled: true
 
+  # Annotations on the standalone exporter Deployment's pod template. Needed by
+  # annotation-based scrapers (Grafana Alloy / Prometheus pod-annotation discovery),
+  # which never see the exporter otherwise: e.g. prometheus.io/scrape: "true",
+  # prometheus.io/port: "9121", prometheus.io/path: "/metrics".
+  # No-op in replication -- there the exporter is a sidecar in the StatefulSet, so
+  # use redis.podAnnotations instead.
+  podAnnotations: {}
+
   podSecurityContext:
     runAsNonRoot: true
     seccompProfile:


### PR DESCRIPTION
## Problem

In `architecture: standalone` the redis_exporter runs as its own Deployment, and
`exporter-deployment.yaml` passed no `podAnnotations` to `common.exporterDeployment`.
`redis.podAnnotations` only reaches the StatefulSet, so there was **no way to annotate the
exporter pod** in standalone mode.

That breaks any metrics agent that discovers targets from pod annotations — Grafana Alloy, or
plain Prometheus `kubernetes_sd_configs` with a `prometheus.io/scrape` keep rule. Such an agent
never scrapes the exporter, so `redis_up` is absent entirely rather than `0`: dashboards read
"No data" and `absent()`-style alerts are the only thing that can catch it.
`exporter.serviceMonitor.enabled` is no substitute when there is no Prometheus Operator in the
cluster (or when its `serviceMonitorSelector` does not match the rendered ServiceMonitor).

Found on a real install: a standalone release scraped by Alloy had a healthy redis and a healthy
exporter, and a permanently blank "Redis UP" panel.

## Change

- `exporter.podAnnotations` (default `{}`) — rendered onto the standalone exporter Deployment's
  pod template. No-op in replication, where the exporter is a sidecar and `redis.podAnnotations`
  already applies.
- README: new "Annotation-based scrapers" section (when a ServiceMonitor is not enough, plus the
  annotation snippet for each architecture) and a values-table row.
- CHANGELOG + `version: 1.5.2`.

## Compatibility

Additive. With the default `{}` no annotations key is rendered, so existing installs are
unchanged — replication output is byte-identical to 1.5.1 apart from the `helm.sh/chart` label
(and the `checksum/config` that hashes it, as on any version bump).

## Verification

- `helm unittest -f 'tests/unit/*_test.yaml' redis` — 12 suites, 123 tests pass, including two new
  cases: annotations land on the pod template, and no `annotations` key when unset.
- `helm lint`, `scripts/check-vendored-subcharts.sh` clean.
- Rendered standalone with the three `prometheus.io/*` annotations and confirmed they appear under
  `spec.template.metadata.annotations`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable pod annotations for standalone Redis exporter deployments.
  * Annotations default to empty and do not affect replication mode.
  * Added guidance for annotation-based Prometheus scrapers.

* **Documentation**
  * Documented exporter annotation configuration and required scrape labels and paths.
  * Added a changelog entry for version 1.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->