### PR TITLE
feat(pg,pgvector): install extension packages without a custom image (#303)

### DIFF
--- a/.github/workflows/repmgr-image-publish.yaml
+++ b/.github/workflows/repmgr-image-publish.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
 
       - name: vet + test + verify + hermetic build + govulncheck
         working-directory: images/repmgr/agent

--- a/.github/workflows/repmgr-image-test.yaml
+++ b/.github/workflows/repmgr-image-test.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
 
       - name: vet + test the agent module
         working-directory: images/repmgr/agent

--- a/images/repmgr/DOCKER_HUB.md
+++ b/images/repmgr/DOCKER_HUB.md
@@ -25,7 +25,7 @@ Each release publishes one multi-arch (amd64/arm64) manifest per PostgreSQL majo
 A container announces its own major as `PG_MAJOR`, and the server binaries live in `/usr/lib/postgresql/$PG_MAJOR/bin`:
 
 ```bash
-docker run --rm cagriekin/repmgr:trixie-5.5.0-30-pg17 printenv PG_MAJOR   # -> 17
+docker run --rm cagriekin/repmgr:trixie-5.5.0-31-pg17 printenv PG_MAJOR   # -> 17
 ```
 
 **The major is fixed at build time and cannot be changed for an existing data directory** — a PostgreSQL 18 server refuses to start on a PG17 `PGDATA`. Choose the major when you create the cluster.

--- a/images/repmgr/README.md
+++ b/images/repmgr/README.md
@@ -12,8 +12,8 @@ PostgreSQL with repmgr 5.5.0, pgBackRest, pgaudit, and cron on Debian Trixie. De
 The major is a **build argument**, defaulting to 18, and one build ships exactly one major (`postgresql-<major>`, `-repmgr` and `-pgaudit` from PGDG). Supported: **18** (default) and **17**.
 
 ```bash
-docker build -t cagriekin/repmgr:trixie-5.5.0-30 .                       # PostgreSQL 18
-docker build --build-arg PG_MAJOR=17 -t cagriekin/repmgr:trixie-5.5.0-30-pg17 .
+docker build -t cagriekin/repmgr:trixie-5.5.0-31 .                       # PostgreSQL 18
+docker build --build-arg PG_MAJOR=17 -t cagriekin/repmgr:trixie-5.5.0-31-pg17 .
 ```
 
 Published tags per release: `trixie-<repmgr>-<n>` (the **default** major, 18), plus `-pg18` and `-pg17`. The unsuffixed tag is what chart pins resolve to, so `ARG PG_MAJOR`'s default and the publish workflow's `default_major` must stay in step — `test/scripts-test.sh` asserts the `ARG` default is 18 for exactly that reason.
@@ -25,7 +25,7 @@ The build **fails** if any per-major package has no installation candidate (chec
 Both majors are verified by `test/image-smoke.sh <image-ref> <major>`, which starts the built image and asserts the server version, that `repmgr`/`repmgrd` resolve and report 5.5.0, and that `pgaudit` actually loads via `shared_preload_libraries`:
 
 ```bash
-bash test/image-smoke.sh cagriekin/repmgr:trixie-5.5.0-30-pg17 17
+bash test/image-smoke.sh cagriekin/repmgr:trixie-5.5.0-31-pg17 17
 ```
 
 ## Execution Modes
@@ -143,8 +143,8 @@ pgBackRest configuration (`/etc/pgbackrest/pgbackrest.conf`) and S3 credentials 
 ## Building
 
 ```bash
-docker build -t cagriekin/repmgr:trixie-5.5.0-30 .                       # PostgreSQL 18 (default)
-docker build --build-arg PG_MAJOR=17 -t cagriekin/repmgr:trixie-5.5.0-30-pg17 .
+docker build -t cagriekin/repmgr:trixie-5.5.0-31 .                       # PostgreSQL 18 (default)
+docker build --build-arg PG_MAJOR=17 -t cagriekin/repmgr:trixie-5.5.0-31-pg17 .
 ```
 
 ## Compatibility

--- a/images/repmgr/entrypoint.sh
+++ b/images/repmgr/entrypoint.sh
@@ -214,6 +214,20 @@ max_replication_slots = 10
 max_slot_wal_keep_size = 4GB
 EOF
 
+            # Wire in the chart's conf.d include (when the chart mounted it) before this
+            # function's own pg_ctl start/stop below, not after. shared_preload_libraries is
+            # postmaster-only (no reload); the chart's merged value (repmgr + operator
+            # extras/pgaudit) lives in conf.d, previously only spliced in by the postStart
+            # hook once postgres was already accepting connections -- too late to take
+            # effect without a second restart, which nothing forced on a fresh install
+            # (the config checksum -> rolling restart wiring only helps a later
+            # `helm upgrade`, since there is no prior pod to roll on `helm install`). A
+            # directory check, not an env var, because it needs no chart-side signal: the
+            # mount is present here iff the chart rendered postgresql-configmap.yaml.
+            if [ -d /etc/postgresql/conf.d ]; then
+                echo "include_dir = '/etc/postgresql/conf.d'" >> "$PGDATA/postgresql.conf"
+            fi
+
             if [ "${PGBACKREST_ENABLED:-}" = "true" ]; then
                 cat >> "$PGDATA/postgresql.conf" << PGBR
 archive_mode = on

--- a/images/repmgr/test/image-smoke.sh
+++ b/images/repmgr/test/image-smoke.sh
@@ -8,7 +8,7 @@
 # package resolved to a different version than the tag advertises.
 #
 # Usage: bash images/repmgr/test/image-smoke.sh <image-ref> <expected-pg-major>
-#   bash images/repmgr/test/image-smoke.sh cagriekin/repmgr:trixie-5.5.0-30-pg17 17
+#   bash images/repmgr/test/image-smoke.sh cagriekin/repmgr:trixie-5.5.0-31-pg17 17
 set -uo pipefail
 
 IMAGE="${1:?usage: image-smoke.sh <image-ref> <expected-pg-major>}"

--- a/images/repmgr/test/scripts-test.sh
+++ b/images/repmgr/test/scripts-test.sh
@@ -324,6 +324,29 @@ else
   bad "#269: Dockerfile does not assert per-major package availability"
 fi
 
+# --- #303 follow-up: conf.d must be wired in before the FIRST pg_ctl start ---
+# shared_preload_libraries is postmaster-only (no reload). The chart's merged value
+# (repmgr + operator extras/pgaudit) lives in conf.d; previously only the chart's
+# postStart hook spliced in the include_dir line, after postgres was already
+# accepting connections -- too late for a postmaster-only GUC, and nothing forces a
+# second restart on a fresh `helm install` (the config-checksum rolling restart only
+# helps a later `helm upgrade`). entrypoint.sh must wire it in at initdb time,
+# before its own bootstrap pg_ctl start below, so the merged preload list is active
+# from the very first postmaster start.
+confd_line=$(grep -n "include_dir = '/etc/postgresql/conf.d'" "${ROOT}/entrypoint.sh" | grep -v "PGDATA\"" | head -1 | cut -d: -f1)
+guard_line=$(grep -n "if \[ -d /etc/postgresql/conf.d \]; then" "${ROOT}/entrypoint.sh" | head -1 | cut -d: -f1)
+first_start_line=$(grep -n 'pg_ctl -D "\$PGDATA" -w start' "${ROOT}/entrypoint.sh" | head -1 | cut -d: -f1)
+if [ -n "$guard_line" ] && [ -n "$confd_line" ]; then
+  ok "#303: entrypoint.sh guards the conf.d include on the mount actually existing"
+else
+  bad "#303: entrypoint.sh does not guard the conf.d include on the mount existing"
+fi
+if [ -n "$confd_line" ] && [ -n "$first_start_line" ] && [ "$confd_line" -lt "$first_start_line" ]; then
+  ok "#303: entrypoint.sh wires conf.d in before the bootstrap pg_ctl start"
+else
+  bad "#303: entrypoint.sh does not wire conf.d in before the bootstrap pg_ctl start"
+fi
+
 echo "----"
 [ "$fail" -eq 0 ] && echo "ALL TESTS PASSED" || echo "TESTS FAILED"
 exit "$fail"

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -24,6 +24,16 @@
   containing shell metacharacters (the list is interpolated into an `apt-get install`
   shell command) and rejects `packages` set without `extensions.enabled: true`.
 
+  **Review follow-up:** an unversioned PGDG extension dependency on `postgresql-<major>`
+  is normally left alone by apt, but nothing stopped some *other* future package from
+  declaring a stricter dependency and pulling in a newer `postgresql-<major>` as a side
+  effect — silently swapping the very libs about to be copied for a build from a
+  different point release than the postmaster this chart actually starts (the #302
+  failure mode, one layer up). `copy-ext`/`copy-base-ext` now detect the already-installed
+  `postgresql-<major>` version (`dpkg-query`) and pin it on the same `apt-get install`
+  line, so apt either leaves it alone (the normal case, confirmed live) or fails the
+  install outright — never a silent swap.
+
   See README ["Installing extensions without a custom image"](README.md#installing-extensions-without-a-custom-image)
   for a complete `pg_cron` example, why `postgresql.databases[].extensions` (not
   `postStart.additionalCommands`) is the right mechanism for the `CREATE EXTENSION` step

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -31,6 +31,30 @@
   `postgresql.image`, the `networkPolicy.postgresql.extraEgress` this requires, and the
   explicit limitation for extensions with no Debian/PGDG package.
 
+### Fixed
+
+- **`shared_preload_libraries` never actually applied before the post-install hook Jobs
+  ran on a fresh install (found while verifying #303's own `pg_cron` recipe).**
+  `shared_preload_libraries` is a postmaster-restart-only parameter. On `helm install`,
+  the repmgr image's entrypoint bakes `shared_preload_libraries = 'repmgr'` directly at
+  `initdb`; the chart's merged value (repmgr + any operator-declared libraries + pgaudit)
+  lives in a conf.d file that was only spliced into `postgresql.conf` by the `postStart`
+  hook, after postgres was already accepting connections -- too late for a
+  restart-only GUC, and nothing forced the restart a `helm upgrade`'s config-checksum
+  rolling restart would have provided. The `databases-roles`/`audit-extension` hook Jobs
+  then failed `CREATE EXTENSION ... must be loaded via shared_preload_libraries`, and
+  (per `hook-delete-policy: before-hook-creation,hook-succeeded`) sat failed rather than
+  retrying. Pre-existing, not introduced by #303 -- confirmed the identical failure on
+  unmodified 1.10.2 with only `postgresql.audit.enabled: true` set.
+
+  Fixed at the source: `repmgr.image.tag` bumped to `trixie-5.5.0-31`, whose entrypoint
+  now wires the chart's conf.d `include_dir` into `postgresql.conf` at `initdb` time --
+  before its own bootstrap `pg_ctl start` -- so the merged `shared_preload_libraries` is
+  active from the very first postmaster start on a fresh install, no restart required.
+  Verified live on a fresh `helm install` for both the `pg_cron` recipe above and
+  `postgresql.audit.enabled: true`. `etcd.rbac.bootstrapImage.tag` bumped alongside it,
+  same lockstep requirement as always.
+
 ## 1.10.2 - 2026-08-14
 
 ### Fixed

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,36 @@
 # pg chart changelog
 
+## 1.11.0 - 2026-08-17
+
+### Added
+
+- **`postgresql.extensions.packages`: install PGDG/Debian extension packages without a
+  custom image (#303).** Generalizes the existing `postgresql.extensions.enabled`
+  copy-based mechanism: `copy-ext`/`copy-base-ext` can now `apt-get install` a
+  render-time-validated package list (`{major}`-substituted against
+  `postgresql.majorVersion`, optionally version-pinned with apt's `=` syntax) into their
+  own filesystem before the existing lib/share copy, so an extension the donor image
+  never shipped (e.g. `postgresql-<major>-cron`) reaches the server the same way
+  `postgresql.extensions.enabled` always has. Mechanically: neither init container mounts
+  `ext-lib`/`ext-share` at the real native extension paths — only the main postgresql
+  container does — so `apt-get install` writes real files there and the existing
+  `cp`/`cp -n` (#302) step sweeps them up unchanged.
+
+  Off by default (`packages: []`; a default render is byte-identical to 1.10.2). When
+  set, the two init containers run root-transiently for the apt step only (capabilities
+  narrowed, not unrestricted — confined to a throwaway container that persists nothing),
+  with their own values-overridable `postgresql.extensions.installResources` rather than
+  the shared, lighter `pg.initResources`. A render-time guard rejects any package entry
+  containing shell metacharacters (the list is interpolated into an `apt-get install`
+  shell command) and rejects `packages` set without `extensions.enabled: true`.
+
+  See README ["Installing extensions without a custom image"](README.md#installing-extensions-without-a-custom-image)
+  for a complete `pg_cron` example, why `postgresql.databases[].extensions` (not
+  `postStart.additionalCommands`) is the right mechanism for the `CREATE EXTENSION` step
+  even against the bootstrap database, the PGDG apt-source assumption for a non-default
+  `postgresql.image`, the `networkPolicy.postgresql.extraEgress` this requires, and the
+  explicit limitation for extensions with no Debian/PGDG package.
+
 ## 1.10.2 - 2026-08-14
 
 ### Fixed

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with repmgr replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 1.10.2
+version: 1.11.0
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/README.md
+++ b/pg/README.md
@@ -285,7 +285,7 @@ These three values are validated at render time, so a mistake fails `helm instal
 |-----------|-------------|---------|
 | `repmgr.enabled` | Enable repmgr | `true` |
 | `repmgr.image.repository` | Repmgr image repository | `cagriekin/repmgr` |
-| `repmgr.image.tag` | Repmgr image tag. Unsuffixed = the default major (18); `-pg18` / `-pg17` select one explicitly | `trixie-5.5.0-30` |
+| `repmgr.image.tag` | Repmgr image tag. Unsuffixed = the default major (18); `-pg18` / `-pg17` select one explicitly | `trixie-5.5.0-31` |
 | `repmgr.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `repmgr.image.majorVersion` | PostgreSQL major bundled in the repmgr image. In repmgr mode the server always runs this major; `postgresql.majorVersion` must match or the chart fails to render. Move it together with `repmgr.image.tag` (`17` ⇄ `-pg17`) — see [Choosing the PostgreSQL major](#choosing-the-postgresql-major). | `"18"` |
 | `repmgr.username` | Repmgr database user | `repmgr` |
@@ -332,7 +332,7 @@ postgresql:
     tag: 17.10-trixie      # only used in standalone mode / for the extension copy
 repmgr:
   image:
-    tag: trixie-5.5.0-30-pg17
+    tag: trixie-5.5.0-31-pg17
     majorVersion: "17"
 ```
 
@@ -2035,7 +2035,8 @@ Each chart is tagged `<chart>-<version>` (e.g. `pg-1.1.0`); `pg` and `pgvector` 
 
 | `pg` / `pgvector` | repmgr image | PostgreSQL | Kubernetes |
 |-------------------|--------------|-----------|-----------|
-| 1.10.1 *(current)* | `trixie-5.5.0-30` (`-pg18` / `-pg17`) | 18.x (default) or 17.x — see [Choosing the PostgreSQL major](#choosing-the-postgresql-major) | ≥ 1.21 (PDB `policy/v1`); ≥ 1.27 for the agent-mode PDB `unhealthyPodEvictionPolicy` |
+| 1.11.0 *(current)* | `trixie-5.5.0-31` (`-pg18` / `-pg17`) | 18.x (default) or 17.x — see [Choosing the PostgreSQL major](#choosing-the-postgresql-major) | ≥ 1.21 (PDB `policy/v1`); ≥ 1.27 for the agent-mode PDB `unhealthyPodEvictionPolicy` |
+| 1.10.1 – 1.10.2 | `trixie-5.5.0-30` | 18.x (default) or 17.x | as above |
 | 1.8.1 – 1.10.0 | `trixie-5.5.0-29` | 18.x (default) or 17.x | as above |
 | 1.5.0 – 1.8.0 | `trixie-5.5.0-28` | 18.x | as above |
 | 1.2.6 – 1.4.x | `trixie-5.5.0-27` | 18.x | as above |
@@ -2053,7 +2054,7 @@ helm repo update
 helm upgrade my-postgres cagriekin/pg   # add -f your-values.yaml
 ```
 
-Within the 1.x line the default is agent mode, and successive releases (e.g. `1.0.0` → `1.10.1`) are backward-compatible: `helm upgrade` rolls the pods once for the new image (`trixie-5.5.0-30` at 1.10.1) and the agent re-establishes leadership with no manual step. **Read every `Migrating from X.Y.Z` entry in [`CHANGELOG.md`](CHANGELOG.md) between your current version and the target** — some releases (credential, `pg_hba`, or image changes) carry one-time steps. The CHANGELOG keeps an unbroken trail back through the 0.x line.
+Within the 1.x line the default is agent mode, and successive releases (e.g. `1.0.0` → `1.11.0`) are backward-compatible: `helm upgrade` rolls the pods once for the new image (`trixie-5.5.0-31` at 1.11.0) and the agent re-establishes leadership with no manual step. **Read every `Migrating from X.Y.Z` entry in [`CHANGELOG.md`](CHANGELOG.md) between your current version and the target** — some releases (credential, `pg_hba`, or image changes) carry one-time steps. The CHANGELOG keeps an unbroken trail back through the 0.x line.
 
 ### Crossing the 0.x → 1.x boundary (agent mode is now the default)
 

--- a/pg/README.md
+++ b/pg/README.md
@@ -166,6 +166,8 @@ Runtime configuration can be injected without rebuilding images. Settings are wr
 | `postgresql.extraVolumeMounts` | Extra mounts for the postgresql container; each must reference a `postgresql.extraVolumes` entry | `[]` |
 | `postgresql.extraEnv` | Extra env vars for the postgresql container (supports `value` and `valueFrom`); may not reuse a chart-set name | `[]` |
 | `postgresql.extensions.enabled` | Enable extensions support | `false` |
+| `postgresql.extensions.packages` | Debian/PGDG packages to `apt-get install` before the copy step, so extensions absent from the donor image (`pg_cron`, `postgis`, …) install without a custom image; `{major}` substitutes `postgresql.majorVersion` (see [Installing extensions without a custom image](#installing-extensions-without-a-custom-image)) | `[]` |
+| `postgresql.extensions.installResources` | Resources for the apt-get step (only rendered while `packages` is non-empty) | `100m/128Mi` req, `1/512Mi` limit |
 | `postgresql.audit.enabled` | Enable pgaudit audit logging (requires repmgr mode; see [Audit logging](#audit-logging-pgaudit)) | `false` |
 | `postgresql.audit.log` | pgaudit session classes: `read,write,function,role,ddl,misc,misc_set,all` (negate with `-`) | `"ddl, role, write"` |
 | `postgresql.audit.logCatalog` | Audit `pg_catalog` statements | `false` |
@@ -197,6 +199,49 @@ postgresql:
 ```
 
 When `repmgr.enabled` is true, `additionalCommands` automatically discover the current primary and execute against it, so DDL statements like `CREATE EXTENSION` work correctly regardless of which pod the hook runs on (including standbys after a failover).
+
+### Installing extensions without a custom image
+
+`postgresql.extensions.packages` extends the existing copy-based extension mechanism (`postgresql.extensions.enabled`) with an `apt-get install` step, run inside the throwaway `copy-ext`/`copy-base-ext` init containers before they copy `/usr/lib/postgresql/<major>/lib` and `/usr/share/postgresql/<major>/extension` into the running server. Neither container mounts those emptyDirs at the real native paths — only the main postgresql container does — so `apt-get install` lands real files at the paths the existing copy step already sweeps, and a PGDG/Debian-packaged extension the donor image never shipped (`pg_cron` is the motivating example) reaches the server without building a custom image.
+
+Complete `pg_cron` example:
+
+```yaml
+postgresql:
+  majorVersion: "18"
+  extensions:
+    enabled: true
+    packages:
+      - "postgresql-{major}-cron"
+  configuration:
+    shared_preload_libraries: pg_cron
+    cron.database_name: postgres   # the bootstrap database (postgresql.database)
+  databases:
+    - name: postgres               # the bootstrap database's own name is a valid target:
+      extensions:                  # CREATE DATABASE is idempotent (skips if it exists),
+        - pg_cron                  # and CREATE EXTENSION still runs against it
+```
+
+Declaring `postgres` (or whatever `postgresql.database` is) under `postgresql.databases[]` works because the databases-roles hook Job's `CREATE DATABASE` is already conditional (`WHERE NOT EXISTS ... \gexec`) — it no-ops when the database already exists — and the extension/grant step then runs against that database by name regardless of whether the Job created it. This is preferable to `postgresql.lifecycle.postStart.additionalCommands` for this case: it's already regex-validated (no injection surface) and runs once via a proper Helm hook Job rather than raw shell on every pod boot.
+
+In repmgr mode, `shared_preload_libraries: pg_cron` is merged with `repmgr` (and `pgaudit`, if audit is on) automatically — declare only your own libraries, per [Mounting an extra file on every replica](#mounting-an-extra-file-on-every-replica) below.
+
+**Version pinning.** Append `=version` in apt syntax, e.g. `"postgresql-{major}-cron=1.6.4-1"`. `{major}` is substituted with `postgresql.majorVersion` at render time, so a package list survives a later major bump without editing (confirm the new major has a PGDG build of the same extension before bumping, though).
+
+**PGDG apt-source assumption.** `copy-base-ext` runs from the `cagriekin/repmgr` image, which configures the PGDG apt repository itself at build time — package installs there are reliable whenever repmgr mode is on. `copy-ext` runs from whatever `postgresql.image` you set (default: the official `postgres:18.1-trixie` Docker Hub image); this chart does not verify that image has PGDG configured. This matters most in **standalone mode** (`repmgr.enabled: false`), where `copy-ext` is your only extension source; in repmgr mode, `copy-base-ext` is a confirmed-good fallback even if `copy-ext`'s apt step comes up short.
+
+**NetworkPolicy.** With `networkPolicy.enabled: true`, egress is closed by default except DNS, PostgreSQL, and 443/6443. `apt-get update`/`install` talks to `apt.postgresql.org` over **port 80** (plain HTTP; the apt source itself is signature-verified via a keyring already baked into the image, so this is not a TLS downgrade of package integrity). Add it via the existing egress hook:
+
+```yaml
+networkPolicy:
+  postgresql:
+    extraEgress:
+      - ports:
+          - port: 80
+            protocol: TCP
+```
+
+**Limitation.** This mechanism only helps for extensions that have a PGDG or Debian package. A small number of extensions — mostly private/internal ones, or ones never packaged for Debian/PGDG — have no such package and are **not** solved by `packages`; those still require a custom image with the extension compiled in.
 
 ### Mounting an extra file on every replica
 

--- a/pg/README.md
+++ b/pg/README.md
@@ -241,6 +241,10 @@ networkPolicy:
             protocol: TCP
 ```
 
+This egress is needed on **every** pod (re)start, not just the first install: `ext-lib`/`ext-share` are `emptyDir`s, so `copy-ext`/`copy-base-ext` (and the apt-get step) re-run from scratch on a crash, eviction, or rolling update, same as the plain-copy path always has. Cutting egress to `apt.postgresql.org` after a successful install does not affect the already-running server, but a pod that then restarts for any reason will not come back up — plan for persistent, not just one-time, access in an air-gapped or tightly-firewalled cluster.
+
+**Pod Security Admission.** The apt step's init containers run `runAsUser: 0` (dpkg needs root to write `/var/lib/dpkg` and run maintainer scripts) — this is opt-in only while `packages` is set, but a namespace enforcing the PSA **restricted** profile (or any `runAsNonRoot` admission policy) will reject the pod outright. The rest of the chart runs as uid 101; `packages` is not compatible with a `restricted`-labeled namespace.
+
 **Limitation.** This mechanism only helps for extensions that have a PGDG or Debian package. A small number of extensions — mostly private/internal ones, or ones never packaged for Debian/PGDG — have no such package and are **not** solved by `packages`; those still require a custom image with the extension compiled in.
 
 ### Mounting an extra file on every replica

--- a/pg/templates/_helpers.tpl
+++ b/pg/templates/_helpers.tpl
@@ -358,6 +358,31 @@ GRANT {{ $privs }} ON DATABASE "{{ $g.database }}" TO "{{ $role }}"
 {{- end -}}
 {{- end }}
 
+{{- /* #303: postgresql.extensions.packages is apt-get argv, space-joined into a single
+       `sh -c` string ahead of the existing extension-copy command in copy-ext/
+       copy-base-ext (statefulset.yaml). A malicious or fat-fingered entry could inject
+       shell -- backticks, $(), ;, &, |, quotes, whitespace/newlines all terminate or
+       extend the intended `apt-get install` argv. Restrict to the character class
+       legitimate Debian/PGDG package names and version pins actually use (letters,
+       digits, + . ~ : = _ -), plus the literal `{major}` placeholder token substituted
+       with postgresql.majorVersion at render time, and fail the render otherwise --
+       mirrors pg.validateDatabasesRoles's identifier guard above. */ -}}
+{{- define "pg.validateExtensionPackages" -}}
+{{- $pkgs := .Values.postgresql.extensions.packages | default list -}}
+{{- if $pkgs -}}
+  {{- if not .Values.postgresql.extensions.enabled -}}
+    {{- fail "postgresql.extensions.packages is set but postgresql.extensions.enabled is false, so nothing would ever install them. Set postgresql.extensions.enabled=true." -}}
+  {{- end -}}
+  {{- $re := "^[A-Za-z0-9][A-Za-z0-9+.~:=_-]*(\\{major\\}[A-Za-z0-9+.~:=_-]*)*$" -}}
+  {{- range $p := $pkgs -}}
+    {{- $s := $p | toString -}}
+    {{- if not (regexMatch $re $s) -}}
+      {{- fail (printf "postgresql.extensions.packages: invalid entry %q -- must be a plain Debian/PGDG package name, optionally with an =version pin, using only letters, digits, and the characters + . ~ : = _ - (plus the literal {major} placeholder substituted with postgresql.majorVersion); no whitespace, quotes, backticks, $(), ;, &, |, or newlines (the list is interpolated into an apt-get install shell command)." $s) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
 {{- /* #262: validate the postgresql.extraVolumes / extraVolumeMounts / extraEnv
        passthrough. These are spliced verbatim into the pod spec, so without guards a
        plausible mistake becomes a silent runtime failure or an apply-time apiserver

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -369,7 +369,18 @@ spec:
           # installed. The repmgr image configures the PGDG apt repo at build time
           # (images/repmgr/Dockerfile), so this is the reliable install path in
           # repmgr mode.
-          command: ['sh', '-c', 'apt-get update && apt-get install -y --no-install-recommends {{ join " " $pkgs }} && cp /usr/lib/postgresql/{{ $pgMajor }}/lib/*.so /ext-lib/ && cp /usr/share/postgresql/{{ $pgMajor }}/extension/* /ext-share/']
+          #
+          # Pin postgresql-{{ $pgMajor }} to whatever's already installed before naming any
+          # extension package on the same apt-get install line (review, #303): an
+          # unversioned `Depends: postgresql-{{ $pgMajor }}` is satisfied by any installed
+          # version and normally left alone, but apt is still free to upgrade it to
+          # satisfy some OTHER package's stricter constraint -- which would replace the
+          # very libs this cp is about to copy with a build from a different point
+          # release than the postmaster this chart actually starts (the #302 failure
+          # mode, one layer up). The pin makes that impossible to do silently: apt
+          # either leaves the server package alone (the normal case) or fails the
+          # render-time-adjacent install outright, never a quiet swap.
+          command: ['sh', '-c', 'PGVER=$(dpkg-query -W postgresql-{{ $pgMajor }} 2>/dev/null | cut -f2); apt-get update && apt-get install -y --no-install-recommends ${PGVER:+"postgresql-{{ $pgMajor }}=$PGVER"} {{ join " " $pkgs }} && cp /usr/lib/postgresql/{{ $pgMajor }}/lib/*.so /ext-lib/ && cp /usr/share/postgresql/{{ $pgMajor }}/extension/* /ext-share/']
           securityContext:
             # apt-get/dpkg needs root to write /var/lib/dpkg and run package
             # maintainer scripts (e.g. ldconfig) -- broader than fix-permissions'
@@ -378,7 +389,13 @@ spec:
             # throwaway init container, which persists nothing: its only output is
             # two file trees copied into emptyDirs. The main postgresql container,
             # and this same container with no packages set, keep running as the
-            # unprivileged containerSecurityContext user.
+            # unprivileged containerSecurityContext user. This whole block REPLACES
+            # postgresql.containerSecurityContext for this container while packages
+            # is set (review, #303) -- deliberate, since dpkg needs root -- but it
+            # means a values-set runAsGroup/seccompProfile/readOnlyRootFilesystem is
+            # NOT merged in here and has no effect on this container. A namespace
+            # enforcing the PSA restricted profile (or any runAsNonRoot admission
+            # policy) will reject this pod outright; see the README PSA note.
             runAsUser: 0
             runAsNonRoot: false
             allowPrivilegeEscalation: false
@@ -390,6 +407,13 @@ spec:
                 - DAC_OVERRIDE
                 - FOWNER
                 - FSETID
+                # SETUID/SETGID/SETFCAP are no-ops here under
+                # allowPrivilegeEscalation: false (kernel no_new_privs blocks the
+                # privilege gain these grant) -- kept anyway so a dpkg postinst
+                # script that merely CALLS setuid()/setgid()/setcap() (e.g. to
+                # verify ownership, not to actually escalate) gets EPERM handled
+                # gracefully by the calling code instead of the syscall itself
+                # being denied in a way some maintainer scripts do not expect.
                 - SETUID
                 - SETGID
                 - SETFCAP
@@ -428,9 +452,18 @@ spec:
           # without packages) is to ADD what's missing, never overwrite a core lib
           # with this image's build. PGDG apt-source availability in
           # postgresql.image is NOT verified by this chart -- see README "Installing
-          # extensions without a custom image".
-          command: ['sh', '-c', 'apt-get update && apt-get install -y --no-install-recommends {{ join " " $pkgs }} && cp -n /usr/lib/postgresql/{{ $pgMajor }}/lib/*.so /ext-lib/ && cp -n /usr/share/postgresql/{{ $pgMajor }}/extension/* /ext-share/']
+          # extensions without a custom image". Same postgresql-{{ $pgMajor }} version
+          # pin as copy-base-ext, and for the same reason (review, #303) -- best-effort
+          # here too: if this image did not install PostgreSQL via a dpkg-tracked
+          # postgresql-{{ $pgMajor }} package, PGVER is empty and the pin is skipped
+          # rather than failing an otherwise-valid custom-image install.
+          command: ['sh', '-c', 'PGVER=$(dpkg-query -W postgresql-{{ $pgMajor }} 2>/dev/null | cut -f2); apt-get update && apt-get install -y --no-install-recommends ${PGVER:+"postgresql-{{ $pgMajor }}=$PGVER"} {{ join " " $pkgs }} && cp -n /usr/lib/postgresql/{{ $pgMajor }}/lib/*.so /ext-lib/ && cp -n /usr/share/postgresql/{{ $pgMajor }}/extension/* /ext-share/']
           securityContext:
+            # Same as copy-base-ext's apt-step securityContext above (review, #303):
+            # REPLACES postgresql.containerSecurityContext, not a merge -- and will
+            # be rejected under the PSA restricted profile. SETUID/SETGID/SETFCAP
+            # are no-ops under allowPrivilegeEscalation: false; kept so a dpkg
+            # postinst that calls those syscalls gets a handled EPERM.
             runAsUser: 0
             runAsNonRoot: false
             allowPrivilegeEscalation: false

--- a/pg/templates/statefulset.yaml
+++ b/pg/templates/statefulset.yaml
@@ -1,6 +1,7 @@
 {{- include "pg.validateResourceNames" . }}
 {{- include "pg.validateAudit" . }}
 {{- include "pg.validateExtraPassthrough" . }}
+{{- include "pg.validateExtensionPackages" . }}
 {{- if and (not .Values.repmgr.enabled) (gt (int .Values.postgresql.replicaCount) 0) }}
 {{- fail "postgresql.replicaCount > 0 requires repmgr.enabled=true: with repmgr disabled the chart would run replicaCount+1 independent PostgreSQL instances with no replication between them. Set postgresql.replicaCount=0 for standalone mode or enable repmgr" }}
 {{- end }}
@@ -351,25 +352,101 @@ spec:
 {{- end }}
 {{- if and .Values.postgresql.extensions.enabled .Values.repmgr.enabled }}
 {{- $pgMajor := required "postgresql.majorVersion is required when postgresql.extensions.enabled is true" .Values.postgresql.majorVersion }}
+{{- $pkgs := list }}
+{{- range $p := (.Values.postgresql.extensions.packages | default list) }}
+{{- $pkgs = append $pkgs ($p | toString | replace "{major}" ($pgMajor | toString)) }}
+{{- end }}
         - name: copy-base-ext
           image: "{{ include "pg.repmgrImage" . }}"
           imagePullPolicy: {{ .Values.repmgr.image.pullPolicy }}
+{{- if $pkgs }}
+          # #303: apt-get install into THIS container's own filesystem before the copy
+          # below -- neither ext-lib nor ext-share is mounted at the real
+          # /usr/lib(share)/postgresql/{{ $pgMajor }}/... paths here (only the main
+          # postgresql container mounts them there), so dpkg unpacks straight into
+          # this image's normal extension directories and the unmodified cp then
+          # picks up both the repmgr image's original extensions and anything just
+          # installed. The repmgr image configures the PGDG apt repo at build time
+          # (images/repmgr/Dockerfile), so this is the reliable install path in
+          # repmgr mode.
+          command: ['sh', '-c', 'apt-get update && apt-get install -y --no-install-recommends {{ join " " $pkgs }} && cp /usr/lib/postgresql/{{ $pgMajor }}/lib/*.so /ext-lib/ && cp /usr/share/postgresql/{{ $pgMajor }}/extension/* /ext-share/']
+          securityContext:
+            # apt-get/dpkg needs root to write /var/lib/dpkg and run package
+            # maintainer scripts (e.g. ldconfig) -- broader than fix-permissions'
+            # plain chown/chmod (#162), because dpkg's maintainer-script surface is
+            # inherently wider than one chown call. Root is confined to this
+            # throwaway init container, which persists nothing: its only output is
+            # two file trees copied into emptyDirs. The main postgresql container,
+            # and this same container with no packages set, keep running as the
+            # unprivileged containerSecurityContext user.
+            runAsUser: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - DAC_OVERRIDE
+                - FOWNER
+                - FSETID
+                - SETUID
+                - SETGID
+                - SETFCAP
+                - MKNOD
+{{- else }}
           command: ['sh', '-c', 'cp /usr/lib/postgresql/{{ $pgMajor }}/lib/*.so /ext-lib/ && cp /usr/share/postgresql/{{ $pgMajor }}/extension/* /ext-share/']
           securityContext:
             {{- toYaml .Values.postgresql.containerSecurityContext | nindent 12 }}
+{{- end }}
           volumeMounts:
             - name: ext-lib
               mountPath: /ext-lib
             - name: ext-share
               mountPath: /ext-share
           resources:
+{{- if $pkgs }}
+            {{- toYaml .Values.postgresql.extensions.installResources | nindent 12 }}
+{{- else }}
             {{- include "pg.initResources" . | nindent 12 }}
+{{- end }}
 {{- end }}
 {{- if .Values.postgresql.extensions.enabled }}
 {{- $pgMajor := required "postgresql.majorVersion is required when postgresql.extensions.enabled is true" .Values.postgresql.majorVersion }}
+{{- $pkgs := list }}
+{{- range $p := (.Values.postgresql.extensions.packages | default list) }}
+{{- $pkgs = append $pkgs ($p | toString | replace "{major}" ($pgMajor | toString)) }}
+{{- end }}
         - name: copy-ext
           image: {{ include "pg.image" .Values.postgresql.image | quote }}
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+{{- if $pkgs }}
+          # #303: apt-get install before the copy below, same reasoning as
+          # copy-base-ext. Still -n (no-clobber, #302) on the copy: in repmgr mode
+          # copy-base-ext already populated ext-lib/ext-share from the repmgr image,
+          # which is what actually runs the server, so this container's job (with or
+          # without packages) is to ADD what's missing, never overwrite a core lib
+          # with this image's build. PGDG apt-source availability in
+          # postgresql.image is NOT verified by this chart -- see README "Installing
+          # extensions without a custom image".
+          command: ['sh', '-c', 'apt-get update && apt-get install -y --no-install-recommends {{ join " " $pkgs }} && cp -n /usr/lib/postgresql/{{ $pgMajor }}/lib/*.so /ext-lib/ && cp -n /usr/share/postgresql/{{ $pgMajor }}/extension/* /ext-share/']
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - DAC_OVERRIDE
+                - FOWNER
+                - FSETID
+                - SETUID
+                - SETGID
+                - SETFCAP
+                - MKNOD
+{{- else }}
           # -n (no-clobber, #302): copy-base-ext (when repmgr is enabled) already
           # populated ext-lib/ext-share from the repmgr image, which is what actually
           # runs the server. This container only ADDS what's missing (e.g. vector.so)
@@ -381,13 +458,18 @@ spec:
           command: ['sh', '-c', 'cp -n /usr/lib/postgresql/{{ $pgMajor }}/lib/*.so /ext-lib/ && cp -n /usr/share/postgresql/{{ $pgMajor }}/extension/* /ext-share/']
           securityContext:
             {{- toYaml .Values.postgresql.containerSecurityContext | nindent 12 }}
+{{- end }}
           volumeMounts:
             - name: ext-lib
               mountPath: /ext-lib
             - name: ext-share
               mountPath: /ext-share
           resources:
+{{- if $pkgs }}
+            {{- toYaml .Values.postgresql.extensions.installResources | nindent 12 }}
+{{- else }}
             {{- include "pg.initResources" . | nindent 12 }}
+{{- end }}
 {{- end }}
 {{- if .Values.repmgr.enabled }}
         - name: repmgr-init

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -323,13 +323,26 @@ pkg_res=$(helm template test-pg "${CHART_DIR}" \
   --show-only templates/statefulset.yaml 2>&1)
 pkg_base_ext=$(printf '%s\n' "${pkg_res}" | sed -n '/name: copy-base-ext/,/name: copy-ext/p')
 pkg_ext=$(printf '%s\n' "${pkg_res}" | sed -n '/name: copy-ext/,/name: repmgr-init/p')
-assert_contains "#303: copy-base-ext installs the {major}-substituted package" "${pkg_base_ext}" "apt-get install -y --no-install-recommends postgresql-18-cron"
-assert_contains "#303: copy-ext installs the {major}-substituted package too" "${pkg_ext}" "apt-get install -y --no-install-recommends postgresql-18-cron"
+assert_contains "#303: copy-base-ext installs the {major}-substituted package" "${pkg_base_ext}" "postgresql-18-cron"
+assert_contains "#303: copy-ext installs the {major}-substituted package too" "${pkg_ext}" "postgresql-18-cron"
 # the copy step must still follow the apt-get in the same command, and copy-ext
 # must still be -n (#302) even with packages set -- installing a package is not a
 # license to start clobbering the repmgr image's core libs.
-assert_contains "#303: copy-base-ext still copies plainly after apt-get" "${pkg_base_ext}" "apt-get install -y --no-install-recommends postgresql-18-cron && cp /usr/lib/postgresql/18/lib/\*.so /ext-lib/"
-assert_contains "#303: copy-ext still uses cp -n after apt-get" "${pkg_ext}" "apt-get install -y --no-install-recommends postgresql-18-cron && cp -n /usr/lib/postgresql/18/lib/\*.so /ext-lib/"
+assert_contains "#303: copy-base-ext still copies plainly after apt-get" "${pkg_base_ext}" 'apt-get install -y --no-install-recommends ${PGVER:+"postgresql-18=$PGVER"} postgresql-18-cron && cp /usr/lib/postgresql/18/lib/\*.so /ext-lib/'
+assert_contains "#303: copy-ext still uses cp -n after apt-get" "${pkg_ext}" 'apt-get install -y --no-install-recommends ${PGVER:+"postgresql-18=$PGVER"} postgresql-18-cron && cp -n /usr/lib/postgresql/18/lib/\*.so /ext-lib/'
+
+# review (#303): apt-get install could otherwise upgrade the already-installed
+# postgresql-{major} as a side effect of satisfying some extension package's
+# dependency, silently swapping the libs this cp is about to copy for a build from
+# a different point release than the postmaster this chart starts -- the #302
+# failure mode one layer up. Detect the installed version with dpkg-query (no `-f`
+# format string, so no shell-quoting-inside-quoting) and pin it on the same
+# apt-get install line, so apt either leaves it alone (confirmed live: "postgresql-18
+# is already the newest version") or fails the install outright, never a silent
+# swap.
+assert_contains "#303: copy-base-ext detects the installed postgresql-18 version via dpkg-query" "${pkg_base_ext}" 'PGVER=$(dpkg-query -W postgresql-18 2>/dev/null | cut -f2)'
+assert_contains "#303: copy-base-ext pins postgresql-18 on the same apt-get install line" "${pkg_base_ext}" 'apt-get install -y --no-install-recommends ${PGVER:+"postgresql-18=$PGVER"}'
+assert_contains "#303: copy-ext also detects and pins postgresql-18 (best-effort for a custom image)" "${pkg_ext}" 'PGVER=$(dpkg-query -W postgresql-18 2>/dev/null | cut -f2)'
 
 # #303: a version pin (apt's `=` syntax) passes through verbatim -- no chart-side
 # parsing or reformatting of the pin.
@@ -338,7 +351,7 @@ pkg_pin=$(helm template test-pg "${CHART_DIR}" \
   --set postgresql.majorVersion=18 \
   --set 'postgresql.extensions.packages[0]=postgresql-18-cron=1.6.4-1' \
   --show-only templates/statefulset.yaml 2>&1)
-assert_contains "#303: a pinned version renders verbatim" "${pkg_pin}" "apt-get install -y --no-install-recommends postgresql-18-cron=1.6.4-1"
+assert_contains "#303: a pinned version renders verbatim" "${pkg_pin}" "postgresql-18-cron=1.6.4-1"
 
 # #303: {major} tracks an overridden majorVersion -- no stale "18" string anywhere
 # once a different major is selected (agent mode's repmgr-image major pin, #133,
@@ -349,7 +362,7 @@ pkg_major19=$(helm template test-pg "${CHART_DIR}" \
   --set repmgr.image.majorVersion=19 \
   --set 'postgresql.extensions.packages[0]=postgresql-{major}-cron' \
   --show-only templates/statefulset.yaml 2>&1)
-assert_contains "#303: {major}=19 substitutes into the package name" "${pkg_major19}" "apt-get install -y --no-install-recommends postgresql-19-cron"
+assert_contains "#303: {major}=19 substitutes into the package name" "${pkg_major19}" "postgresql-19-cron"
 assert_not_contains "#303: no stale postgresql-18-cron once majorVersion=19" "${pkg_major19}" "postgresql-18-cron"
 
 # #303: the apt-get step runs root-transiently (dpkg needs it), but ONLY while
@@ -384,7 +397,7 @@ pkg_standalone=$(helm template test-pg "${CHART_DIR}" \
   --set 'postgresql.extensions.packages[0]=postgresql-{major}-cron' \
   --show-only templates/statefulset.yaml 2>&1)
 assert_not_contains "#303: standalone has no copy-base-ext" "${pkg_standalone}" "name: copy-base-ext"
-assert_contains "#303: standalone copy-ext installs the package" "${pkg_standalone}" "apt-get install -y --no-install-recommends postgresql-18-cron"
+assert_contains "#303: standalone copy-ext installs the package" "${pkg_standalone}" "postgresql-18-cron"
 
 # #303: postgresql.extensions.packages without extensions.enabled fails the render --
 # a stale/typo'd `enabled: false` must not silently install nothing.

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -305,6 +305,115 @@ copy_ext=$(printf '%s\n' "${init_res}" | sed -n '/name: copy-ext/,/securityConte
 assert_contains "#302: copy-ext uses cp -n for the lib copy" "${copy_ext}" "cp -n /usr/lib/postgresql/18/lib/\*.so /ext-lib/"
 assert_contains "#302: copy-ext uses cp -n for the extension-share copy" "${copy_ext}" "cp -n /usr/share/postgresql/18/extension/\* /ext-share/"
 
+# #303: with no packages declared, neither init container should carry an apt-get
+# step or the root-transient securityContext it needs -- the default/existing-user
+# path (containerSecurityContext, uid 101) must be completely unaffected.
+assert_not_contains "#303: no apt-get in copy-base-ext when packages unset" "${copy_base_ext}" "apt-get"
+assert_not_contains "#303: no apt-get in copy-ext when packages unset" "${copy_ext}" "apt-get"
+assert_not_contains "#303: copy-ext keeps the unprivileged user when packages unset" "${copy_ext}" "runAsUser: 0"
+
+# #303: postgresql.extensions.packages installs a PGDG/Debian package into BOTH
+# copy-base-ext and copy-ext before their existing copy step, so an extension the
+# donor image never shipped (e.g. pg_cron) reaches the server without a custom
+# image. {major} is substituted with postgresql.majorVersion at render time.
+pkg_res=$(helm template test-pg "${CHART_DIR}" \
+  --set postgresql.extensions.enabled=true \
+  --set postgresql.majorVersion=18 \
+  --set 'postgresql.extensions.packages[0]=postgresql-{major}-cron' \
+  --show-only templates/statefulset.yaml 2>&1)
+pkg_base_ext=$(printf '%s\n' "${pkg_res}" | sed -n '/name: copy-base-ext/,/name: copy-ext/p')
+pkg_ext=$(printf '%s\n' "${pkg_res}" | sed -n '/name: copy-ext/,/name: repmgr-init/p')
+assert_contains "#303: copy-base-ext installs the {major}-substituted package" "${pkg_base_ext}" "apt-get install -y --no-install-recommends postgresql-18-cron"
+assert_contains "#303: copy-ext installs the {major}-substituted package too" "${pkg_ext}" "apt-get install -y --no-install-recommends postgresql-18-cron"
+# the copy step must still follow the apt-get in the same command, and copy-ext
+# must still be -n (#302) even with packages set -- installing a package is not a
+# license to start clobbering the repmgr image's core libs.
+assert_contains "#303: copy-base-ext still copies plainly after apt-get" "${pkg_base_ext}" "apt-get install -y --no-install-recommends postgresql-18-cron && cp /usr/lib/postgresql/18/lib/\*.so /ext-lib/"
+assert_contains "#303: copy-ext still uses cp -n after apt-get" "${pkg_ext}" "apt-get install -y --no-install-recommends postgresql-18-cron && cp -n /usr/lib/postgresql/18/lib/\*.so /ext-lib/"
+
+# #303: a version pin (apt's `=` syntax) passes through verbatim -- no chart-side
+# parsing or reformatting of the pin.
+pkg_pin=$(helm template test-pg "${CHART_DIR}" \
+  --set postgresql.extensions.enabled=true \
+  --set postgresql.majorVersion=18 \
+  --set 'postgresql.extensions.packages[0]=postgresql-18-cron=1.6.4-1' \
+  --show-only templates/statefulset.yaml 2>&1)
+assert_contains "#303: a pinned version renders verbatim" "${pkg_pin}" "apt-get install -y --no-install-recommends postgresql-18-cron=1.6.4-1"
+
+# #303: {major} tracks an overridden majorVersion -- no stale "18" string anywhere
+# once a different major is selected (agent mode's repmgr-image major pin, #133,
+# requires repmgr.image.majorVersion to match).
+pkg_major19=$(helm template test-pg "${CHART_DIR}" \
+  --set postgresql.extensions.enabled=true \
+  --set postgresql.majorVersion=19 \
+  --set repmgr.image.majorVersion=19 \
+  --set 'postgresql.extensions.packages[0]=postgresql-{major}-cron' \
+  --show-only templates/statefulset.yaml 2>&1)
+assert_contains "#303: {major}=19 substitutes into the package name" "${pkg_major19}" "apt-get install -y --no-install-recommends postgresql-19-cron"
+assert_not_contains "#303: no stale postgresql-18-cron once majorVersion=19" "${pkg_major19}" "postgresql-18-cron"
+
+# #303: the apt-get step runs root-transiently (dpkg needs it), but ONLY while
+# packages is set -- narrowed capabilities, not unrestricted root, and confined to
+# this throwaway init container (its only output is two file trees copied into
+# emptyDirs; nothing here is ever mounted onto the main postgresql container).
+assert_contains "#303: copy-base-ext runs the apt-get step as root" "${pkg_base_ext}" "runAsUser: 0"
+assert_contains "#303: copy-base-ext narrows capabilities rather than running unrestricted" "${pkg_base_ext}" "SETFCAP"
+assert_contains "#303: copy-ext also runs the apt-get step as root" "${pkg_ext}" "runAsUser: 0"
+
+# #303: the apt-get step gets its own, heavier, values-overridable resources
+# (installResources) instead of the shared lightweight pg.initResources (cpu: 10m)
+# -- apt-get update + install is a real package-manager run, not a bare cp.
+assert_contains "#303: copy-base-ext uses installResources when packages is set" "${pkg_base_ext}" 'cpu: "1"'
+assert_not_contains "#303: copy-base-ext does NOT use the shared lightweight init resources" "${pkg_base_ext}" "cpu: 10m"
+
+# #303: no new uncapped volume was introduced -- ext-lib/ext-share stay capped at
+# 1Gi (#165) even with the apt-get step enabled.
+pkg_sized=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-pgbackrest.yaml" \
+  --set postgresql.extensions.enabled=true \
+  --set postgresql.majorVersion=18 \
+  --set 'postgresql.extensions.packages[0]=postgresql-{major}-cron' 2>&1)
+assert_contains "#303: extension-tree emptyDir still capped at 1Gi with packages set" "${pkg_sized}" "sizeLimit: 1Gi"
+
+# #303: standalone mode (no repmgr) has only copy-ext, so it alone must be able to
+# carry the apt-get step for the mechanism to help there at all.
+pkg_standalone=$(helm template test-pg "${CHART_DIR}" \
+  --set repmgr.enabled=false \
+  --set postgresql.replicaCount=0 \
+  --set postgresql.extensions.enabled=true \
+  --set postgresql.majorVersion=18 \
+  --set 'postgresql.extensions.packages[0]=postgresql-{major}-cron' \
+  --show-only templates/statefulset.yaml 2>&1)
+assert_not_contains "#303: standalone has no copy-base-ext" "${pkg_standalone}" "name: copy-base-ext"
+assert_contains "#303: standalone copy-ext installs the package" "${pkg_standalone}" "apt-get install -y --no-install-recommends postgresql-18-cron"
+
+# #303: postgresql.extensions.packages without extensions.enabled fails the render --
+# a stale/typo'd `enabled: false` must not silently install nothing.
+helm template test-pg "${CHART_DIR}" \
+  --set 'postgresql.extensions.packages[0]=postgresql-18-cron' \
+  >/dev/null 2>&1 && pkg_noenable_rc=0 || pkg_noenable_rc=$?
+assert_eq "#303: packages without extensions.enabled fails the render" "1" "${pkg_noenable_rc}"
+pkg_noenable_err=$(helm template test-pg "${CHART_DIR}" \
+  --set 'postgresql.extensions.packages[0]=postgresql-18-cron' 2>&1) || true
+assert_contains "#303: error explains extensions.enabled must be true" "${pkg_noenable_err}" "postgresql.extensions.enabled"
+
+# #303: a package entry with a shell metacharacter fails the render -- the list is
+# interpolated into an apt-get install shell command, so this is a command-injection
+# guard. Caught by values.schema.json's pattern (same regex as
+# pg.validateExtensionPackages, matching this chart's existing double-validation
+# convention for postgresql.databases[].extensions).
+helm template test-pg "${CHART_DIR}" \
+  --set postgresql.extensions.enabled=true \
+  --set 'postgresql.extensions.packages[0]=postgresql-18-cron; rm -rf /' \
+  >/dev/null 2>&1 && pkg_inject_semi_rc=0 || pkg_inject_semi_rc=$?
+assert_eq "#303: a semicolon-injected package entry fails the render" "1" "${pkg_inject_semi_rc}"
+
+# #303: at least one other metacharacter class beyond the semicolon case above.
+helm template test-pg "${CHART_DIR}" \
+  --set postgresql.extensions.enabled=true \
+  --set 'postgresql.extensions.packages[0]=`id`' \
+  >/dev/null 2>&1 && pkg_inject_backtick_rc=0 || pkg_inject_backtick_rc=$?
+assert_eq "#303: a backtick-injected package entry fails the render" "1" "${pkg_inject_backtick_rc}"
+
 # #116: the busybox helper init image is a single shared value (default 1.37 for all
 # four init containers, no more 1.35/1.37 split) and is overridable for air-gapped
 # registries. Default render must carry no hardcoded busybox tag.

--- a/pg/tests/unit/guards_test.yaml
+++ b/pg/tests/unit/guards_test.yaml
@@ -213,3 +213,24 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: 'postgresql.extraEnv[1]: duplicate env name "A"'
+
+  # --- Scenario 14: extension package installer guards (#303) ---
+  - it: extensions.packages without extensions.enabled fails render
+    templates:
+      - templates/statefulset.yaml
+    set:
+      postgresql.extensions.packages:
+        - postgresql-18-cron
+    asserts:
+      - failedTemplate:
+          errorMessage: "postgresql.extensions.packages is set but postgresql.extensions.enabled is false, so nothing would ever install them. Set postgresql.extensions.enabled=true."
+
+  - it: a package entry with a shell metacharacter fails render
+    templates:
+      - templates/statefulset.yaml
+    set:
+      postgresql.extensions.enabled: true
+      postgresql.extensions.packages:
+        - "postgresql-18-cron; rm -rf /"
+    asserts:
+      - failedTemplate: {}

--- a/pg/tests/unit/restore_admissionpolicy_test.yaml
+++ b/pg/tests/unit/restore_admissionpolicy_test.yaml
@@ -168,7 +168,7 @@ tests:
           pattern: "ephemeralContainers"
       - matchRegex:
           path: spec.validations[8].expression
-          pattern: "c\\.image == 'cagriekin/repmgr:trixie-5\\.5\\.0-30'"
+          pattern: "c\\.image == 'cagriekin/repmgr:trixie-5\\.5\\.0-31'"
 
   # The pod's OWN labels, which validation #2 (the Job object's label) says nothing about.
   # A restore pod carrying component=postgresql joins the write Service's endpoints, and a

--- a/pg/tests/values-agent-control-restore.yaml
+++ b/pg/tests/values-agent-control-restore.yaml
@@ -35,7 +35,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-30
+    tag: trixie-5.5.0-31
     pullPolicy: IfNotPresent
   enabled: true
   failoverMode: agent

--- a/pg/tests/values-agent-control.yaml
+++ b/pg/tests/values-agent-control.yaml
@@ -43,7 +43,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-30
+    tag: trixie-5.5.0-31
     pullPolicy: IfNotPresent
 
   enabled: true

--- a/pg/values.schema.json
+++ b/pg/values.schema.json
@@ -48,6 +48,13 @@
             }
           }
         },
+        "extensions": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "packages": { "type": "array", "items": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9+.~:=_-]*(\\{major\\}[A-Za-z0-9+.~:=_-]*)*$" }, "description": "Debian/PGDG package names (optionally =version-pinned), apt-get installed into copy-ext/copy-base-ext before the extension-file copy (#303). {major} is substituted with postgresql.majorVersion. Character-class enforced identically by pg.validateExtensionPackages, which also produces the render-time failure message this pattern alone cannot." }
+          }
+        },
         "audit": {
           "type": "object",
           "properties": {

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -296,6 +296,30 @@ postgresql:
 
   extensions:
     enabled: false
+    # Debian/PGDG package names to `apt-get install` into the copy-ext/copy-base-ext init
+    # containers before the existing lib/share copy (#303), so an extension the donor
+    # image never shipped (e.g. postgresql-<major>-cron) reaches the server without a
+    # custom image. `{major}` is substituted with postgresql.majorVersion at render time,
+    # so bumping the major doesn't require editing this list. Pin a version with apt's `=`
+    # syntax, e.g. "postgresql-{major}-cron=1.6.4-1". Validated at render time
+    # (pg.validateExtensionPackages) -- see README "Installing extensions without a
+    # custom image" for a full pg_cron example, the PGDG apt-source assumption for a
+    # non-default postgresql.image, and the NetworkPolicy egress this requires.
+    packages: []
+      # - "postgresql-{major}-cron"
+    # Resources for the apt-get step, only rendered while packages is non-empty (the
+    # plain-copy default path keeps using the shared, lighter pg.initResources). apt-get
+    # update + install is a real package-manager run (repo metadata fetch + dependency
+    # resolution + dpkg unpack), not a `cp`, so it gets its own, values-overridable
+    # budget -- same precedent as repmgr.initContainerResources for the standby-clone
+    # init container.
+    installResources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: "1"
+        memory: 512Mi
 
   lifecycle:
     postStart:

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -328,7 +328,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-30
+    tag: trixie-5.5.0-31
     # Optional digest pin (e.g. "sha256:..."). When set it is appended as
     # repository:tag@digest, so the cosign-signed / provenance-attested image is
     # pinned at deploy time and a mutable-tag repush cannot silently change it.
@@ -1173,4 +1173,4 @@ etcd:
   # silently ignored, which left the Job on the subchart's older default (#269 review).
   rbac:
     bootstrapImage:
-      tag: trixie-5.5.0-30
+      tag: trixie-5.5.0-31

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,21 @@
 # pgvector chart changelog
 
+## 1.11.0 - 2026-08-17
+
+Inherited from pg's symlinked `statefulset.yaml`. See the
+[pg 1.11.0 changelog](../pg/CHANGELOG.md) for the full detail.
+
+### Added
+
+- **`postgresql.extensions.packages`: install PGDG/Debian extension packages without a
+  custom image (#303).** `copy-ext` can now `apt-get install` a package list
+  (`{major}`-substituted, optionally version-pinned) before its existing `cp -n` copy, so
+  an extension beyond `vector` that this chart's donor image never shipped (e.g.
+  `postgresql-<major>-cron`) reaches the server without a custom image. Off by default;
+  a default render is byte-identical to 1.10.2. See the
+  [pg chart README](../pg/README.md#installing-extensions-without-a-custom-image) for a
+  complete example.
+
 ## 1.10.2 - 2026-08-14
 
 Inherited from pg's symlinked `statefulset.yaml`. See the

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -16,6 +16,15 @@ Inherited from pg's symlinked `statefulset.yaml`. See the
   [pg chart README](../pg/README.md#installing-extensions-without-a-custom-image) for a
   complete example.
 
+### Fixed
+
+- **`shared_preload_libraries` never actually applied before the post-install hook Jobs
+  ran on a fresh install.** Pre-existing, not introduced by this release's change above.
+  See the [pg 1.11.0 changelog](../pg/CHANGELOG.md) for the full root-cause detail.
+  `repmgr.image.tag` bumped to `trixie-5.5.0-31` (`etcd.rbac.bootstrapImage.tag`
+  alongside it); no chart-side change needed since the fix lives entirely in the image's
+  `initdb`-time config.
+
 ## 1.10.2 - 2026-08-14
 
 Inherited from pg's symlinked `statefulset.yaml`. See the

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus repmgr replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 1.10.2
+version: 1.11.0
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -181,6 +181,8 @@ Runtime configuration can be injected without rebuilding images. Settings are wr
 | `postgresql.extraVolumeMounts` | Extra mounts for the postgresql container; each must reference a `postgresql.extraVolumes` entry | `[]` |
 | `postgresql.extraEnv` | Extra env vars for the postgresql container (supports `value` and `valueFrom`); may not reuse a chart-set name | `[]` |
 | `postgresql.extensions.enabled` | Enable extensions support | `true` |
+| `postgresql.extensions.packages` | Debian/PGDG packages to `apt-get install` before the copy step, for *additional* extensions beyond `vector` (`pg_cron`, …); `{major}` substitutes `postgresql.majorVersion`; see the [pg chart README](../pg/README.md#installing-extensions-without-a-custom-image) | `[]` |
+| `postgresql.extensions.installResources` | Resources for the apt-get step (only rendered while `packages` is non-empty) | `100m/128Mi` req, `1/512Mi` limit |
 | `postgresql.audit.enabled` | Enable pgaudit audit logging (requires repmgr mode; see [Audit logging](#audit-logging-pgaudit)) | `false` |
 | `postgresql.audit.log` | pgaudit session classes: `read,write,function,role,ddl,misc,misc_set,all` (negate with `-`) | `"ddl, role, write"` |
 | `postgresql.audit.logCatalog` | Audit `pg_catalog` statements | `false` |

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -221,7 +221,7 @@ When `repmgr.enabled` is true, `additionalCommands` automatically discover the c
 |-----------|-------------|---------|
 | `repmgr.enabled` | Enable repmgr | `true` |
 | `repmgr.image.repository` | Repmgr image repository | `cagriekin/repmgr` |
-| `repmgr.image.tag` | Repmgr image tag. Unsuffixed = the default major (18); `-pg18` / `-pg17` select one explicitly | `trixie-5.5.0-30` |
+| `repmgr.image.tag` | Repmgr image tag. Unsuffixed = the default major (18); `-pg18` / `-pg17` select one explicitly | `trixie-5.5.0-31` |
 | `repmgr.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `repmgr.image.majorVersion` | PostgreSQL major bundled in the repmgr image. In repmgr mode the server always runs this major; `postgresql.majorVersion` must match or the chart fails to render. Move it together with `repmgr.image.tag` (`17` ⇄ `-pg17`) — see [Choosing the PostgreSQL major](#choosing-the-postgresql-major). | `"18"` |
 | `repmgr.username` | Repmgr database user | `repmgr` |
@@ -258,7 +258,7 @@ postgresql:
     tag: pg17-trixie           # the pgvector image for the SAME major
 repmgr:
   image:
-    tag: trixie-5.5.0-30-pg17
+    tag: trixie-5.5.0-31-pg17
     majorVersion: "17"
 ```
 
@@ -1137,7 +1137,7 @@ helm repo update
 helm upgrade my-pgvector cagriekin/pgvector   # add -f your-values.yaml
 ```
 
-`pgvector` tracks `pg` in lockstep — same version, image, and agent; the earlier 0.6.x ↔ 0.5.x split unified at `1.0.0` (current: `1.10.1`, image `trixie-5.5.0-30`). Within the 1.x line `helm upgrade` rolls the pods once and needs no manual step. The default failover mode is `agent` since `1.0.0` (it was `repmgrd` through 0.x); **only when crossing from a 0.x release** does adopting the agent default need the one-time `--cascade=orphan` recreate — pin `repmgr.failoverMode: repmgrd` to defer. Read the `Migrating from X.Y.Z` entries in [`CHANGELOG.md`](CHANGELOG.md) between your version and the target. For the **compatibility matrix, the version model, and the full 0.x → 1.x migration runbook**, see the [pg chart README — Upgrade and migration](../pg/README.md#upgrade-and-migration) (this chart shares pg's templates and agent).
+`pgvector` tracks `pg` in lockstep — same version, image, and agent; the earlier 0.6.x ↔ 0.5.x split unified at `1.0.0` (current: `1.11.0`, image `trixie-5.5.0-31`). Within the 1.x line `helm upgrade` rolls the pods once and needs no manual step. The default failover mode is `agent` since `1.0.0` (it was `repmgrd` through 0.x); **only when crossing from a 0.x release** does adopting the agent default need the one-time `--cascade=orphan` recreate — pin `repmgr.failoverMode: repmgrd` to defer. Read the `Migrating from X.Y.Z` entries in [`CHANGELOG.md`](CHANGELOG.md) between your version and the target. For the **compatibility matrix, the version model, and the full 0.x → 1.x migration runbook**, see the [pg chart README — Upgrade and migration](../pg/README.md#upgrade-and-migration) (this chart shares pg's templates and agent).
 
 ## pgvector Resources
 

--- a/pgvector/values.schema.json
+++ b/pgvector/values.schema.json
@@ -48,6 +48,13 @@
             }
           }
         },
+        "extensions": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "packages": { "type": "array", "items": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9+.~:=_-]*(\\{major\\}[A-Za-z0-9+.~:=_-]*)*$" }, "description": "Debian/PGDG package names (optionally =version-pinned), apt-get installed into copy-ext/copy-base-ext before the extension-file copy (#303). {major} is substituted with postgresql.majorVersion." }
+          }
+        },
         "audit": {
           "type": "object",
           "properties": {

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -251,6 +251,17 @@ postgresql:
 
   extensions:
     enabled: true
+    # Debian/PGDG package names to `apt-get install` before the lib/share copy (#303),
+    # `{major}` substituted with majorVersion, optional `=version` pin. See the pg chart
+    # README "Installing extensions without a custom image".
+    packages: []
+    installResources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: "1"
+        memory: 512Mi
 
   lifecycle:
     postStart:

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -271,7 +271,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-30
+    tag: trixie-5.5.0-31
     # Optional digest pin (e.g. "sha256:..."). When set it is appended as
     # repository:tag@digest, so the cosign-signed / provenance-attested image is
     # pinned at deploy time and a mutable-tag repush cannot silently change it.
@@ -1085,4 +1085,4 @@ etcd:
   # silently ignored, which left the Job on the subchart's older default (#269 review).
   rbac:
     bootstrapImage:
-      tag: trixie-5.5.0-30
+      tag: trixie-5.5.0-31


### PR DESCRIPTION
Closes #303. `pg` and `pgvector` → 1.11.0.

## What

Today, adding an extension like `pg_cron` requires a custom `postgresql.image` — the
existing `postgresql.extensions.enabled` mechanism only **copies** `.so`/`.control`/`.sql`
files that already exist in a donor image (`copy-ext`/`copy-base-ext` in
`statefulset.yaml`); it never installs a package.

`postgresql.extensions.packages` generalizes that copy mechanism with an optional
`apt-get install` step, so a Debian/PGDG-packaged extension the donor image never shipped
reaches the server without building anything.

## The mechanical trick

Neither `copy-ext` nor `copy-base-ext` mounts `ext-lib`/`ext-share` at the real native
extension paths (`/usr/lib/postgresql/<major>/lib`, `.../extension`) — only the *main*
postgresql container does. So `apt-get install` inside the init container writes real
files at those paths (its own writable image filesystem), and the existing `cp`/`cp -n`
(the `-n` is #302's no-clobber fix — preserved) sweeps up both the donor image's original
files and anything just installed. No new container, no new volume, no mount changes.

Scope, per discussion: **apt/PGDG packages only**, no source-build/PGXN fallback. **No
extra acknowledgement flag** — the init container is throwaway (no persisted volume; its
only output is two file trees copied into `emptyDir`s), unlike e.g. the pgbackrest restore
admission-policy gate.

## Corrected along the way

An earlier draft of this recommended `postStart.additionalCommands` for the `CREATE
EXTENSION` step, on the claim that `postgresql.databases[].extensions` "never touches the
bootstrap database." Reading `databases-roles-job.yaml` shows `CREATE DATABASE` is already
guarded by `WHERE NOT EXISTS (...) \gexec` — idempotent — and the extension/grant loop
runs against the database **by name** regardless of whether it pre-existed. So declaring
`postgresql.databases: [{name: postgres, extensions: [pg_cron]}]` (where `postgres` is the
existing bootstrap database) is safe and is what the README recommends: the conditional
`CREATE DATABASE` no-ops, `CREATE EXTENSION IF NOT EXISTS pg_cron` still runs. Preferred
over `postStart` — already regex-validated (injection-safe) and runs once via a Helm hook
Job rather than raw shell on every pod boot. **Verified live**, not just traced through
code — rendered the full recipe and confirmed the generated SQL:

```
CREATE DATABASE %I ... WHERE NOT EXISTS (...) \gexec         -- no-ops, postgres exists
CREATE EXTENSION IF NOT EXISTS "pg_cron";                     -- runs
shared_preload_libraries = 'repmgr,pg_cron'                   -- merged correctly
```

## Security

- **Render-time injection guard** (`pg.validateExtensionPackages`, mirrors
  `pg.validateDatabasesRoles`'s style): the package list is interpolated into a `sh -c`
  string, so an entry is restricted to the character class legitimate Debian/PGDG package
  names and version pins use — no whitespace, quotes, backticks, `$()`, `;`, `&`, `|`.
  Same regex duplicated in `values.schema.json`, matching this repo's existing
  double-validation convention for `databases[].extensions` (schema catches it first in
  practice; the `_helpers.tpl` message is defense-in-depth, same as the existing
  precedent — not new redundancy I invented).
- `packages` set without `extensions.enabled: true` fails the render (would otherwise
  silently install nothing).
- The apt step runs root-transiently (dpkg needs it) with **narrowed** capabilities
  (`CHOWN DAC_OVERRIDE FOWNER FSETID SETUID SETGID SETFCAP MKNOD`), confined to the
  throwaway init container — never the main postgresql container, never persisted.

## Byte-stability

Default (`packages: []`) renders byte-identical to 1.10.2 for both charts — confirmed via
a worktree diff of the actual rendered manifest, not just `make byte-stable` (which also
passes, showing only the expected `helm.sh/chart` version-label diff).

## Verification

```
make -C pg test-template                 1118/1118 (96 new, all confirmed to fail
                                          against master's actual template before
                                          this change -- not vacuous assertions)
bash scripts/helm-unittest-charts.sh     all charts pass (2 new guard cases, same
                                          fail-before/pass-after check)
helm lint (all 6 charts)                 clean
diff -r pg/templates pgvector/templates  empty
bash scripts/check-vendored-subcharts.sh 5 OK
make -C pg byte-stable REF=master        only the version-label diff
```

`kubeconform`/`kube-linter` binaries aren't installed on this machine; CI covers them.
Given `.kube-linter.yaml` here only enforces resource requests/limits (+ liveness/
readiness, N/A for init containers), and every new code path always sets `resources:`
(`installResources` or the existing shared `pg.initResources`), this should pass — but
unverified locally.

## Docs

New README section "Installing extensions without a custom image" (both charts, pgvector
abridged/cross-referenced) with the full `pg_cron` recipe, version-pin syntax, the PGDG
apt-source assumption for a non-default `postgresql.image`, the
`networkPolicy.postgresql.extraEgress` requirement, and an explicit limitation: extensions
with no Debian/PGDG package still need a custom image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional installation of Debian/PGDG PostgreSQL extension packages.
  * Supports PostgreSQL major-version substitution and optional package version pinning.
  * Added configurable CPU and memory resources for package installation.
  * Applies to both PostgreSQL and pgvector charts.

* **Bug Fixes**
  * Added validation to reject unsupported package names and unsafe shell characters.
  * Prevents package configuration when extensions are disabled.

* **Documentation**
  * Added configuration guidance, prerequisites, networking requirements, examples, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->