### PR TITLE
copy-ext: use cp -n so it can't clobber copy-base-ext's libs

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,21 @@
 # pg chart changelog
 
+## 1.10.2 - 2026-08-14
+
+### Fixed
+
+- **`copy-ext` could silently overwrite `copy-base-ext`'s libs with a mismatched build
+  (#302).** When `repmgr.enabled=true` and `postgresql.extensions.enabled=true`,
+  `copy-base-ext` populates `ext-lib`/`ext-share` from the repmgr image -- the image that
+  actually runs the server -- and `copy-ext` then ran an unconditional wildcard `cp` from
+  `postgresql.image` on top of it. If the two images drifted to different PostgreSQL point
+  releases (`postgresql.image` is often pinned to a floating tag), `copy-ext` silently
+  replaced core libs such as `libpqwalreceiver.so` with a mismatched build, and every
+  freshly-created pod failed to stream replication (`undefined symbol`) -- `ext-lib`/
+  `ext-share` are emptyDirs, so this hit on every pod, not just the first. `copy-ext`'s
+  copy is now `cp -n` (no-clobber): it can only add files the repmgr image doesn't already
+  provide (e.g. `vector.so`), never overwrite one.
+
 ## 1.10.1 - 2026-08-11
 
 ### Fixed

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with repmgr replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 1.10.1
+version: 1.10.2
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -370,10 +370,10 @@ spec:
         - name: copy-ext
           image: {{ include "pg.image" .Values.postgresql.image | quote }}
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
-          # -n (no-clobber): copy-base-ext (when repmgr is enabled) already populated
-          # ext-lib/ext-share from the repmgr image, which is what actually runs the
-          # server. This container only ADDS what's missing (e.g. vector.so) -- it
-          # must never overwrite a core lib (e.g. libpqwalreceiver.so) with this
+          # -n (no-clobber, #302): copy-base-ext (when repmgr is enabled) already
+          # populated ext-lib/ext-share from the repmgr image, which is what actually
+          # runs the server. This container only ADDS what's missing (e.g. vector.so)
+          # -- it must never overwrite a core lib (e.g. libpqwalreceiver.so) with this
           # image's build. The two images can drift to different postgres point
           # releases independently (this image's tag is often floating), and an
           # unconditional overwrite silently reintroduces an ABI mismatch between

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -370,7 +370,15 @@ spec:
         - name: copy-ext
           image: {{ include "pg.image" .Values.postgresql.image | quote }}
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
-          command: ['sh', '-c', 'cp /usr/lib/postgresql/{{ $pgMajor }}/lib/*.so /ext-lib/ && cp /usr/share/postgresql/{{ $pgMajor }}/extension/* /ext-share/']
+          # -n (no-clobber): copy-base-ext (when repmgr is enabled) already populated
+          # ext-lib/ext-share from the repmgr image, which is what actually runs the
+          # server. This container only ADDS what's missing (e.g. vector.so) -- it
+          # must never overwrite a core lib (e.g. libpqwalreceiver.so) with this
+          # image's build. The two images can drift to different postgres point
+          # releases independently (this image's tag is often floating), and an
+          # unconditional overwrite silently reintroduces an ABI mismatch between
+          # the running server and its own WAL receiver plugin.
+          command: ['sh', '-c', 'cp -n /usr/lib/postgresql/{{ $pgMajor }}/lib/*.so /ext-lib/ && cp -n /usr/share/postgresql/{{ $pgMajor }}/extension/* /ext-share/']
           securityContext:
             {{- toYaml .Values.postgresql.containerSecurityContext | nindent 12 }}
           volumeMounts:

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -294,6 +294,17 @@ assert_contains "#153: lightweight init containers declare resources" "${init_re
 repmgr_init_res=$(printf '%s\n' "${init_res}" | sed -n '/name: repmgr-init/,/name: setup-config/p')
 assert_contains "#153: repmgr-init declares its (heavier) clone resources" "${repmgr_init_res}" 'cpu: "1"'
 
+# #302: copy-ext must never clobber copy-base-ext's libs. copy-base-ext (repmgr
+# image, runs first) populates ext-lib/ext-share; copy-ext (postgresql.image) only
+# adds what copy-base-ext didn't provide, so its cp must stay no-clobber -- a plain
+# cp would silently overwrite the repmgr image's core libs (e.g. libpqwalreceiver.so)
+# if postgresql.image and repmgr.image drift to different postgres point releases.
+copy_base_ext=$(printf '%s\n' "${init_res}" | sed -n '/name: copy-base-ext/,/name: copy-ext/p')
+assert_contains "#302: copy-base-ext copies plainly (it runs first, nothing to preserve yet)" "${copy_base_ext}" "cp /usr/lib/postgresql/18/lib/\*.so /ext-lib/"
+copy_ext=$(printf '%s\n' "${init_res}" | sed -n '/name: copy-ext/,/securityContext/p')
+assert_contains "#302: copy-ext uses cp -n for the lib copy" "${copy_ext}" "cp -n /usr/lib/postgresql/18/lib/\*.so /ext-lib/"
+assert_contains "#302: copy-ext uses cp -n for the extension-share copy" "${copy_ext}" "cp -n /usr/share/postgresql/18/extension/\* /ext-share/"
+
 # #116: the busybox helper init image is a single shared value (default 1.37 for all
 # four init containers, no more 1.35/1.37 split) and is overridable for air-gapped
 # registries. Default render must carry no hardcoded busybox tag.

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,28 @@
 # pgvector chart changelog
 
+## 1.10.2 - 2026-08-14
+
+Inherited from pg's symlinked `statefulset.yaml`. See the
+[pg 1.10.2 changelog](../pg/CHANGELOG.md) for the full detail.
+
+### Fixed
+
+- **`copy-ext` could silently overwrite `copy-base-ext`'s libs with a mismatched build
+  (#302).** Hit in production: this chart's `postgresql.image` (previously the floating
+  `pg18-trixie` tag) had drifted to a newer PostgreSQL point release than the pinned
+  `repmgr.image`, and `copy-ext`'s unconditional `cp` replaced the running server's
+  `libpqwalreceiver.so`, breaking replication on every freshly-created pod. `copy-ext`
+  now uses `cp -n` (no-clobber).
+
+### Changed
+
+- **`postgresql.image.tag` default pinned from the floating `pg18-trixie` to
+  `0.8.5-pg18-trixie` (#302),** matching `repmgr.image`'s default point release (18.4).
+  `cp -n` above means this image can no longer clobber the running server's libs
+  regardless, but a matching point release is still required for `CREATE EXTENSION
+  vector` (built against 18.4 headers) to load safely. Bump only in lockstep with
+  `repmgr.image`.
+
 ## 1.10.1 - 2026-08-11
 
 ### Fixed

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus repmgr replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 1.10.1
+version: 1.10.2
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -117,7 +117,7 @@ SELECT * FROM items ORDER BY embedding <-> '[1,2,3,...]' LIMIT 5;
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `postgresql.image.repository` | PostgreSQL image repository | `pgvector/pgvector` |
-| `postgresql.image.tag` | PostgreSQL image tag | `0.8.5-pg18-trixie` |
+| `postgresql.image.tag` | PostgreSQL image tag. Must bundle the same PostgreSQL point release as `repmgr.image.tag` (#302) — `copy-ext`'s no-clobber copy keeps a drifted image from corrupting the running server, but `CREATE EXTENSION vector` still needs a matching point release to load safely. Bump only in lockstep with `repmgr.image`. | `0.8.5-pg18-trixie` |
 | `postgresql.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `postgresql.majorVersion` | PostgreSQL major version in `image.tag`; builds the extension paths (`/usr/lib/postgresql/<major>/lib`, `/usr/share/postgresql/<major>/extension`) when `extensions.enabled=true`. In repmgr mode the server runs from the repmgr image and follows `repmgr.image.majorVersion` regardless of `postgresql.image`; the chart fails to render if the two majors differ. Set both to `"17"` (with a `-pg17` repmgr tag) to run PostgreSQL 17 — see [Choosing the PostgreSQL major](#choosing-the-postgresql-major). | `"18"` |
 | `postgresql.replicaCount` | Number of PostgreSQL replicas (total instances = replicaCount + 1); values > 0 require `repmgr.enabled=true` | `1` |

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -117,7 +117,7 @@ SELECT * FROM items ORDER BY embedding <-> '[1,2,3,...]' LIMIT 5;
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `postgresql.image.repository` | PostgreSQL image repository | `pgvector/pgvector` |
-| `postgresql.image.tag` | PostgreSQL image tag | `pg18-trixie` |
+| `postgresql.image.tag` | PostgreSQL image tag | `0.8.5-pg18-trixie` |
 | `postgresql.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `postgresql.majorVersion` | PostgreSQL major version in `image.tag`; builds the extension paths (`/usr/lib/postgresql/<major>/lib`, `/usr/share/postgresql/<major>/extension`) when `extensions.enabled=true`. In repmgr mode the server runs from the repmgr image and follows `repmgr.image.majorVersion` regardless of `postgresql.image`; the chart fails to render if the two majors differ. Set both to `"17"` (with a `-pg17` repmgr tag) to run PostgreSQL 17 — see [Choosing the PostgreSQL major](#choosing-the-postgresql-major). | `"18"` |
 | `postgresql.replicaCount` | Number of PostgreSQL replicas (total instances = replicaCount + 1); values > 0 require `repmgr.enabled=true` | `1` |

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -17,10 +17,10 @@ postgresql:
     repository: pgvector/pgvector
     # Pinned to the pgvector build bundling postgres 18.4, matching the
     # repmgr.image default below (also 18.4), instead of the floating
-    # `pg18-trixie` tag. copy-ext's `cp -n` no longer lets this image clobber
-    # the server's own libs regardless, but a matching point release is still
-    # what makes `CREATE EXTENSION vector` (built against 18.4's headers) safe
-    # to load into an 18.4 backend. Bump only in lockstep with repmgr.image.
+    # `pg18-trixie` tag (#302). copy-ext's `cp -n` no longer lets this image
+    # clobber the server's own libs regardless, but a matching point release is
+    # still what makes `CREATE EXTENSION vector` (built against 18.4's headers)
+    # safe to load into an 18.4 backend. Bump only in lockstep with repmgr.image.
     tag: 0.8.5-pg18-trixie
     digest: ""
     pullPolicy: IfNotPresent

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -15,7 +15,13 @@ busyboxImage:
 postgresql:
   image:
     repository: pgvector/pgvector
-    tag: pg18-trixie
+    # Pinned to the pgvector build bundling postgres 18.4, matching the
+    # repmgr.image default below (also 18.4), instead of the floating
+    # `pg18-trixie` tag. copy-ext's `cp -n` no longer lets this image clobber
+    # the server's own libs regardless, but a matching point release is still
+    # what makes `CREATE EXTENSION vector` (built against 18.4's headers) safe
+    # to load into an 18.4 backend. Bump only in lockstep with repmgr.image.
+    tag: 0.8.5-pg18-trixie
     digest: ""
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Problem

`copy-ext` and `copy-base-ext` both write into the same `ext-lib`/`ext-share` emptyDirs (pg and pgvector charts share this template — `pgvector/templates/statefulset.yaml` is a symlink to `pg`'s). When repmgr is enabled, `copy-base-ext` runs first, copying `/usr/lib/postgresql/<major>/lib/*.so` out of the **repmgr image** — the image that actually runs the server. `copy-ext` then runs the same unconditional wildcard `cp` out of `postgresql.image`, unconditionally overwriting whatever `copy-base-ext` just placed, including core libs neither image intends to touch (e.g. `libpqwalreceiver.so`).

Hit this in production use: `postgresql.image` (pgvector chart, tag `pg18-trixie`, floating) moved to a newer PostgreSQL point release (18.6) than the pinned `repmgr.image` (18.4) bundles. The wildcard overwrite silently replaced the running server's `libpqwalreceiver.so` with the mismatched build, and every freshly-created pod (init containers run on every pod start; `ext-lib` is ephemeral) failed to stream replication:

```
FATAL:  could not load library "/usr/lib/postgresql/18/lib/libpqwalreceiver.so": undefined symbol: WalRcvIdentifySystemLsn
```

This isn't specific to that one version pairing — any time `postgresql.image` and `repmgr.image` independently drift to different point releases of the same major, `copy-ext` can silently break the server it's supposed to be adding an extension *to*.

## Fix

1. `copy-ext`'s copy becomes `cp -n` (no-clobber) for both the lib and extension-share copies. It still adds whatever `postgresql.image` provides that the repmgr image doesn't (e.g. `vector.so`), but can never overwrite a file `copy-base-ext` already placed.
2. pgvector chart's default `postgresql.image.tag` is pinned from the floating `pg18-trixie` to `0.8.5-pg18-trixie`, confirmed to bundle postgres 18.4 — matching `repmgr.image`'s default (`trixie-5.5.0-30`, also 18.4). `cp -n` means this image can no longer break the running server regardless, but a matching point release is still what makes `CREATE EXTENSION vector` (built against 18.4's headers) safe to load. README updated to match.

## Test plan
- [ ] `CREATE EXTENSION vector` still succeeds (unique files still copied)
- [ ] With `postgresql.image` pinned to a *different* postgres point release than `repmgr.image`, the server's own core libs (e.g. `libpqwalreceiver.so`) are untouched and replication still works
- [ ] Fresh install with defaults: `postgresql.image.tag` (0.8.5-pg18-trixie) and `repmgr.image.tag` (trixie-5.5.0-30) resolve to the same postgres point release (18.4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented PostgreSQL extension files from overwriting existing files during initialization.
  * Improved compatibility between PostgreSQL and repmgr-provided libraries.

* **Updates**
  * Pinned the pgvector PostgreSQL image to `0.8.5-pg18-trixie` for consistent PostgreSQL versions.
  * Updated documentation and changelogs to reflect these changes.

* **Tests**
  * Added regression coverage for extension-library copy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->