### PR TITLE
fix(agent): backport scale-up primary/replication fixes to 1.x (1.10.1) (#297)

### DIFF
--- a/images/repmgr/agent/cmd/agent/main.go
+++ b/images/repmgr/agent/cmd/agent/main.go
@@ -1095,6 +1095,15 @@ func desiredRoleLabels(self string, peers []reconcile.PeerState) map[string]stri
 // node is absent from its own repmgr.nodes copy (#297); the remedy is the same, namely take
 // this node's data and metadata from the current primary.
 func (a *agent) rejoinOnto(ctx context.Context, target string) error {
+	// Invalidate the follow latch on ENTRY, not after the rejoin succeeds. Either point is
+	// defensible -- the latch caches which upstream replication is actually pointed at, so
+	// keeping it through a failed rejoin is arguably the more truthful state -- but clearing
+	// it up front makes the invariant unconditional: an attempt to rejoin always invalidates
+	// it. Nothing today depends on that (the escalation is only reachable when the latch
+	// already differs from the target, so a stale value can never wedge the Follow path, and
+	// its one consumer -- cascadeFollowTarget's stickiness -- re-checks cascadeQualifies).
+	// It removes a footgun for whoever later reads the latch earlier in the decision.
+	a.followUpstream = ""
 	// Invariant 9: never rewind/reclone onto a different cluster. Checked before the
 	// demote so a healthy node is not stopped for a doomed rejoin.
 	if err := a.assertSameCluster(ctx, target); err != nil {
@@ -1111,9 +1120,6 @@ func (a *agent) rejoinOnto(ctx context.Context, target string) error {
 		// whatever restore the record beside it describes.
 		a.dropRestoreRecord("the data directory was re-cloned from " + target)
 	}
-	// Replication was reconfigured from scratch, so the follow latch is meaningless now;
-	// let the next tick re-evaluate rather than assume we still track this upstream.
-	a.followUpstream = ""
 	return a.sup.Start(ctx)
 }
 

--- a/images/repmgr/agent/cmd/agent/main.go
+++ b/images/repmgr/agent/cmd/agent/main.go
@@ -11,6 +11,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -533,6 +534,30 @@ func (a *agent) observe(ctx context.Context) reconcile.Observation {
 	// This pod's name, compared against Marker.Primary so an empty-data lease holder
 	// can recognize it is not the recorded primary and release the lease (#186).
 	o.LocalNode = a.cfg.PodName
+	// #297: read repmgr.nodes ONLY for a promote candidate -- the holder, running and in
+	// recovery, i.e. the one tick-state where the gate can fire. Every other node skips
+	// the query, so this adds no steady-state cost, and RegistryRead stays false so the
+	// gate is inert. The read is against the LOCAL node: repmgr.nodes replicates from the
+	// primary, so this node's own copy is exactly what repmgr itself would consult when
+	// asked to follow someone.
+	if o.HoldLease && ls.Running && ls.InRecovery {
+		ids, rerr := a.prober.RegisteredNodeIDs(ctx, a.selfConn())
+		if rerr != nil {
+			// Unreadable: leave RegistryRead false so the gate cannot fire on a failed
+			// read (that would refuse a legitimate promotion). Warn, do not block.
+			a.log.Warn("read repmgr.nodes for the promote registration gate", "err", rerr)
+		} else {
+			o.RegistryRead = true
+			registered := make(map[int]bool, len(ids))
+			for _, id := range ids {
+				registered[id] = true
+			}
+			o.LocalRegistered = registered[nodeID(a.cfg.PodName)]
+			for i := range o.Peers {
+				o.Peers[i].Registered = registered[nodeID(o.Peers[i].Name)]
+			}
+		}
+	}
 	// Cascading replication (#29): when enabled, a standby may follow another standby
 	// (the pure cascadeFollowTarget decides; default off -> follow the primary).
 	o.Cascade = a.cfg.CascadeReplication
@@ -678,6 +703,22 @@ func (a *agent) act(ctx context.Context, dec reconcile.Decision, obs reconcile.O
 			return nil
 		}
 		if err := a.mech.Follow(ctx, up); err != nil {
+			// #297: this node has no row in its own metadata copy -- a freshly-cloned standby
+			// whose upstream changed before it registered. It can never obtain the row (that
+			// needs replication, which is what it is trying to establish), so it would retry
+			// forever, Running but never Ready, silently not replicating. Re-clone from the
+			// current primary: that replaces both its data AND its metadata copy, and a
+			// standby in this state has no writes of its own to lose.
+			//
+			// Scoped narrowly on purpose. It fires ONLY on the local-record error, never on a
+			// missing UPSTREAM record -- that one is the ordinary post-failover case where the
+			// target simply has not promoted yet, and escalating there demotes and re-clones a
+			// healthy standby (a mistake made and reverted on #286).
+			if errors.Is(err, mechanism.ErrLocalRecordMissing) {
+				a.log.Warn("this node is absent from its own repmgr.nodes copy; re-cloning from the current primary",
+					"target", dec.Target, "err", err)
+				return a.rejoinOnto(ctx, dec.Target)
+			}
 			return err
 		}
 		a.followUpstream = dec.Target
@@ -688,23 +729,7 @@ func (a *agent) act(ctx context.Context, dec reconcile.Decision, obs reconcile.O
 		return a.sup.Demote(ctx, true)
 
 	case reconcile.RejoinForward:
-		// Invariant 9: never rewind/reclone onto a different cluster. Checked before
-		// the demote so a healthy node is not stopped for a doomed rejoin.
-		if err := a.assertSameCluster(ctx, dec.Target); err != nil {
-			return err
-		}
-		if err := a.sup.Demote(ctx, true); err != nil {
-			return err
-		}
-		if err := a.mech.RejoinForceRewind(ctx, a.peerMechConn(dec.Target)); err != nil {
-			if err := a.mech.ReclonePreserving(ctx, a.peerMechConn(dec.Target)); err != nil {
-				return err
-			}
-			// A full re-clone: this directory's contents now come from the peer, not from
-			// whatever restore the record beside it describes.
-			a.dropRestoreRecord("the data directory was re-cloned from " + dec.Target)
-		}
-		return a.sup.Start(ctx)
+		return a.rejoinOnto(ctx, dec.Target)
 
 	case reconcile.BootstrapClone:
 		if err := a.mech.Clone(ctx, a.peerMechConn(dec.Target)); err != nil {
@@ -1062,6 +1087,34 @@ func desiredRoleLabels(self string, peers []reconcile.PeerState) map[string]stri
 		}
 	}
 	return m
+}
+
+// rejoinOnto brings this node back under target: rewind forward onto it, or -- when the
+// histories diverged too far for pg_rewind -- re-clone while preserving the old data
+// directory (#175). Shared by the RejoinForward decision and by the Follow path when this
+// node is absent from its own repmgr.nodes copy (#297); the remedy is the same, namely take
+// this node's data and metadata from the current primary.
+func (a *agent) rejoinOnto(ctx context.Context, target string) error {
+	// Invariant 9: never rewind/reclone onto a different cluster. Checked before the
+	// demote so a healthy node is not stopped for a doomed rejoin.
+	if err := a.assertSameCluster(ctx, target); err != nil {
+		return err
+	}
+	if err := a.sup.Demote(ctx, true); err != nil {
+		return err
+	}
+	if err := a.mech.RejoinForceRewind(ctx, a.peerMechConn(target)); err != nil {
+		if err := a.mech.ReclonePreserving(ctx, a.peerMechConn(target)); err != nil {
+			return err
+		}
+		// A full re-clone: this directory's contents now come from the peer, not from
+		// whatever restore the record beside it describes.
+		a.dropRestoreRecord("the data directory was re-cloned from " + target)
+	}
+	// Replication was reconfigured from scratch, so the follow latch is meaningless now;
+	// let the next tick re-evaluate rather than assume we still track this upstream.
+	a.followUpstream = ""
+	return a.sup.Start(ctx)
 }
 
 func (a *agent) selfConn() pg.ConnInfo {

--- a/images/repmgr/agent/cmd/agent/main_test.go
+++ b/images/repmgr/agent/cmd/agent/main_test.go
@@ -176,6 +176,13 @@ func (s *scriptedExec) Run(_ context.Context, _ []string, name string, args ...s
 // Follow act() path (register -> streaming probe -> follow) is exercised end to end.
 func newFollowTestAgent(t *testing.T, ex *scriptedExec) *agent {
 	t.Helper()
+	return newFollowTestAgentWithPM(t, ex, &fakePostmaster{})
+}
+
+// newFollowTestAgentWithPM is newFollowTestAgent with an injectable postmaster, so a test can
+// make Demote fail and exercise an EARLY return from rejoinOnto.
+func newFollowTestAgentWithPM(t *testing.T, ex *scriptedExec, pm *fakePostmaster) *agent {
+	t.Helper()
 	m := mechanism.NewRepmgr("/etc/repmgr/repmgr.conf", t.TempDir(), "pw")
 	m.Runner = ex
 	return &agent{
@@ -191,7 +198,7 @@ func newFollowTestAgent(t *testing.T, ex *scriptedExec) *agent {
 		dcs:    &fakeDCS{},
 		mech:   m,
 		prober: &pg.Prober{Exec: ex, Timeout: time.Second},
-		sup:    process.NewSupervisor(&fakePostmaster{}),
+		sup:    process.NewSupervisor(pm),
 		metr:   observe.New(),
 	}
 }
@@ -247,6 +254,29 @@ func TestActFollowReclonesWhenLocalRecordMissing(t *testing.T) {
 	}
 	if a.followUpstream != "" {
 		t.Fatalf("the follow latch must reset after a re-clone, got %q", a.followUpstream)
+	}
+}
+
+// The follow latch is invalidated on ENTRY to rejoinOnto, so it is cleared even when the
+// rejoin fails before reconfiguring anything (here: Demote fails). Clearing it late would
+// leave a stale latch behind a failed rejoin. Nothing depends on that today -- the
+// escalation is only reachable when the latch already differs from the target -- but the
+// invariant "an attempt to rejoin invalidates the latch" is unconditional, and this pins it
+// so a future edit that reads the latch earlier cannot silently rely on a stale value.
+func TestRejoinOntoClearsFollowLatchEvenWhenItFailsEarly(t *testing.T) {
+	ex := &scriptedExec{walRcv: "", followOut: "ERROR: unable to retrieve record for local node 1002"}
+	pm := &fakePostmaster{stopErr: errors.New("stop failed")}
+	a := newFollowTestAgentWithPM(t, ex, pm)
+	a.followUpstream = "stale-upstream"
+	dec := reconcile.Decision{Action: reconcile.Follow, Target: "pg-1"}
+	if err := a.act(context.Background(), dec, reconcile.Observation{}); err == nil {
+		t.Fatal("a rejoin whose demote fails must surface an error")
+	}
+	if ex.rejoins != 0 {
+		t.Fatalf("rejoin must not have reconfigured anything after a failed demote, got %d", ex.rejoins)
+	}
+	if a.followUpstream != "" {
+		t.Fatalf("the follow latch must be cleared on entry to a rejoin, got %q", a.followUpstream)
 	}
 }
 

--- a/images/repmgr/agent/cmd/agent/main_test.go
+++ b/images/repmgr/agent/cmd/agent/main_test.go
@@ -134,6 +134,8 @@ type scriptedExec struct {
 	regErr       error  // error returned for `repmgr standby register` (nil = success)
 	follows      int    // number of `repmgr standby follow` calls
 	unregistered []int  // node_ids passed to `repmgr standby unregister`
+	followOut    string // combined output for `repmgr standby follow`; non-empty = it fails
+	rejoins      int    // number of `repmgr node rejoin` calls (the #297 re-clone escalation)
 }
 
 func (s *scriptedExec) Run(_ context.Context, _ []string, name string, args ...string) (string, error) {
@@ -150,6 +152,12 @@ func (s *scriptedExec) Run(_ context.Context, _ []string, name string, args ...s
 		return "ok", nil
 	case name == "repmgr" && strings.Contains(joined, "standby follow"):
 		s.follows++
+		if s.followOut != "" {
+			return s.followOut, errors.New("exit status 1")
+		}
+		return "ok", nil
+	case name == "repmgr" && strings.Contains(joined, "node rejoin"):
+		s.rejoins++
 		return "ok", nil
 	case name == "repmgr" && strings.Contains(joined, "standby unregister"):
 		for _, a := range args {
@@ -220,6 +228,40 @@ func TestActFollowRunsWhenNotStreaming(t *testing.T) {
 	}
 	if a.followUpstream != "pg-0" {
 		t.Fatal("followUpstream must latch after a successful follow")
+	}
+}
+
+// #297: a standby absent from its OWN repmgr.nodes copy can never obtain the row, so
+// following is permanently impossible -- it would sit Running-but-never-Ready, silently not
+// replicating. Re-clone from the current primary, which replaces data and metadata together.
+func TestActFollowReclonesWhenLocalRecordMissing(t *testing.T) {
+	ex := &scriptedExec{walRcv: "", followOut: "ERROR: unable to retrieve record for local node 1002"}
+	a := newFollowTestAgent(t, ex)
+	a.followUpstream = "stale"
+	dec := reconcile.Decision{Action: reconcile.Follow, Target: "pg-1"}
+	if err := a.act(context.Background(), dec, reconcile.Observation{}); err != nil {
+		t.Fatalf("act must recover by re-cloning, got %v", err)
+	}
+	if ex.rejoins != 1 {
+		t.Fatalf("a missing local record must escalate to a rejoin/re-clone, got %d calls", ex.rejoins)
+	}
+	if a.followUpstream != "" {
+		t.Fatalf("the follow latch must reset after a re-clone, got %q", a.followUpstream)
+	}
+}
+
+// ...but a missing UPSTREAM record must NOT re-clone. That is the ordinary post-failover
+// case (the target has not promoted yet) and waiting is correct; re-cloning there demotes a
+// healthy standby and destroys its data directory -- the #286 regression this guards.
+func TestActFollowDoesNotRecloneWhenUpstreamRecordMissing(t *testing.T) {
+	ex := &scriptedExec{walRcv: "", followOut: "ERROR: unable to find record for intended upstream node 1002"}
+	a := newFollowTestAgent(t, ex)
+	dec := reconcile.Decision{Action: reconcile.Follow, Target: "pg-1"}
+	if err := a.act(context.Background(), dec, reconcile.Observation{}); err == nil {
+		t.Fatal("a missing upstream record must surface so the next tick retries")
+	}
+	if ex.rejoins != 0 {
+		t.Fatalf("a missing upstream record must NOT re-clone the node, got %d rejoins", ex.rejoins)
 	}
 }
 

--- a/images/repmgr/agent/internal/mechanism/mechanism.go
+++ b/images/repmgr/agent/internal/mechanism/mechanism.go
@@ -43,6 +43,24 @@ type ConfigOpts struct {
 	UseReplicationSlots bool
 }
 
+// ErrLocalRecordMissing is returned by Follow when the mechanism cannot act because
+// THIS node has no record of itself in the metadata it reads.
+//
+// With repmgr that is "unable to retrieve record for local node N", and it identifies a
+// freshly-cloned standby precisely: its repmgr.nodes copy is a snapshot of the primary
+// taken BEFORE it registered, so it contains no row for itself. It cannot obtain the row
+// either -- receiving it requires replicating, and repointing replication is what needs
+// the row. A normal clone never hits this because clone -R writes primary_conninfo and it
+// streams without a follow; only a clone whose upstream changed underneath it must
+// repoint, and then it is stuck permanently (#297).
+//
+// This is deliberately distinct from a MISSING UPSTREAM record ("unable to find record for
+// intended upstream node"), which is the ordinary post-failover case where the target has
+// simply not promoted and registered YET, and where waiting is correct. Conflating the two
+// is not a theoretical concern: escalating on the upstream variant demotes a healthy node
+// and re-clones it over a transient condition.
+var ErrLocalRecordMissing = errors.New("mechanism: local node has no record in its own metadata copy")
+
 // Mechanism performs the Postgres replication mechanics. Each method is its own
 // scoped operation with its own wrapped error (no monolithic catch). The caller
 // (reconcile) has already decided, via the Lease and the timeline/LSN rules, that

--- a/images/repmgr/agent/internal/mechanism/repmgr.go
+++ b/images/repmgr/agent/internal/mechanism/repmgr.go
@@ -94,6 +94,12 @@ func (r *Repmgr) Follow(ctx context.Context, upstreamNodeID int) error {
 		if isAlreadyFollowing(out) {
 			return nil
 		}
+		// THIS node is absent from its own metadata copy: a freshly-cloned standby whose
+		// upstream changed before it registered. It can never obtain the row on its own, so
+		// report it distinctly and let the caller re-clone from the current primary (#297).
+		if isLocalRecordMissing(out) {
+			return fmt.Errorf("%w: repmgr standby follow: %v: %s", ErrLocalRecordMissing, err, strings.TrimSpace(out))
+		}
 		return fmt.Errorf("repmgr standby follow: %w: %s", err, strings.TrimSpace(out))
 	}
 	return nil
@@ -108,6 +114,17 @@ func isAlreadyFollowing(out string) bool {
 	s := strings.ToLower(out)
 	return strings.Contains(s, "already exists as an active slot") &&
 		(strings.Contains(s, "this server is not ahead") || strings.Contains(s, "timelines are same"))
+}
+
+// isLocalRecordMissing recognizes the repmgr output emitted when the LOCAL node has no
+// repmgr.nodes row in the copy it can read. Matched on "local node" specifically: the
+// superficially-similar "unable to find record for intended upstream node" means the
+// TARGET is unregistered, which is the transient post-failover case and must NOT be
+// escalated (doing so demotes and re-clones a healthy standby).
+func isLocalRecordMissing(out string) bool {
+	s := strings.ToLower(out)
+	return strings.Contains(s, "unable to retrieve record for local node") ||
+		strings.Contains(s, "no record found for local node")
 }
 
 func (r *Repmgr) Clone(ctx context.Context, source Conn) error {

--- a/images/repmgr/agent/internal/mechanism/repmgr_test.go
+++ b/images/repmgr/agent/internal/mechanism/repmgr_test.go
@@ -82,6 +82,33 @@ func TestCLICommands(t *testing.T) {
 		}
 	})
 
+	t.Run("#297 follow reports a missing LOCAL record distinctly", func(t *testing.T) {
+		// A freshly-cloned standby whose upstream changed before it registered: its own
+		// repmgr.nodes copy has no row for itself, and it can never obtain one. Must be
+		// distinguishable so the agent re-clones instead of retrying forever.
+		fr := &fakeRunner{failOn: "standby follow",
+			failOut: "ERROR: unable to retrieve record for local node 1002"}
+		err := newTestRepmgr(fr).Follow(ctx, 1001)
+		if !errors.Is(err, ErrLocalRecordMissing) {
+			t.Errorf("want ErrLocalRecordMissing so the caller re-clones, got %v", err)
+		}
+	})
+
+	t.Run("#297 a missing UPSTREAM record is NOT the local-record error", func(t *testing.T) {
+		// The ordinary post-failover case: the TARGET has not promoted and registered yet.
+		// Waiting is correct here; escalating demotes and re-clones a healthy standby, which
+		// is the mistake #286 made and reverted. The two must never be conflated.
+		fr := &fakeRunner{failOn: "standby follow",
+			failOut: "ERROR: unable to find record for intended upstream node 1002"}
+		err := newTestRepmgr(fr).Follow(ctx, 1002)
+		if err == nil {
+			t.Fatal("a missing upstream record must still surface as an error")
+		}
+		if errors.Is(err, ErrLocalRecordMissing) {
+			t.Errorf("an upstream-record failure must NOT be classed as a local-record failure: %v", err)
+		}
+	})
+
 	t.Run("follow surfaces a genuine failure", func(t *testing.T) {
 		// A real failure (slot active but NOT the benign already-following case) must
 		// still surface so it is not silently swallowed.

--- a/images/repmgr/agent/internal/pg/probe.go
+++ b/images/repmgr/agent/internal/pg/probe.go
@@ -234,6 +234,36 @@ func (p *Prober) SystemIdentifier(ctx context.Context, ci ConnInfo) (id uint64, 
 	return n, true, nil
 }
 
+// RegisteredNodeIDs returns every node_id present in repmgr.nodes, read from whichever
+// copy ci points at. Unlike StandbyNodeIDs this includes the primary row and is meant to
+// be run against the LOCAL node: repmgr.nodes replicates from the primary, so a standby's
+// own copy tells it which nodes the cluster has a record for.
+//
+// That is the signal behind the #297 promote gate. A node whose own row is absent has
+// never registered, so no survivor can `repmgr standby follow` it -- promoting it would
+// leave the cluster with no serving primary. A malformed row is an error rather than a
+// silent skip, so a broken table cannot read as "nobody is registered" and quietly
+// disable the gate.
+func (p *Prober) RegisteredNodeIDs(ctx context.Context, ci ConnInfo) ([]int, error) {
+	out, err := p.psql(ctx, ci, "SELECT node_id FROM repmgr.nodes;")
+	if err != nil {
+		return nil, err
+	}
+	var ids []int
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		n, perr := strconv.Atoi(line)
+		if perr != nil {
+			return nil, fmt.Errorf("parse repmgr.nodes node_id %q: %w", line, perr)
+		}
+		ids = append(ids, n)
+	}
+	return ids, nil
+}
+
 // StandbyNodeIDs returns the node_ids of the STANDBY rows in repmgr.nodes, queried on
 // the repmgr database (ci must point at it). The primary uses this to find ghost records
 // left by a replicaCount scale-down (#139). It excludes the primary row deliberately: a

--- a/images/repmgr/agent/internal/reconcile/reconcile.go
+++ b/images/repmgr/agent/internal/reconcile/reconcile.go
@@ -421,24 +421,49 @@ func unsafeToServe(o Observation) (bool, string) {
 	return false, ""
 }
 
-// registeredPeerToServe returns a reachable peer that IS registered in repmgr.nodes when
-// THIS node is not, or "" when the gate must not fire. Guarding promotion on this is the
-// #297 fix: an unregistered primary is one no survivor can follow.
+// registeredPeerToServe returns a peer that is a SAFE substitute for promoting this node
+// when this node has no repmgr.nodes record, or "" when the gate must not fire. Guarding
+// promotion on this is the #297 fix: an unregistered primary is one no survivor can follow.
 //
-// Returns "" -- i.e. allows the promotion -- whenever the answer is not certain:
-// the registry was not read this tick, this node is registered, or no reachable peer has
-// a record. Availability wins over metadata tidiness; the only case worth blocking is the
-// one where a strictly better candidate demonstrably exists.
+// A candidate must be reachable, registered, AND positionally safe -- same valid timeline
+// and an LSN at least as high as this node's. The position requirement is not a nicety:
+// this gate runs only after the invariant-8 check has established that no reachable peer is
+// AHEAD, so any candidate here is equal or behind. Handing the Lease to a node that is
+// behind is doubly wrong. It flaps -- the peer acquires, its own moreAdvancedPeer check sees
+// this node ahead and reachable, and it releases straight back, forever -- and it parks
+// leadership on a node with less WAL, so if this node then dies the peer promotes and those
+// transactions are gone. Equal position is fine and is the case this gate exists for.
+//
+// Returns "" -- allowing the promotion -- whenever the answer is not certain: the registry
+// was not read this tick, this node is registered, or no reachable peer is both registered
+// and current. Availability wins over metadata tidiness, and promoting the most-advanced
+// node is never a durability regression; the only case worth blocking is the one where a
+// demonstrably safe alternative exists.
 func registeredPeerToServe(o Observation) string {
 	if !o.RegistryRead || o.LocalRegistered {
 		return ""
 	}
 	for i := range o.Peers {
-		if o.Peers[i].Reachable && o.Peers[i].Registered {
-			return o.Peers[i].Name
+		p := &o.Peers[i]
+		if p.Reachable && p.Registered && peerNotBehind(*p, o.Local) {
+			return p.Name
 		}
 	}
 	return ""
+}
+
+// peerNotBehind reports whether p is at least as current as the local node: same timeline
+// and an LSN no lower. Both positions must be KNOWN -- an unreadable timeline or LSN on
+// either side means the comparison cannot be made, and an unprovable candidate is not a
+// safe hand-off target (the caller then promotes the local node instead).
+func peerNotBehind(p PeerState, l LocalState) bool {
+	if !p.TimelineOK || !l.TimelineOK || p.Timeline != l.Timeline {
+		return false
+	}
+	if !p.LSNOK || !l.LSNOK {
+		return false
+	}
+	return !l.LSN.Greater(p.LSN)
 }
 
 // newestPrimaryAbove returns the reachable live primary on the highest timeline

--- a/images/repmgr/agent/internal/reconcile/reconcile.go
+++ b/images/repmgr/agent/internal/reconcile/reconcile.go
@@ -77,6 +77,10 @@ type PeerState struct {
 	TimelineOK bool
 	LSN        pg.LSN
 	LSNOK      bool
+	// Registered reports that this peer has a row in repmgr.nodes, as seen from the local
+	// node's copy of that table. A registered, reachable peer is a safe hand-off target
+	// for an unregistered lease holder that must not promote (#297).
+	Registered bool
 }
 
 // MarkerState is the durable highwater marker (<fullname>-primary).
@@ -124,6 +128,18 @@ type Observation struct {
 	// replaying WAL toward consistency is alive but not yet SQL-ready. The agent
 	// must not act on a starting node's stale on-disk role (#181).
 	LocalProcessAlive bool
+	// RegistryRead reports that repmgr.nodes was read successfully this tick, and
+	// LocalRegistered that this node's own row was present in it. Populated only for a
+	// promote candidate (holder, running, in recovery), so a non-candidate leaves
+	// RegistryRead false and the #297 gate inert.
+	//
+	// A node with no row of its own has never registered, so no survivor holds a record
+	// for it and none can follow it after it promotes -- the scale-up race that leaves a
+	// cluster with no serving primary. RegistryRead is required before acting on
+	// LocalRegistered: an unreadable table must not be mistaken for "not registered",
+	// which would refuse a legitimate promotion.
+	RegistryRead    bool
+	LocalRegistered bool
 	// Cascade enables cascading replication (#29): a standby may follow another
 	// standby instead of the primary, to offload the primary's WAL senders. Default
 	// false -> every standby follows the lease holder (byte-stable). Even when true,
@@ -207,6 +223,21 @@ func Decide(o Observation) Decision {
 			}
 			if o.PeersPending {
 				return d(Wait, "", "cold boot: waiting for peers to report their position before promoting (recovery-mode makes stopped primary-state peers observable)")
+			}
+			// #297: never promote a node that has no repmgr.nodes row while a registered,
+			// reachable peer could serve instead. A scale-up can hand the Lease to a pod
+			// that cloned and started but has not yet registered; if it promotes, the
+			// survivors hold no record for it, `repmgr standby follow` can never resolve
+			// it, and the cluster is left with no serving primary until an operator
+			// intervenes. Handing the Lease to a registered peer is always recoverable --
+			// this node registers as its standby on a later tick and can promote then.
+			//
+			// Deliberately conservative: it fires ONLY when the registry was actually
+			// read AND a registered reachable peer exists. An unreadable table, or a
+			// cluster where nobody is registered, falls through and promotes -- serving
+			// with degraded metadata beats refusing to serve at all.
+			if t := registeredPeerToServe(o); t != "" {
+				return d(ReleaseLease, t, "refuse to promote: this node has no repmgr.nodes record, so no peer could follow it; release so registered peer "+t+" serves instead (#297)")
 			}
 			return d(Promote, "", "standby holds lease, caught up and most-advanced: promote")
 
@@ -388,6 +419,26 @@ func unsafeToServe(o Observation) (bool, string) {
 		}
 	}
 	return false, ""
+}
+
+// registeredPeerToServe returns a reachable peer that IS registered in repmgr.nodes when
+// THIS node is not, or "" when the gate must not fire. Guarding promotion on this is the
+// #297 fix: an unregistered primary is one no survivor can follow.
+//
+// Returns "" -- i.e. allows the promotion -- whenever the answer is not certain:
+// the registry was not read this tick, this node is registered, or no reachable peer has
+// a record. Availability wins over metadata tidiness; the only case worth blocking is the
+// one where a strictly better candidate demonstrably exists.
+func registeredPeerToServe(o Observation) string {
+	if !o.RegistryRead || o.LocalRegistered {
+		return ""
+	}
+	for i := range o.Peers {
+		if o.Peers[i].Reachable && o.Peers[i].Registered {
+			return o.Peers[i].Name
+		}
+	}
+	return ""
 }
 
 // newestPrimaryAbove returns the reachable live primary on the highest timeline

--- a/images/repmgr/agent/internal/reconcile/reconcile_test.go
+++ b/images/repmgr/agent/internal/reconcile/reconcile_test.go
@@ -18,6 +18,14 @@ func standby(name string, t uint32, hi, lo uint64) PeerState {
 
 // gossipPeer is an unreachable peer whose position is known only from gossip (its
 // role is unknown -- gossip carries position, not a trusted role).
+// registeredStandby is a reachable standby that HAS a repmgr.nodes row -- a safe
+// hand-off target for the #297 promote gate.
+func registeredStandby(name string, t uint32, hi, lo uint64) PeerState {
+	p := standby(name, t, hi, lo)
+	p.Registered = true
+	return p
+}
+
 func gossipPeer(name string, t uint32, hi, lo uint64) PeerState {
 	return PeerState{Name: name, Reachable: false, Gossip: true, Role: pg.RoleUnknown, Timeline: tl(t), TimelineOK: true, LSN: ls(hi, lo), LSNOK: true}
 }
@@ -56,6 +64,34 @@ func TestDecide(t *testing.T) {
 		{"holder + empty + a live primary -> clone not initdb", Observation{HoldLease: true, Local: emptyData, Peers: []PeerState{primary("pg-1", 5, 5, 0x100)}}, BootstrapClone, "pg-1"},
 
 		{"holder standby caught up most-advanced -> promote", Observation{HoldLease: true, Local: localStandby, Peers: []PeerState{standby("pg-1", 5, 5, 0x80)}}, Promote, ""},
+
+		// #297: a scale-up can hand the Lease to a pod that cloned and started but has
+		// never registered in repmgr.nodes. If it promotes, no survivor holds a record for
+		// it, none can `repmgr standby follow` it, and the cluster ends up with no serving
+		// primary. Release to a registered peer instead -- always recoverable, because this
+		// node registers as its standby on a later tick.
+		{"#297 holder standby NOT registered + registered reachable peer -> release to it",
+			Observation{HoldLease: true, Local: localStandby, RegistryRead: true, LocalRegistered: false,
+				Peers: []PeerState{registeredStandby("pg-1", 5, 5, 0x80)}}, ReleaseLease, "pg-1"},
+		// Registered: the normal case, promote as before.
+		{"#297 holder standby registered -> promote",
+			Observation{HoldLease: true, Local: localStandby, RegistryRead: true, LocalRegistered: true,
+				Peers: []PeerState{registeredStandby("pg-1", 5, 5, 0x80)}}, Promote, ""},
+		// Registry unreadable: must NOT be mistaken for "not registered" -- that would
+		// refuse a legitimate promotion (e.g. the repmgr db briefly unavailable).
+		{"#297 registry unreadable -> promote (never block on an unknown)",
+			Observation{HoldLease: true, Local: localStandby, RegistryRead: false, LocalRegistered: false,
+				Peers: []PeerState{registeredStandby("pg-1", 5, 5, 0x80)}}, Promote, ""},
+		// Nobody else is registered: releasing would hand off to a peer that is no better
+		// off, so serve with degraded metadata rather than refuse to serve at all.
+		{"#297 nobody registered -> promote (availability over metadata)",
+			Observation{HoldLease: true, Local: localStandby, RegistryRead: true, LocalRegistered: false,
+				Peers: []PeerState{standby("pg-1", 5, 5, 0x80)}}, Promote, ""},
+		// The registered peer is unreachable: it cannot take the Lease, so handing off would
+		// only stall. Promote.
+		{"#297 registered peer unreachable -> promote",
+			Observation{HoldLease: true, Local: localStandby, RegistryRead: true, LocalRegistered: false,
+				Peers: []PeerState{func() PeerState { p := registeredStandby("pg-1", 5, 5, 0x80); p.Reachable = false; return p }()}}, Promote, ""},
 		{"holder standby + newer primary peer -> rejoin forward", Observation{HoldLease: true, Local: localStandby, Peers: []PeerState{primary("pg-1", 6, 6, 0x10)}}, RejoinForward, "pg-1"},
 		{"holder standby below highwater -> release", Observation{HoldLease: true, Local: localStandby, Marker: MarkerState{Present: true, Timeline: tl(6)}}, ReleaseLease, ""},
 		{"holder standby but a peer has more WAL -> release/handoff", Observation{HoldLease: true, Local: localStandby, Peers: []PeerState{standby("pg-2", 5, 5, 0x200)}}, ReleaseLease, "pg-2"},

--- a/images/repmgr/agent/internal/reconcile/reconcile_test.go
+++ b/images/repmgr/agent/internal/reconcile/reconcile_test.go
@@ -70,18 +70,41 @@ func TestDecide(t *testing.T) {
 		// it, none can `repmgr standby follow` it, and the cluster ends up with no serving
 		// primary. Release to a registered peer instead -- always recoverable, because this
 		// node registers as its standby on a later tick.
-		{"#297 holder standby NOT registered + registered reachable peer -> release to it",
+		//
+		// The target must be positionally SAFE, not merely registered. This gate runs after
+		// the invariant-8 check, so no reachable peer is ahead; a candidate is equal or
+		// behind. Equal is the case to hand off to:
+		{"#297 holder standby NOT registered + caught-up registered peer -> release to it",
 			Observation{HoldLease: true, Local: localStandby, RegistryRead: true, LocalRegistered: false,
-				Peers: []PeerState{registeredStandby("pg-1", 5, 5, 0x80)}}, ReleaseLease, "pg-1"},
+				Peers: []PeerState{registeredStandby("pg-1", 5, 5, 0x100)}}, ReleaseLease, "pg-1"},
+		// ...but a registered peer that is BEHIND must NOT be handed the Lease. It would
+		// acquire, its own moreAdvancedPeer check would see this node ahead and reachable,
+		// and it would release straight back -- an endless flap -- and meanwhile leadership
+		// would sit on a node with less WAL, losing those transactions if this node died.
+		// Promote instead: the most-advanced node serving with stale metadata is strictly
+		// better, and the follow path repairs the metadata.
+		{"#297 registered peer is BEHIND -> promote, never hand off backwards",
+			Observation{HoldLease: true, Local: localStandby, RegistryRead: true, LocalRegistered: false,
+				Peers: []PeerState{registeredStandby("pg-1", 5, 5, 0x80)}}, Promote, ""},
+		// A registered peer on a DIFFERENT timeline is not comparable and so not provably
+		// safe; promote rather than hand off on an unprovable position. (A peer on a NEWER
+		// timeline is caught earlier by the rejoin-forward check.)
+		{"#297 registered peer on an older timeline -> promote",
+			Observation{HoldLease: true, Local: localStandby, RegistryRead: true, LocalRegistered: false,
+				Peers: []PeerState{registeredStandby("pg-1", 4, 4, 0x400)}}, Promote, ""},
+		// Position unknown (LSN unreadable) -> not provably safe -> promote.
+		{"#297 registered peer with an unreadable LSN -> promote",
+			Observation{HoldLease: true, Local: localStandby, RegistryRead: true, LocalRegistered: false,
+				Peers: []PeerState{func() PeerState { p := registeredStandby("pg-1", 5, 5, 0x100); p.LSNOK = false; return p }()}}, Promote, ""},
 		// Registered: the normal case, promote as before.
 		{"#297 holder standby registered -> promote",
 			Observation{HoldLease: true, Local: localStandby, RegistryRead: true, LocalRegistered: true,
-				Peers: []PeerState{registeredStandby("pg-1", 5, 5, 0x80)}}, Promote, ""},
+				Peers: []PeerState{registeredStandby("pg-1", 5, 5, 0x100)}}, Promote, ""},
 		// Registry unreadable: must NOT be mistaken for "not registered" -- that would
 		// refuse a legitimate promotion (e.g. the repmgr db briefly unavailable).
 		{"#297 registry unreadable -> promote (never block on an unknown)",
 			Observation{HoldLease: true, Local: localStandby, RegistryRead: false, LocalRegistered: false,
-				Peers: []PeerState{registeredStandby("pg-1", 5, 5, 0x80)}}, Promote, ""},
+				Peers: []PeerState{registeredStandby("pg-1", 5, 5, 0x100)}}, Promote, ""},
 		// Nobody else is registered: releasing would hand off to a peer that is no better
 		// off, so serve with degraded metadata rather than refuse to serve at all.
 		{"#297 nobody registered -> promote (availability over metadata)",
@@ -91,7 +114,7 @@ func TestDecide(t *testing.T) {
 		// only stall. Promote.
 		{"#297 registered peer unreachable -> promote",
 			Observation{HoldLease: true, Local: localStandby, RegistryRead: true, LocalRegistered: false,
-				Peers: []PeerState{func() PeerState { p := registeredStandby("pg-1", 5, 5, 0x80); p.Reachable = false; return p }()}}, Promote, ""},
+				Peers: []PeerState{func() PeerState { p := registeredStandby("pg-1", 5, 5, 0x100); p.Reachable = false; return p }()}}, Promote, ""},
 		{"holder standby + newer primary peer -> rejoin forward", Observation{HoldLease: true, Local: localStandby, Peers: []PeerState{primary("pg-1", 6, 6, 0x10)}}, RejoinForward, "pg-1"},
 		{"holder standby below highwater -> release", Observation{HoldLease: true, Local: localStandby, Marker: MarkerState{Present: true, Timeline: tl(6)}}, ReleaseLease, ""},
 		{"holder standby but a peer has more WAL -> release/handoff", Observation{HoldLease: true, Local: localStandby, Peers: []PeerState{standby("pg-2", 5, 5, 0x200)}}, ReleaseLease, "pg-2"},

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,46 @@
 # pg chart changelog
 
+## 1.10.1 - 2026-08-11
+
+### Fixed
+
+- **Backport (#297): a scale-up could leave the cluster without a serving primary, or with a
+  standby that never replicates.** Both affect agent mode -- the default since `1.0.0` -- from
+  that release onward. Fixed on the 2.0.0 line first; backported here because they are
+  data-availability bugs in a shipped release.
+
+  Adding a replica (`postgresql.replicaCount` N -> N+1) also changes `REPMGR_NODE_COUNT`, which
+  rolls every pod, so the new pod is created while the others restart. Two things could go wrong:
+
+  1. **No serving primary.** The new pod could win the Lease before registering in
+     `repmgr.nodes`. Once it promoted, no survivor held a record for it, so none could
+     `repmgr standby follow` it -- it failed `unable to find record for intended upstream node`
+     on every reconcile tick, and nothing served writes. *Fix:* a promote candidate now reads
+     `repmgr.nodes` and, if it has no row of its own while a registered and reachable peer
+     exists, releases the Lease instead of promoting. Conservative by design -- an unreadable
+     registry, a cluster where nobody is registered, or an unreachable peer all still promote,
+     because serving with degraded metadata beats refusing to serve.
+  2. **A standby that never replicates.** The new pod's own `repmgr.nodes` copy is a snapshot of
+     the primary taken *before* it registered, so it holds no row for itself and cannot obtain
+     one -- receiving it requires replicating, and repointing replication is what needs it. It
+     failed `unable to retrieve record for local node` forever, `Running` but never `Ready`.
+     *Fix:* that specific error now triggers a re-clone from the current primary, replacing data
+     and metadata together.
+
+  The re-clone is scoped by error string, not by state, and the distinction matters: a missing
+  **upstream** record is the ordinary post-failover case where the target has simply not promoted
+  yet, and escalating there would demote and re-clone a healthy standby. A unit test asserts the
+  upstream variant does not escalate.
+
+  **This release is only complete with a republished image.** The fix is in the agent binary, so
+  `repmgr.image.tag` must be bumped past `trixie-5.5.0-29` (and the image published) before
+  1.10.1 ships -- a 1.10.1 pointing at `-29` carries the chart change without the fix.
+
+  Verification: reproduced and fixed on a live KinD cluster on the 2.0.0 line, whose `upgrade`
+  suite scales an agent-mode cluster up. **1.x's own `upgrade` suite pins `failoverMode: repmgrd`**
+  (whose `OrderedReady` serialises pod creation and closes the window), so the 1.x suites prove
+  no regression rather than proving the fix. The agent binary is identical to the verified one.
+
 ## 1.10.0 - 2026-08-02
 
 ### Added

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with repmgr replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 1.10.0
+version: 1.10.1
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,46 @@
 # pgvector chart changelog
 
+## 1.10.1 - 2026-08-11
+
+### Fixed
+
+- **Backport (#297): a scale-up could leave the cluster without a serving primary, or with a
+  standby that never replicates.** Both affect agent mode -- the default since `1.0.0` -- from
+  that release onward. Fixed on the 2.0.0 line first; backported here because they are
+  data-availability bugs in a shipped release.
+
+  Adding a replica (`postgresql.replicaCount` N -> N+1) also changes `REPMGR_NODE_COUNT`, which
+  rolls every pod, so the new pod is created while the others restart. Two things could go wrong:
+
+  1. **No serving primary.** The new pod could win the Lease before registering in
+     `repmgr.nodes`. Once it promoted, no survivor held a record for it, so none could
+     `repmgr standby follow` it -- it failed `unable to find record for intended upstream node`
+     on every reconcile tick, and nothing served writes. *Fix:* a promote candidate now reads
+     `repmgr.nodes` and, if it has no row of its own while a registered and reachable peer
+     exists, releases the Lease instead of promoting. Conservative by design -- an unreadable
+     registry, a cluster where nobody is registered, or an unreachable peer all still promote,
+     because serving with degraded metadata beats refusing to serve.
+  2. **A standby that never replicates.** The new pod's own `repmgr.nodes` copy is a snapshot of
+     the primary taken *before* it registered, so it holds no row for itself and cannot obtain
+     one -- receiving it requires replicating, and repointing replication is what needs it. It
+     failed `unable to retrieve record for local node` forever, `Running` but never `Ready`.
+     *Fix:* that specific error now triggers a re-clone from the current primary, replacing data
+     and metadata together.
+
+  The re-clone is scoped by error string, not by state, and the distinction matters: a missing
+  **upstream** record is the ordinary post-failover case where the target has simply not promoted
+  yet, and escalating there would demote and re-clone a healthy standby. A unit test asserts the
+  upstream variant does not escalate.
+
+  **This release is only complete with a republished image.** The fix is in the agent binary, so
+  `repmgr.image.tag` must be bumped past `trixie-5.5.0-29` (and the image published) before
+  1.10.1 ships -- a 1.10.1 pointing at `-29` carries the chart change without the fix.
+
+  Verification: reproduced and fixed on a live KinD cluster on the 2.0.0 line, whose `upgrade`
+  suite scales an agent-mode cluster up. **1.x's own `upgrade` suite pins `failoverMode: repmgrd`**
+  (whose `OrderedReady` serialises pod creation and closes the window), so the 1.x suites prove
+  no regression rather than proving the fix. The agent binary is identical to the verified one.
+
 ## 1.10.0 - 2026-08-02
 
 Inherited from pg's symlinked templates and the shared repmgr image. See the

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus repmgr replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 1.10.0
+version: 1.10.1
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg


### PR DESCRIPTION
Backport of #297 to the **1.x line** (`master`). The forward fix is #299 against `pg-v2`.

`pg` and `pgvector` → **1.10.1** (patch, in lockstep).

## Why backport

Both bugs affect **agent mode, the default since `1.0.0`**, so every 1.x release carries them. They
are data-availability bugs — a routine `postgresql.replicaCount` N → N+1 could leave a cluster with
no serving primary, or with a standby that silently never replicates — and neither self-heals.

## What is fixed

Scaling up also changes `REPMGR_NODE_COUNT`, which rolls every pod, so the new pod is created while
the others restart.

1. **No serving primary.** The new pod could win the Lease before registering in `repmgr.nodes`.
   Once it promoted, no survivor held a record for it, so none could `repmgr standby follow` it —
   `unable to find record for intended upstream node` on every tick, nothing serving writes.
   *Fix:* a promote candidate reads `repmgr.nodes` and, if it has no row of its own while a
   **registered and reachable** peer exists, releases the Lease instead of promoting.
2. **A standby that never replicates.** The new pod's `repmgr.nodes` copy is a snapshot of the
   primary taken *before* it registered, so it holds no row for itself and cannot obtain one —
   receiving it needs replication, and repointing replication needs the row. `unable to retrieve
   record for local node`, forever, `Running` but never `Ready`.
   *Fix:* that specific error triggers a re-clone from the current primary.

The re-clone is scoped by **error string**, not state. A missing *upstream* record is the ordinary
post-failover case where the target has not promoted yet; escalating there demotes and re-clones a
healthy standby. A unit test asserts the upstream variant does **not** escalate.

Fix-path guards are conservative — unreadable registry, nobody registered, or an unreachable peer
all still promote, because serving with degraded metadata beats refusing to serve.

## Scope: agent binary only

Deliberately minimal for a patch release — the agent, its unit tests, the two version bumps, and
the two CHANGELOG entries. No template, values, schema, or suite changes. The forward PR's
strengthened `test-upgrade` assertions (readiness + per-node topology agreement) are **not**
backported: on 1.x that suite pins `failoverMode: repmgrd`, where they would assert a different
mode's behaviour, and adding new assertions to a shipped line's CI is not what a patch release is
for.

```
images/repmgr/agent/cmd/agent/main.go               (+ recovery escalation, shared rejoinOnto)
images/repmgr/agent/internal/mechanism/mechanism.go (+ ErrLocalRecordMissing)
images/repmgr/agent/internal/mechanism/repmgr.go    (+ isLocalRecordMissing)
images/repmgr/agent/internal/pg/probe.go            (+ RegisteredNodeIDs)
images/repmgr/agent/internal/reconcile/reconcile.go (+ the promote gate)
+ unit tests for each
pg/Chart.yaml, pgvector/Chart.yaml                  1.10.0 -> 1.10.1
pg/CHANGELOG.md, pgvector/CHANGELOG.md
```

## Verification, stated precisely

The agent binary here is **identical** to the one verified on #299 (`git diff` between the two
branches over `images/repmgr/agent` is empty), and master's agent was identical to `pg-v2`'s before
that fix — so this is the same code, not a re-implementation.

Where it was verified: on the 2.0.0 line, whose `upgrade` suite scales an **agent-mode** cluster up.
Both bugs reproduced live on KinD before the fix (the Lease jumping to the new pod and the former
primary wedging; then the new pod stuck `Running`/`ready=false` with no row for itself), and after
the fix all three nodes come up Ready and agree on the topology. `test-pgpool-failover` passed 9/9
with no `pgdata.diverged.*` created.

**What 1.x CI does *not* prove.** master's `upgrade` suite pins `failoverMode: repmgrd`, whose
`OrderedReady` serialises pod creation and closes the window this bug needs. So the 1.x suites here
demonstrate **no regression**, not the fix. Adding agent-mode scale-up coverage to 1.x would mean
changing what that suite tests on a shipped line; #299 carries that coverage on 2.x instead.

Also worth stating: in the passing runs the **recovery** path fired and the **prevention** path did
not — its window is nondeterministic. Recovery is live-verified; prevention is covered by unit tests
only, and fails safe by construction.

Local on this branch: `go vet ./... && go test ./...` clean, `make -C pg test-template` 1093/1093,
all helm-unittest suites, `helm lint` clean for both charts, `diff -r pg/templates
pgvector/templates` empty.

## Release gate — read before tagging

**The fix is in the agent binary, so 1.10.1 is incomplete without a republished image.**
`repmgr.image.tag` still pins `trixie-5.5.0-29`; a 1.10.1 released against `-29` ships the chart
bump without the fix. The two-step is the documented one: publish the new image tag, then bump
`repmgr.image.tag` in **both** `pg/values.yaml` and `pgvector/values.yaml`. I have deliberately not
bumped it here rather than point the chart at a tag that does not exist yet.

CI builds the image from source, so the suites on this PR do exercise the fixed agent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent-mode scale-up recovery when local replication metadata is missing.
  * Standbys now re-clone and resume following when local registration is unavailable.
  * Prevented unnecessary re-cloning when only upstream registration is missing.
  * Improved promotion safety by favoring reachable, registered, caught-up peers.
  * Registry read failures no longer incorrectly block promotion or cause unsafe decisions.
  * Ensured recovery clears stale follow state, including after early failures.

* **Documentation**
  * Added version 1.10.1 changelog entries describing fixes and upgrade requirements.

* **Chores**
  * Updated PostgreSQL and pgvector Helm chart versions to 1.10.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->