### PR TITLE
feat(pg,pgvector): pg_wal disk-usage metric and WAL alert rules (#305)

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -27,6 +27,15 @@
     alert until now) and the new `PGWALSizeHigh` to configurable thresholds
     (`staleArchiveSeconds`, `walSizeBytesThreshold`).
 
+  **Review follow-up:** the `for` durations (`archiveFailingFor`/`archiveStaleFor`/
+  `sizeHighFor`, defaulting to `5m`/`15m`/`15m`) are now values-overridable rather than
+  hardcoded, so a small `postgresql.persistence.size` can page sooner than the default
+  15m backstop; the `pg_wal_size_file_count` description was corrected (it also counts
+  `.partial`/`.history`/`.backup` files, not just segments); and the README/values now
+  call out that `prometheusRule.enabled` alone is a no-op without
+  `serviceMonitor.enabled` (or an equivalent scrape) actually feeding the exporter's
+  metrics to Prometheus.
+
 ## 1.11.0 - 2026-08-17
 
 ### Added

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,32 @@
 # pg chart changelog
 
+## 1.12.0 - 2026-08-18
+
+### Added
+
+- **`prometheusExporter.prometheusRule`: alert on stuck WAL archiving and pg_wal disk
+  usage (#305).** When `archive_command` gets stuck (pgBackRest repository unreachable
+  or full), PostgreSQL correctly refuses to recycle un-archived WAL, and nothing
+  previously surfaced that growth before it filled the shared PGDATA/`pg_wal` volume.
+  This is an **observability-only** fix -- it does not throttle writes or take any
+  automatic corrective action when a threshold is crossed; that remains a separate,
+  larger change to the Go failover agent's reconcile loop, deliberately out of scope
+  here (see README ["WAL Disk Usage"](README.md#wal-disk-usage-305) for the full
+  reasoning).
+
+  Two pieces:
+  - A new, ungated `pg_wal_size` exporter query group (`pg_wal_size_bytes`,
+    `pg_wal_size_file_count` via `pg_ls_waldir()`) reporting actual `pg_wal` bytes on
+    disk, regardless of *why* WAL is being retained -- unlike the existing
+    `pg_wal_archive` counters (which only exist when `pgbackrest.enabled` and only
+    reflect archive attempt/failure counts, not disk usage). No new grant needed:
+    `pg_ls_waldir()` has been part of the `pg_monitor` role since PG10.
+  - `prometheusExporter.prometheusRule.enabled` (default `false`) ships a
+    `PrometheusRule` wiring `PGWALArchiveFailing`/`PGWALArchiveStale` (the existing
+    `pg_wal_archive_*` metrics from #30, collected since 1.x but never wired to an
+    alert until now) and the new `PGWALSizeHigh` to configurable thresholds
+    (`staleArchiveSeconds`, `walSizeBytesThreshold`).
+
 ## 1.11.0 - 2026-08-17
 
 ### Added

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -14,27 +14,27 @@
   here (see README ["WAL Disk Usage"](README.md#wal-disk-usage-305) for the full
   reasoning).
 
-  Two pieces:
-  - A new, ungated `pg_wal_size` exporter query group (`pg_wal_size_bytes`,
-    `pg_wal_size_file_count` via `pg_ls_waldir()`) reporting actual `pg_wal` bytes on
-    disk, regardless of *why* WAL is being retained -- unlike the existing
-    `pg_wal_archive` counters (which only exist when `pgbackrest.enabled` and only
-    reflect archive attempt/failure counts, not disk usage). No new grant needed:
-    `pg_ls_waldir()` has been part of the `pg_monitor` role since PG10.
-  - `prometheusExporter.prometheusRule.enabled` (default `false`) ships a
-    `PrometheusRule` wiring `PGWALArchiveFailing`/`PGWALArchiveStale` (the existing
-    `pg_wal_archive_*` metrics from #30, collected since 1.x but never wired to an
-    alert until now) and the new `PGWALSizeHigh` to configurable thresholds
-    (`staleArchiveSeconds`, `walSizeBytesThreshold`).
+  `prometheusExporter.prometheusRule.enabled` (default `false`) ships a `PrometheusRule`
+  wiring `PGWALArchiveFailing`/`PGWALArchiveStale` (the existing `pg_wal_archive_*`
+  metrics from #30, collected since 1.x but never wired to an alert until now) and
+  `PGWALSizeHigh` (`pg_wal_size_bytes`, the exporter's own **built-in** `wal` collector --
+  see below) to configurable thresholds (`staleArchiveSeconds`, `walSizeBytesThreshold`)
+  and `for` durations (`archiveFailingFor`/`archiveStaleFor`/`sizeHighFor`).
 
-  **Review follow-up:** the `for` durations (`archiveFailingFor`/`archiveStaleFor`/
-  `sizeHighFor`, defaulting to `5m`/`15m`/`15m`) are now values-overridable rather than
-  hardcoded, so a small `postgresql.persistence.size` can page sooner than the default
-  15m backstop; the `pg_wal_size_file_count` description was corrected (it also counts
-  `.partial`/`.history`/`.backup` files, not just segments); and the README/values now
-  call out that `prometheusRule.enabled` alone is a no-op without
-  `serviceMonitor.enabled` (or an equivalent scrape) actually feeding the exporter's
-  metrics to Prometheus.
+  **No new metric was added.** The original version of this change defined a chart-side
+  `pg_wal_size` query group to report `pg_wal` disk usage. Live-testing against the
+  actual shipped exporter image (`quay.io/prometheuscommunity/postgres-exporter:v0.19.1`)
+  before merge caught that its `pg_wal_size_bytes` name collides with a metric the
+  exporter's own built-in `wal` collector already emits (enabled by default) under the
+  same name but different help text -- Prometheus client libraries reject that as a
+  duplicate-metric registration, which fails the **entire** `/metrics` scrape, not just
+  the new metric. The chart-defined query was deleted; `PGWALSizeHigh` alerts on the
+  exporter's pre-existing `pg_wal_size_bytes` directly, so this ships with no new query
+  and no new `pg_monitor` grant dependency.
+
+  **Also from review:** the README/values now call out that `prometheusRule.enabled`
+  alone is a no-op without `serviceMonitor.enabled` (or an equivalent scrape) actually
+  feeding the exporter's metrics to Prometheus.
 
 ## 1.11.0 - 2026-08-17
 

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with repmgr replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 1.11.0
+version: 1.12.0
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/README.md
+++ b/pg/README.md
@@ -1444,21 +1444,21 @@ Unlike the counters above, `pg_wal_size` reflects actual bytes on disk regardles
 | Metric | Description |
 |--------|-------------|
 | `pg_wal_size_bytes` | Total bytes currently used by `pg_wal` on disk |
-| `pg_wal_size_file_count` | Number of WAL segment files currently in `pg_wal` |
+| `pg_wal_size_file_count` | Number of files currently in `pg_wal` (segments plus `.partial`/`.history`/`.backup` entries) |
 
 `pg_wal` shares the single PGDATA volume (`postgresql.persistence.size`) — there is no separate WAL volume/tablespace. If `archive_command` gets stuck (repository unreachable or full), PostgreSQL correctly refuses to recycle un-archived WAL, and `pg_wal_size_bytes` will climb without bound until the volume fills and the instance stops accepting writes. **This chart ships observability for that condition only** — a shipped alert (below) so you can page and act manually — not an automatic write-throttle or backpressure mechanism. Bounding the *action*, not just visibility into the problem, is tracked as a follow-up.
 
 ### WAL Alert Rules
 
-Set `prometheusExporter.prometheusRule.enabled: true` to ship a `PrometheusRule` (requires the Prometheus Operator CRDs) wiring the metrics above to alerts:
+Set `prometheusExporter.prometheusRule.enabled: true` to ship a `PrometheusRule` (requires the Prometheus Operator CRDs) wiring the metrics above to alerts. **This is a no-op unless something actually scrapes the exporter** — the rule alerts on metrics the exporter emits, so it does nothing on its own; enable `prometheusExporter.serviceMonitor.enabled` too (or point your own scrape config at it) or the alerts will simply never fire.
 
 | Alert | Condition | Requires |
 |-------|-----------|----------|
-| `PGWALArchiveFailing` | `rate(pg_wal_archive_failed_count[5m]) > 0` for 5m | `pgbackrest.enabled` |
-| `PGWALArchiveStale` | `pg_wal_archive_seconds_since_last_archived > prometheusExporter.prometheusRule.staleArchiveSeconds` for 15m | `pgbackrest.enabled` |
-| `PGWALSizeHigh` | `pg_wal_size_bytes > prometheusExporter.prometheusRule.walSizeBytesThreshold` for 15m | — |
+| `PGWALArchiveFailing` | `rate(pg_wal_archive_failed_count[5m]) > 0` for `archiveFailingFor` (default `5m`) | `pgbackrest.enabled` |
+| `PGWALArchiveStale` | `pg_wal_archive_seconds_since_last_archived > staleArchiveSeconds` for `archiveStaleFor` (default `15m`) | `pgbackrest.enabled` |
+| `PGWALSizeHigh` | `pg_wal_size_bytes > walSizeBytesThreshold` for `sizeHighFor` (default `15m`) | — |
 
-`PGWALArchiveFailing` is the most actionable of the three — it fires as soon as `archive-push` starts failing, before any WAL has had time to accumulate. `PGWALArchiveStale` and `PGWALSizeHigh` are backstops with the same idle-primary caveat as the metrics they read; tune `staleArchiveSeconds`/`walSizeBytesThreshold` to your WAL generation rate and `postgresql.persistence.size` headroom.
+`PGWALArchiveFailing` is the most actionable of the three — it fires as soon as `archive-push` starts failing, before any WAL has had time to accumulate. `PGWALArchiveStale` and `PGWALSizeHigh` are backstops with the same idle-primary caveat as the metrics they read; tune `staleArchiveSeconds`/`walSizeBytesThreshold` to your WAL generation rate and `postgresql.persistence.size` headroom, and tighten the `*For` durations (Prometheus duration syntax) if that volume is small enough that 15m is too long to wait before paging.
 
 ### Exporter Parameters
 
@@ -1497,6 +1497,9 @@ Set `prometheusExporter.prometheusRule.enabled: true` to ship a `PrometheusRule`
 | `prometheusExporter.prometheusRule.additionalLabels` | Additional labels on PrometheusRule | `{}` |
 | `prometheusExporter.prometheusRule.staleArchiveSeconds` | `PGWALArchiveStale` threshold, in seconds | `900` |
 | `prometheusExporter.prometheusRule.walSizeBytesThreshold` | `PGWALSizeHigh` threshold, in bytes | `5368709120` (5Gi) |
+| `prometheusExporter.prometheusRule.archiveFailingFor` | `PGWALArchiveFailing` `for` duration | `5m` |
+| `prometheusExporter.prometheusRule.archiveStaleFor` | `PGWALArchiveStale` `for` duration | `15m` |
+| `prometheusExporter.prometheusRule.sizeHighFor` | `PGWALSizeHigh` `for` duration | `15m` |
 
 ## Backup
 

--- a/pg/README.md
+++ b/pg/README.md
@@ -1437,6 +1437,29 @@ When pgBackRest is enabled, the exporter adds a `pg_wal_archive` query group fro
 
 Alert on `rate(pg_wal_archive_failed_count[5m]) > 0` to catch a failing `archive_command` — this is the actionable signal. `pg_wal_archive_seconds_since_last_archived` also grows on an idle primary that has no WAL to archive, so alert on it only in conjunction with a WAL-generation signal (e.g. it rising while `pg_wal_archive_archived_count` stays flat), not on its own.
 
+### WAL Disk Usage (#305)
+
+Unlike the counters above, `pg_wal_size` reflects actual bytes on disk regardless of *why* WAL is being retained — a stuck `archive_command`, a lagging replication slot, or a slow standby — so it is emitted on every instance, not gated on `pgbackrest.enabled`:
+
+| Metric | Description |
+|--------|-------------|
+| `pg_wal_size_bytes` | Total bytes currently used by `pg_wal` on disk |
+| `pg_wal_size_file_count` | Number of WAL segment files currently in `pg_wal` |
+
+`pg_wal` shares the single PGDATA volume (`postgresql.persistence.size`) — there is no separate WAL volume/tablespace. If `archive_command` gets stuck (repository unreachable or full), PostgreSQL correctly refuses to recycle un-archived WAL, and `pg_wal_size_bytes` will climb without bound until the volume fills and the instance stops accepting writes. **This chart ships observability for that condition only** — a shipped alert (below) so you can page and act manually — not an automatic write-throttle or backpressure mechanism. Bounding the *action*, not just visibility into the problem, is tracked as a follow-up.
+
+### WAL Alert Rules
+
+Set `prometheusExporter.prometheusRule.enabled: true` to ship a `PrometheusRule` (requires the Prometheus Operator CRDs) wiring the metrics above to alerts:
+
+| Alert | Condition | Requires |
+|-------|-----------|----------|
+| `PGWALArchiveFailing` | `rate(pg_wal_archive_failed_count[5m]) > 0` for 5m | `pgbackrest.enabled` |
+| `PGWALArchiveStale` | `pg_wal_archive_seconds_since_last_archived > prometheusExporter.prometheusRule.staleArchiveSeconds` for 15m | `pgbackrest.enabled` |
+| `PGWALSizeHigh` | `pg_wal_size_bytes > prometheusExporter.prometheusRule.walSizeBytesThreshold` for 15m | — |
+
+`PGWALArchiveFailing` is the most actionable of the three — it fires as soon as `archive-push` starts failing, before any WAL has had time to accumulate. `PGWALArchiveStale` and `PGWALSizeHigh` are backstops with the same idle-primary caveat as the metrics they read; tune `staleArchiveSeconds`/`walSizeBytesThreshold` to your WAL generation rate and `postgresql.persistence.size` headroom.
+
 ### Exporter Parameters
 
 | Parameter | Description | Default |
@@ -1470,6 +1493,10 @@ Alert on `rate(pg_wal_archive_failed_count[5m]) > 0` to catch a failing `archive
 | `prometheusExporter.serviceMonitor.interval` | Scrape interval | `30s` |
 | `prometheusExporter.serviceMonitor.scrapeTimeout` | Scrape timeout | `10s` |
 | `prometheusExporter.serviceMonitor.additionalLabels` | Additional labels on ServiceMonitor | `{}` |
+| `prometheusExporter.prometheusRule.enabled` | Ship the `PrometheusRule` covering the WAL alerts above (#305) | `false` |
+| `prometheusExporter.prometheusRule.additionalLabels` | Additional labels on PrometheusRule | `{}` |
+| `prometheusExporter.prometheusRule.staleArchiveSeconds` | `PGWALArchiveStale` threshold, in seconds | `900` |
+| `prometheusExporter.prometheusRule.walSizeBytesThreshold` | `PGWALSizeHigh` threshold, in bytes | `5368709120` (5Gi) |
 
 ## Backup
 

--- a/pg/README.md
+++ b/pg/README.md
@@ -1439,12 +1439,14 @@ Alert on `rate(pg_wal_archive_failed_count[5m]) > 0` to catch a failing `archive
 
 ### WAL Disk Usage (#305)
 
-Unlike the counters above, `pg_wal_size` reflects actual bytes on disk regardless of *why* WAL is being retained — a stuck `archive_command`, a lagging replication slot, or a slow standby — so it is emitted on every instance, not gated on `pgbackrest.enabled`:
+Unlike the counters above, `pg_wal_size_bytes` reflects actual bytes on disk regardless of *why* WAL is being retained — a stuck `archive_command`, a lagging replication slot, or a slow standby. It comes from the exporter's own **built-in** `wal` collector (enabled by default in `quay.io/prometheuscommunity/postgres-exporter`, not a chart-defined query), so it is emitted on every instance without any chart configuration, regardless of `pgbackrest.enabled`:
 
 | Metric | Description |
 |--------|-------------|
 | `pg_wal_size_bytes` | Total bytes currently used by `pg_wal` on disk |
-| `pg_wal_size_file_count` | Number of files currently in `pg_wal` (segments plus `.partial`/`.history`/`.backup` entries) |
+| `pg_wal_segments` | Number of WAL segments currently in `pg_wal` |
+
+> **Why isn't this a chart-defined query group like the others?** It was, briefly — and it broke the exporter. A custom query naming its metric `pg_wal_size_bytes` collided with the exporter's built-in metric of the exact same name but different help text; Prometheus client libraries reject that as a duplicate-metric registration, which fails the **entire** `/metrics` scrape, not just the new metric. Confirmed live against the shipped `v0.19.1` image before this was caught. The fix was to delete the chart-defined query and alert on the metric the exporter already produces.
 
 `pg_wal` shares the single PGDATA volume (`postgresql.persistence.size`) — there is no separate WAL volume/tablespace. If `archive_command` gets stuck (repository unreachable or full), PostgreSQL correctly refuses to recycle un-archived WAL, and `pg_wal_size_bytes` will climb without bound until the volume fills and the instance stops accepting writes. **This chart ships observability for that condition only** — a shipped alert (below) so you can page and act manually — not an automatic write-throttle or backpressure mechanism. Bounding the *action*, not just visibility into the problem, is tracked as a follow-up.
 

--- a/pg/templates/prometheus-exporter-configmap.yaml
+++ b/pg/templates/prometheus-exporter-configmap.yaml
@@ -32,6 +32,10 @@ data:
     # pg_replication_lag_seconds and pg_replication_is_replica; reusing the
     # pg_replication namespace makes the Prometheus registry reject every
     # scrape with a help-text mismatch, so the extra metrics get their own.
+    #
+    # #305: don't add a pg_wal_size query group -- the exporter's built-in `wal`
+    # collector already emits pg_wal_size_bytes/pg_wal_segments, and a
+    # chart-defined metric of the same name collides the same way.
     pg_wal_replication:
       # The receive/replay LSN functions return NULL on a primary; COALESCE
       # keeps the metric emitted without errors.
@@ -47,23 +51,6 @@ data:
         - receive_replay_lag_bytes:
             usage: "GAUGE"
             description: "Bytes of WAL received from the primary but not yet replayed; 0 on the primary"
-    # Actual pg_wal disk usage (#305). Unlike pg_wal_archive below (archive
-    # attempt counters), this reflects real bytes on disk regardless of *why*
-    # WAL is being retained -- stuck archive_command, a lagging replication
-    # slot, or a slow standby -- so it is not gated on pgbackrest.enabled.
-    # pg_ls_waldir() has been grantable to pg_monitor since PG10 (see the
-    # pg_monitor role grant, #28), and works identically in recovery.
-    pg_wal_size:
-      query: |
-        SELECT COALESCE(SUM(size), 0) AS bytes, COUNT(*) AS file_count
-        FROM pg_ls_waldir()
-      metrics:
-        - bytes:
-            usage: "GAUGE"
-            description: "Total bytes currently used by pg_wal on disk"
-        - file_count:
-            usage: "GAUGE"
-            description: "Number of files currently in pg_wal (segments plus .partial/.history/.backup entries)"
 {{- if .Values.pgbackrest.enabled }}
     # WAL archiving health (#30). archive_mode is on only when pgBackRest is
     # enabled, so this group is gated on it and scraped on the primary (archiving

--- a/pg/templates/prometheus-exporter-configmap.yaml
+++ b/pg/templates/prometheus-exporter-configmap.yaml
@@ -63,7 +63,7 @@ data:
             description: "Total bytes currently used by pg_wal on disk"
         - file_count:
             usage: "GAUGE"
-            description: "Number of WAL segment files currently in pg_wal"
+            description: "Number of files currently in pg_wal (segments plus .partial/.history/.backup entries)"
 {{- if .Values.pgbackrest.enabled }}
     # WAL archiving health (#30). archive_mode is on only when pgBackRest is
     # enabled, so this group is gated on it and scraped on the primary (archiving

--- a/pg/templates/prometheus-exporter-configmap.yaml
+++ b/pg/templates/prometheus-exporter-configmap.yaml
@@ -47,6 +47,23 @@ data:
         - receive_replay_lag_bytes:
             usage: "GAUGE"
             description: "Bytes of WAL received from the primary but not yet replayed; 0 on the primary"
+    # Actual pg_wal disk usage (#305). Unlike pg_wal_archive below (archive
+    # attempt counters), this reflects real bytes on disk regardless of *why*
+    # WAL is being retained -- stuck archive_command, a lagging replication
+    # slot, or a slow standby -- so it is not gated on pgbackrest.enabled.
+    # pg_ls_waldir() has been grantable to pg_monitor since PG10 (see the
+    # pg_monitor role grant, #28), and works identically in recovery.
+    pg_wal_size:
+      query: |
+        SELECT COALESCE(SUM(size), 0) AS bytes, COUNT(*) AS file_count
+        FROM pg_ls_waldir()
+      metrics:
+        - bytes:
+            usage: "GAUGE"
+            description: "Total bytes currently used by pg_wal on disk"
+        - file_count:
+            usage: "GAUGE"
+            description: "Number of WAL segment files currently in pg_wal"
 {{- if .Values.pgbackrest.enabled }}
     # WAL archiving health (#30). archive_mode is on only when pgBackRest is
     # enabled, so this group is gated on it and scraped on the primary (archiving

--- a/pg/templates/prometheus-exporter-prometheusrule.yaml
+++ b/pg/templates/prometheus-exporter-prometheusrule.yaml
@@ -1,12 +1,14 @@
 {{- if and .Values.prometheusExporter.enabled (dig "prometheusRule" "enabled" false (.Values.prometheusExporter | default dict)) }}
 {{- /*
 Alert rules over the postgres-exporter's WAL metrics (#305): archive_command
-failures/staleness (pg_wal_archive, already collected but never wired to an
-alert) and actual pg_wal disk usage (pg_wal_size, new). This is observability
-only -- there is no automatic write-throttle or backpressure if a threshold is
-crossed; see the README "WAL Archiving Metrics" section for that scoping
-decision. Requires the Prometheus Operator CRDs (same as
-prometheusExporter.serviceMonitor).
+failures/staleness (pg_wal_archive_*, a chart-defined query group collected
+since #30 but never wired to an alert) and actual pg_wal disk usage
+(pg_wal_size_bytes, the exporter's own built-in `wal` collector -- see the
+queries.yaml comment for why this chart does NOT define that metric itself).
+This is observability only -- there is no automatic write-throttle or
+backpressure if a threshold is crossed; see the README "WAL Disk Usage"
+section for that scoping decision. Requires the Prometheus Operator CRDs
+(same as prometheusExporter.serviceMonitor).
 */}}
 {{- $m := printf "namespace=%q,service=%q" .Release.Namespace (printf "%s-postgres-exporter" (include "pg.fullname" .)) }}
 apiVersion: monitoring.coreos.com/v1
@@ -46,8 +48,10 @@ spec:
             summary: "WAL archiving stale ({{ include "pg.fullname" . }})"
             description: "No successful WAL archive in over {{ .Values.prometheusExporter.prometheusRule.staleArchiveSeconds }}s. This also rises on an idle primary with no WAL to archive -- cross-check against pg_wal_size_bytes or WAL generation before paging on this alone."
 {{- end }}
-        # pg_wal_size_bytes is ungated (also useful for a lagging replication
-        # slot pinning WAL with pgbackrest disabled).
+        # pg_wal_size_bytes comes from the exporter's built-in `wal` collector
+        # (enabled by default, no chart-side query), so it is ungated -- also
+        # useful for a lagging replication slot pinning WAL with pgbackrest
+        # disabled.
         - alert: PGWALSizeHigh
           expr: pg_wal_size_bytes{ {{ $m }} } > {{ .Values.prometheusExporter.prometheusRule.walSizeBytesThreshold | int64 }}
           for: {{ .Values.prometheusExporter.prometheusRule.sizeHighFor }}

--- a/pg/templates/prometheus-exporter-prometheusrule.yaml
+++ b/pg/templates/prometheus-exporter-prometheusrule.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.prometheusExporter.enabled (dig "prometheusRule" "enabled" false (.Values.prometheusExporter | default dict)) }}
+{{- /*
+Alert rules over the postgres-exporter's WAL metrics (#305): archive_command
+failures/staleness (pg_wal_archive, already collected but never wired to an
+alert) and actual pg_wal disk usage (pg_wal_size, new). This is observability
+only -- there is no automatic write-throttle or backpressure if a threshold is
+crossed; see the README "WAL Archiving Metrics" section for that scoping
+decision. Requires the Prometheus Operator CRDs (same as
+prometheusExporter.serviceMonitor).
+*/}}
+{{- $m := printf "namespace=%q,service=%q" .Release.Namespace (printf "%s-postgres-exporter" (include "pg.fullname" .)) }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "pg.fullname" . }}-postgres-exporter
+  labels:
+    {{- include "pg.labels" . | nindent 4 }}
+    {{- with .Values.prometheusExporter.prometheusRule.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with (include "pg.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  groups:
+    - name: {{ include "pg.fullname" . }}-postgres-exporter
+      rules:
+{{- if .Values.pgbackrest.enabled }}
+        # pg_wal_archive_* only exists when pgbackrest.enabled (archive_mode is
+        # on only then) -- see prometheus-exporter-configmap.yaml.
+        - alert: PGWALArchiveFailing
+          expr: rate(pg_wal_archive_failed_count{ {{ $m }} }[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "archive_command failing ({{ include "pg.fullname" . }})"
+            description: "pg_wal_archive_failed_count has been increasing for 5m -- pgBackRest's archive-push is failing (repo unreachable, full, or misconfigured). WAL will accumulate on the primary until this is fixed (#305)."
+        - alert: PGWALArchiveStale
+          expr: pg_wal_archive_seconds_since_last_archived{ {{ $m }} } > {{ .Values.prometheusExporter.prometheusRule.staleArchiveSeconds }}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "WAL archiving stale ({{ include "pg.fullname" . }})"
+            description: "No successful WAL archive in over {{ .Values.prometheusExporter.prometheusRule.staleArchiveSeconds }}s. This also rises on an idle primary with no WAL to archive -- cross-check against pg_wal_size_bytes or WAL generation before paging on this alone."
+{{- end }}
+        # pg_wal_size_bytes is ungated (also useful for a lagging replication
+        # slot pinning WAL with pgbackrest disabled).
+        - alert: PGWALSizeHigh
+          expr: pg_wal_size_bytes{ {{ $m }} } > {{ .Values.prometheusExporter.prometheusRule.walSizeBytesThreshold | int64 }}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "pg_wal disk usage high ({{ include "pg.fullname" . }})"
+            description: "pg_wal has held more than {{ .Values.prometheusExporter.prometheusRule.walSizeBytesThreshold | int64 }} bytes for 15m. pg_wal shares the PGDATA volume (postgresql.persistence.size) -- unbounded growth here (stuck archive_command, a lagging replication slot) will eventually fill it and stop writes."
+{{- end }}

--- a/pg/templates/prometheus-exporter-prometheusrule.yaml
+++ b/pg/templates/prometheus-exporter-prometheusrule.yaml
@@ -31,15 +31,15 @@ spec:
         # on only then) -- see prometheus-exporter-configmap.yaml.
         - alert: PGWALArchiveFailing
           expr: rate(pg_wal_archive_failed_count{ {{ $m }} }[5m]) > 0
-          for: 5m
+          for: {{ .Values.prometheusExporter.prometheusRule.archiveFailingFor }}
           labels:
             severity: warning
           annotations:
             summary: "archive_command failing ({{ include "pg.fullname" . }})"
-            description: "pg_wal_archive_failed_count has been increasing for 5m -- pgBackRest's archive-push is failing (repo unreachable, full, or misconfigured). WAL will accumulate on the primary until this is fixed (#305)."
+            description: "pg_wal_archive_failed_count has been increasing for {{ .Values.prometheusExporter.prometheusRule.archiveFailingFor }} -- pgBackRest's archive-push is failing (repo unreachable, full, or misconfigured). WAL will accumulate on the primary until this is fixed (#305)."
         - alert: PGWALArchiveStale
           expr: pg_wal_archive_seconds_since_last_archived{ {{ $m }} } > {{ .Values.prometheusExporter.prometheusRule.staleArchiveSeconds }}
-          for: 15m
+          for: {{ .Values.prometheusExporter.prometheusRule.archiveStaleFor }}
           labels:
             severity: warning
           annotations:
@@ -50,10 +50,10 @@ spec:
         # slot pinning WAL with pgbackrest disabled).
         - alert: PGWALSizeHigh
           expr: pg_wal_size_bytes{ {{ $m }} } > {{ .Values.prometheusExporter.prometheusRule.walSizeBytesThreshold | int64 }}
-          for: 15m
+          for: {{ .Values.prometheusExporter.prometheusRule.sizeHighFor }}
           labels:
             severity: warning
           annotations:
             summary: "pg_wal disk usage high ({{ include "pg.fullname" . }})"
-            description: "pg_wal has held more than {{ .Values.prometheusExporter.prometheusRule.walSizeBytesThreshold | int64 }} bytes for 15m. pg_wal shares the PGDATA volume (postgresql.persistence.size) -- unbounded growth here (stuck archive_command, a lagging replication slot) will eventually fill it and stop writes."
+            description: "pg_wal has held more than {{ .Values.prometheusExporter.prometheusRule.walSizeBytesThreshold | int64 }} bytes for {{ .Values.prometheusExporter.prometheusRule.sizeHighFor }}. pg_wal shares the PGDATA volume (postgresql.persistence.size) -- unbounded growth here (stuck archive_command, a lagging replication slot) will eventually fill it and stop writes."
 {{- end }}

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -2502,8 +2502,16 @@ assert_not_contains "exporter cm: no collision with built-in pg_replication grou
 assert_contains "exporter cm: in_recovery gauge present" "${exporter_cm}" "pg_is_in_recovery()::int AS in_recovery"
 assert_contains "exporter cm: receive/replay byte lag NULL-safe on primaries" "${exporter_cm}" "COALESCE(pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn()), 0)"
 assert_contains "exporter cm: byte lag metric declared" "${exporter_cm}" "receive_replay_lag_bytes:"
-gauge_count=$(printf '%s' "${exporter_cm}" | grep -c 'usage: "GAUGE"' || true)
+replication_block=$(printf '%s\n' "${exporter_cm}" | sed -n '/pg_wal_replication:/,/pg_wal_size:/p')
+gauge_count=$(printf '%s' "${replication_block}" | grep -c 'usage: "GAUGE"' || true)
 assert_eq "exporter cm: two GAUGE metrics in pg_wal_replication" "2" "${gauge_count}"
+
+# #305: pg_wal disk-usage metrics. Ungated (unlike pg_wal_archive below) --
+# useful even without pgbackrest (e.g. a lagging replication slot).
+assert_contains "exporter cm #305: pg_wal_size group present without pgbackrest" "${exporter_cm}" "pg_wal_size:"
+assert_contains "exporter cm #305: reads pg_ls_waldir" "${exporter_cm}" "FROM pg_ls_waldir()"
+assert_contains "exporter cm #305: bytes metric declared" "${exporter_cm}" "bytes:"
+assert_contains "exporter cm #305: file_count metric declared" "${exporter_cm}" "file_count:"
 
 # #30: WAL-archiving health metrics from pg_stat_archiver, gated on pgbackrest
 # (archive_mode is on only then) and scraped on the primary.
@@ -2516,6 +2524,31 @@ assert_contains "exporter cm #30: seconds_since_last_archived metric declared" "
 assert_contains "exporter cm #30: archiver query reads pg_stat_archiver" "${exporter_cm_arch}" "FROM pg_stat_archiver"
 # absent when pgbackrest disabled (no archiving); exporter_cm above is full-test (pgbackrest off)
 assert_not_contains "exporter cm #30: no pg_wal_archive group when pgbackrest disabled" "${exporter_cm}" "pg_wal_archive:"
+
+# #305: exporter PrometheusRule -- ships only when both prometheusExporter.enabled
+# and prometheusExporter.prometheusRule.enabled are set; the two archive-specific
+# alerts additionally require pgbackrest.enabled (pg_wal_archive_* doesn't exist
+# otherwise), while PGWALSizeHigh is unconditional.
+rule_off=$(helm template test-pg "${CHART_DIR}" --set prometheusExporter.enabled=true \
+  --show-only templates/prometheus-exporter-prometheusrule.yaml 2>&1 || true)
+assert_contains "exporter rule #305: absent when prometheusRule.enabled is false" "${rule_off}" "could not find template"
+
+rule_no_pgbackrest=$(helm template test-pg "${CHART_DIR}" --set prometheusExporter.enabled=true \
+  --set prometheusExporter.prometheusRule.enabled=true --show-only templates/prometheus-exporter-prometheusrule.yaml 2>&1)
+assert_contains "exporter rule #305: PGWALSizeHigh present without pgbackrest" "${rule_no_pgbackrest}" "alert: PGWALSizeHigh"
+assert_not_contains "exporter rule #305: no PGWALArchiveFailing without pgbackrest" "${rule_no_pgbackrest}" "alert: PGWALArchiveFailing"
+assert_not_contains "exporter rule #305: no PGWALArchiveStale without pgbackrest" "${rule_no_pgbackrest}" "alert: PGWALArchiveStale"
+
+rule_full=$(helm template test-pg "${CHART_DIR}" --set prometheusExporter.enabled=true \
+  --set prometheusExporter.prometheusRule.enabled=true --set pgbackrest.enabled=true \
+  --set pgbackrest.s3.endpoint=https://e --set pgbackrest.s3.bucket=b \
+  --set pgbackrest.existingSecret.name=s --show-only templates/prometheus-exporter-prometheusrule.yaml 2>&1)
+assert_contains "exporter rule #305: PGWALArchiveFailing present with pgbackrest" "${rule_full}" "alert: PGWALArchiveFailing"
+assert_contains "exporter rule #305: PGWALArchiveStale present with pgbackrest" "${rule_full}" "alert: PGWALArchiveStale"
+assert_contains "exporter rule #305: PGWALSizeHigh present with pgbackrest" "${rule_full}" "alert: PGWALSizeHigh"
+assert_contains "exporter rule #305: threshold rendered as plain integer, not scientific notation" "${rule_full}" "> 5368709120"
+assert_not_contains "exporter rule #305: no scientific-notation threshold" "${rule_full}" "e+09"
+assert_contains "exporter rule #305: kind is PrometheusRule" "${rule_full}" "kind: PrometheusRule"
 
 # #28: least-privilege monitoring user. A post-install/upgrade hook Job creates a
 # pg_monitor role; the exporter connects as it, not the postgres superuser.

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -2502,16 +2502,14 @@ assert_not_contains "exporter cm: no collision with built-in pg_replication grou
 assert_contains "exporter cm: in_recovery gauge present" "${exporter_cm}" "pg_is_in_recovery()::int AS in_recovery"
 assert_contains "exporter cm: receive/replay byte lag NULL-safe on primaries" "${exporter_cm}" "COALESCE(pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn()), 0)"
 assert_contains "exporter cm: byte lag metric declared" "${exporter_cm}" "receive_replay_lag_bytes:"
-replication_block=$(printf '%s\n' "${exporter_cm}" | sed -n '/pg_wal_replication:/,/pg_wal_size:/p')
+replication_block=$(printf '%s\n' "${exporter_cm}" | sed -n '/pg_wal_replication:/,$p')
 gauge_count=$(printf '%s' "${replication_block}" | grep -c 'usage: "GAUGE"' || true)
 assert_eq "exporter cm: two GAUGE metrics in pg_wal_replication" "2" "${gauge_count}"
 
-# #305: pg_wal disk-usage metrics. Ungated (unlike pg_wal_archive below) --
-# useful even without pgbackrest (e.g. a lagging replication slot).
-assert_contains "exporter cm #305: pg_wal_size group present without pgbackrest" "${exporter_cm}" "pg_wal_size:"
-assert_contains "exporter cm #305: reads pg_ls_waldir" "${exporter_cm}" "FROM pg_ls_waldir()"
-assert_contains "exporter cm #305: bytes metric declared" "${exporter_cm}" "bytes:"
-assert_contains "exporter cm #305: file_count metric declared" "${exporter_cm}" "file_count:"
+# #305: regression guard -- pg_wal_size_bytes/pg_wal_segments come from the
+# exporter's built-in `wal` collector; a chart-defined group of the same name
+# collides and breaks the whole scrape.
+assert_not_contains "exporter cm #305: no chart-defined pg_wal_size group (collides with the exporter's built-in wal collector)" "${exporter_cm}" "pg_wal_size:"
 
 # #30: WAL-archiving health metrics from pg_stat_archiver, gated on pgbackrest
 # (archive_mode is on only then) and scraped on the primary.

--- a/pg/tests/unit/exporter_test.yaml
+++ b/pg/tests/unit/exporter_test.yaml
@@ -74,18 +74,17 @@ tests:
       - notExists:
           path: spec.template.spec.volumes[?(@.name=="postgresql-tls")]
 
-  # #305: pg_wal_size disk-usage metrics and the exporter PrometheusRule.
-  - it: pg_wal_size query group renders without pgbackrest
+  # #305: regression guard -- pg_wal_size_bytes/pg_wal_segments come from the
+  # exporter's built-in `wal` collector; a chart-defined group of the same
+  # name collides and breaks the whole scrape.
+  - it: no chart-defined pg_wal_size query group
     template: templates/prometheus-exporter-configmap.yaml
     set:
       prometheusExporter.enabled: true
     asserts:
-      - matchRegex:
+      - notMatchRegex:
           path: data["queries.yaml"]
           pattern: "pg_wal_size:"
-      - matchRegex:
-          path: data["queries.yaml"]
-          pattern: "FROM pg_ls_waldir\\(\\)"
       - notMatchRegex:
           path: data["queries.yaml"]
           pattern: "pg_wal_archive:"

--- a/pg/tests/unit/exporter_test.yaml
+++ b/pg/tests/unit/exporter_test.yaml
@@ -85,9 +85,6 @@ tests:
       - notMatchRegex:
           path: data["queries.yaml"]
           pattern: "pg_wal_size:"
-      - notMatchRegex:
-          path: data["queries.yaml"]
-          pattern: "pg_wal_archive:"
 
   - it: no PrometheusRule when prometheusExporter.enabled is false
     templates:

--- a/pg/tests/unit/exporter_test.yaml
+++ b/pg/tests/unit/exporter_test.yaml
@@ -1,9 +1,10 @@
-suite: pg prometheus exporter TLS CA volume
+suite: pg prometheus exporter
 # The configmap is listed so the deployment's checksum/config include resolves; each
 # test scopes its assertions to the deployment with an explicit `template:`.
 templates:
   - templates/prometheus-exporter-deployment.yaml
   - templates/prometheus-exporter-configmap.yaml
+  - templates/prometheus-exporter-prometheusrule.yaml
 release:
   name: test-pg
 tests:
@@ -72,3 +73,85 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.volumes[?(@.name=="postgresql-tls")]
+
+  # #305: pg_wal_size disk-usage metrics and the exporter PrometheusRule.
+  - it: pg_wal_size query group renders without pgbackrest
+    template: templates/prometheus-exporter-configmap.yaml
+    set:
+      prometheusExporter.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["queries.yaml"]
+          pattern: "pg_wal_size:"
+      - matchRegex:
+          path: data["queries.yaml"]
+          pattern: "FROM pg_ls_waldir\\(\\)"
+      - notMatchRegex:
+          path: data["queries.yaml"]
+          pattern: "pg_wal_archive:"
+
+  - it: no PrometheusRule when prometheusExporter.enabled is false
+    templates:
+      - templates/prometheus-exporter-prometheusrule.yaml
+    set:
+      prometheusExporter.prometheusRule.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: no PrometheusRule when prometheusRule.enabled is false
+    templates:
+      - templates/prometheus-exporter-prometheusrule.yaml
+    set:
+      prometheusExporter.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: PrometheusRule renders PGWALSizeHigh but not the archive alerts without pgbackrest
+    templates:
+      - templates/prometheus-exporter-prometheusrule.yaml
+    set:
+      prometheusExporter.enabled: true
+      prometheusExporter.prometheusRule.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PrometheusRule
+      - matchRegex:
+          path: spec.groups[0].rules[0].alert
+          pattern: "^PGWALSizeHigh$"
+      - lengthEqual:
+          path: spec.groups[0].rules
+          count: 1
+
+  - it: PrometheusRule renders all three alerts with pgbackrest enabled
+    templates:
+      - templates/prometheus-exporter-prometheusrule.yaml
+    set:
+      prometheusExporter.enabled: true
+      prometheusExporter.prometheusRule.enabled: true
+      pgbackrest.enabled: true
+      pgbackrest.s3.endpoint: https://example.invalid
+      pgbackrest.s3.bucket: b
+      pgbackrest.existingSecret.name: s
+    asserts:
+      - lengthEqual:
+          path: spec.groups[0].rules
+          count: 3
+      - contains:
+          path: spec.groups[0].rules
+          content:
+            alert: PGWALArchiveFailing
+          any: true
+      - contains:
+          path: spec.groups[0].rules
+          content:
+            alert: PGWALArchiveStale
+          any: true
+      - contains:
+          path: spec.groups[0].rules
+          content:
+            alert: PGWALSizeHigh
+          any: true

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -814,6 +814,23 @@ prometheusExporter:
     scrapeTimeout: 10s
     additionalLabels: {}
 
+  # Example alert rules over the exporter's WAL metrics (archive failures/
+  # staleness, pg_wal disk usage). Observability only -- no automatic action is
+  # taken when a threshold is crossed. Requires the Prometheus Operator CRDs
+  # (same as serviceMonitor above). #305
+  prometheusRule:
+    enabled: false
+    additionalLabels: {}
+    # PGWALArchiveStale fires when pg_wal_archive_seconds_since_last_archived
+    # exceeds this many seconds (archive_command stuck). This also rises on an
+    # idle primary with no WAL to archive -- see the README "WAL Archiving
+    # Metrics" caveat before tightening this.
+    staleArchiveSeconds: 900
+    # PGWALSizeHigh fires when pg_wal_size_bytes exceeds this many bytes.
+    # pg_wal shares the PGDATA volume (postgresql.persistence.size) -- set this
+    # with headroom for the base data directory.
+    walSizeBytesThreshold: 5368709120 # 5Gi
+
 service:
   type: ClusterIP
   port: 5432

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -817,7 +817,10 @@ prometheusExporter:
   # Example alert rules over the exporter's WAL metrics (archive failures/
   # staleness, pg_wal disk usage). Observability only -- no automatic action is
   # taken when a threshold is crossed. Requires the Prometheus Operator CRDs
-  # (same as serviceMonitor above). #305
+  # (same as serviceMonitor above). The rules alert on metrics THIS exporter
+  # emits, so they are a no-op (rule installed, alerts never fire) unless
+  # something actually scrapes it -- serviceMonitor.enabled above, or your own
+  # equivalent scrape config. #305
   prometheusRule:
     enabled: false
     additionalLabels: {}
@@ -830,6 +833,13 @@ prometheusExporter:
     # pg_wal shares the PGDATA volume (postgresql.persistence.size) -- set this
     # with headroom for the base data directory.
     walSizeBytesThreshold: 5368709120 # 5Gi
+    # `for` durations (Prometheus duration syntax) before each alert fires.
+    # PGWALSizeHigh in particular is the backstop against a volume-filling
+    # condition -- tighten sizeHighFor if postgresql.persistence.size is small
+    # relative to your WAL generation rate.
+    archiveFailingFor: 5m
+    archiveStaleFor: 15m
+    sizeHighFor: 15m
 
 service:
   type: ClusterIP

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,19 @@
 # pgvector chart changelog
 
+## 1.12.0 - 2026-08-18
+
+Inherited from pg's symlinked `prometheus-exporter-configmap.yaml` and new
+`prometheus-exporter-prometheusrule.yaml`. See the
+[pg 1.12.0 changelog](../pg/CHANGELOG.md) for the full detail.
+
+### Added
+
+- **`prometheusExporter.prometheusRule`: alert on stuck WAL archiving and pg_wal disk
+  usage (#305).** Observability only -- no automatic write-throttle. A new ungated
+  `pg_wal_size` exporter metric group plus an opt-in `PrometheusRule` wiring it and the
+  existing (previously unused) `pg_wal_archive` failure/staleness metrics to alerts. See
+  the [pg chart README](../pg/README.md#wal-disk-usage-305) for the full detail.
+
 ## 1.11.0 - 2026-08-17
 
 Inherited from pg's symlinked `statefulset.yaml`. See the

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -9,10 +9,13 @@ Inherited from pg's symlinked `prometheus-exporter-configmap.yaml` and new
 ### Added
 
 - **`prometheusExporter.prometheusRule`: alert on stuck WAL archiving and pg_wal disk
-  usage (#305).** Observability only -- no automatic write-throttle. A new ungated
-  `pg_wal_size` exporter metric group plus an opt-in `PrometheusRule` wiring it and the
-  existing (previously unused) `pg_wal_archive` failure/staleness metrics to alerts. See
-  the [pg chart README](../pg/README.md#wal-disk-usage-305) for the full detail.
+  usage (#305).** Observability only -- no automatic write-throttle. An opt-in
+  `PrometheusRule` wiring the exporter's own built-in `pg_wal_size_bytes` metric and the
+  existing (previously unused) `pg_wal_archive` failure/staleness metrics to alerts. No
+  new query or grant -- a chart-defined `pg_wal_size` query group was tried and reverted
+  after live-testing caught it colliding with the exporter's built-in metric of the same
+  name, which broke the entire scrape. See the
+  [pg chart README](../pg/README.md#wal-disk-usage-305) for the full detail.
 
 ## 1.11.0 - 2026-08-17
 

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus repmgr replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 1.11.0
+version: 1.12.0
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -724,6 +724,29 @@ When pgBackRest is enabled, the exporter adds a `pg_wal_archive` query group fro
 
 Alert on `rate(pg_wal_archive_failed_count[5m]) > 0` to catch a failing `archive_command` — this is the actionable signal. `pg_wal_archive_seconds_since_last_archived` also grows on an idle primary that has no WAL to archive, so alert on it only in conjunction with a WAL-generation signal (e.g. it rising while `pg_wal_archive_archived_count` stays flat), not on its own.
 
+### WAL Disk Usage (#305)
+
+Unlike the counters above, `pg_wal_size` reflects actual bytes on disk regardless of *why* WAL is being retained — a stuck `archive_command`, a lagging replication slot, or a slow standby — so it is emitted on every instance, not gated on `pgbackrest.enabled`:
+
+| Metric | Description |
+|--------|-------------|
+| `pg_wal_size_bytes` | Total bytes currently used by `pg_wal` on disk |
+| `pg_wal_size_file_count` | Number of WAL segment files currently in `pg_wal` |
+
+`pg_wal` shares the single PGDATA volume (`postgresql.persistence.size`) — there is no separate WAL volume/tablespace. **This chart ships observability for that condition only** — a shipped alert (below) — not an automatic write-throttle or backpressure mechanism.
+
+### WAL Alert Rules
+
+Set `prometheusExporter.prometheusRule.enabled: true` to ship a `PrometheusRule` (requires the Prometheus Operator CRDs):
+
+| Alert | Condition | Requires |
+|-------|-----------|----------|
+| `PGWALArchiveFailing` | `rate(pg_wal_archive_failed_count[5m]) > 0` for 5m | `pgbackrest.enabled` |
+| `PGWALArchiveStale` | `pg_wal_archive_seconds_since_last_archived > prometheusExporter.prometheusRule.staleArchiveSeconds` for 15m | `pgbackrest.enabled` |
+| `PGWALSizeHigh` | `pg_wal_size_bytes > prometheusExporter.prometheusRule.walSizeBytesThreshold` for 15m | — |
+
+See pg's README for the full alert-tuning discussion.
+
 ### Exporter Parameters
 
 | Parameter | Description | Default |
@@ -757,6 +780,10 @@ Alert on `rate(pg_wal_archive_failed_count[5m]) > 0` to catch a failing `archive
 | `prometheusExporter.serviceMonitor.interval` | Scrape interval | `30s` |
 | `prometheusExporter.serviceMonitor.scrapeTimeout` | Scrape timeout | `10s` |
 | `prometheusExporter.serviceMonitor.additionalLabels` | Additional labels on ServiceMonitor | `{}` |
+| `prometheusExporter.prometheusRule.enabled` | Ship the `PrometheusRule` covering the WAL alerts above (#305) | `false` |
+| `prometheusExporter.prometheusRule.additionalLabels` | Additional labels on PrometheusRule | `{}` |
+| `prometheusExporter.prometheusRule.staleArchiveSeconds` | `PGWALArchiveStale` threshold, in seconds | `900` |
+| `prometheusExporter.prometheusRule.walSizeBytesThreshold` | `PGWALSizeHigh` threshold, in bytes | `5368709120` (5Gi) |
 
 ## Backup
 

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -731,19 +731,19 @@ Unlike the counters above, `pg_wal_size` reflects actual bytes on disk regardles
 | Metric | Description |
 |--------|-------------|
 | `pg_wal_size_bytes` | Total bytes currently used by `pg_wal` on disk |
-| `pg_wal_size_file_count` | Number of WAL segment files currently in `pg_wal` |
+| `pg_wal_size_file_count` | Number of files currently in `pg_wal` (segments plus `.partial`/`.history`/`.backup` entries) |
 
 `pg_wal` shares the single PGDATA volume (`postgresql.persistence.size`) — there is no separate WAL volume/tablespace. **This chart ships observability for that condition only** — a shipped alert (below) — not an automatic write-throttle or backpressure mechanism.
 
 ### WAL Alert Rules
 
-Set `prometheusExporter.prometheusRule.enabled: true` to ship a `PrometheusRule` (requires the Prometheus Operator CRDs):
+Set `prometheusExporter.prometheusRule.enabled: true` to ship a `PrometheusRule` (requires the Prometheus Operator CRDs). This is a no-op unless `prometheusExporter.serviceMonitor.enabled` (or an equivalent scrape) is also on.
 
 | Alert | Condition | Requires |
 |-------|-----------|----------|
-| `PGWALArchiveFailing` | `rate(pg_wal_archive_failed_count[5m]) > 0` for 5m | `pgbackrest.enabled` |
-| `PGWALArchiveStale` | `pg_wal_archive_seconds_since_last_archived > prometheusExporter.prometheusRule.staleArchiveSeconds` for 15m | `pgbackrest.enabled` |
-| `PGWALSizeHigh` | `pg_wal_size_bytes > prometheusExporter.prometheusRule.walSizeBytesThreshold` for 15m | — |
+| `PGWALArchiveFailing` | `rate(pg_wal_archive_failed_count[5m]) > 0` for `archiveFailingFor` (default `5m`) | `pgbackrest.enabled` |
+| `PGWALArchiveStale` | `pg_wal_archive_seconds_since_last_archived > staleArchiveSeconds` for `archiveStaleFor` (default `15m`) | `pgbackrest.enabled` |
+| `PGWALSizeHigh` | `pg_wal_size_bytes > walSizeBytesThreshold` for `sizeHighFor` (default `15m`) | — |
 
 See pg's README for the full alert-tuning discussion.
 
@@ -784,6 +784,9 @@ See pg's README for the full alert-tuning discussion.
 | `prometheusExporter.prometheusRule.additionalLabels` | Additional labels on PrometheusRule | `{}` |
 | `prometheusExporter.prometheusRule.staleArchiveSeconds` | `PGWALArchiveStale` threshold, in seconds | `900` |
 | `prometheusExporter.prometheusRule.walSizeBytesThreshold` | `PGWALSizeHigh` threshold, in bytes | `5368709120` (5Gi) |
+| `prometheusExporter.prometheusRule.archiveFailingFor` | `PGWALArchiveFailing` `for` duration | `5m` |
+| `prometheusExporter.prometheusRule.archiveStaleFor` | `PGWALArchiveStale` `for` duration | `15m` |
+| `prometheusExporter.prometheusRule.sizeHighFor` | `PGWALSizeHigh` `for` duration | `15m` |
 
 ## Backup
 

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -726,12 +726,12 @@ Alert on `rate(pg_wal_archive_failed_count[5m]) > 0` to catch a failing `archive
 
 ### WAL Disk Usage (#305)
 
-Unlike the counters above, `pg_wal_size` reflects actual bytes on disk regardless of *why* WAL is being retained — a stuck `archive_command`, a lagging replication slot, or a slow standby — so it is emitted on every instance, not gated on `pgbackrest.enabled`:
+Unlike the counters above, `pg_wal_size_bytes` reflects actual bytes on disk regardless of *why* WAL is being retained. It comes from the exporter's own **built-in** `wal` collector, not a chart-defined query (see the pg chart README for why -- a chart-defined query under the same metric name collided with it and broke the entire scrape):
 
 | Metric | Description |
 |--------|-------------|
 | `pg_wal_size_bytes` | Total bytes currently used by `pg_wal` on disk |
-| `pg_wal_size_file_count` | Number of files currently in `pg_wal` (segments plus `.partial`/`.history`/`.backup` entries) |
+| `pg_wal_segments` | Number of WAL segments currently in `pg_wal` |
 
 `pg_wal` shares the single PGDATA volume (`postgresql.persistence.size`) — there is no separate WAL volume/tablespace. **This chart ships observability for that condition only** — a shipped alert (below) — not an automatic write-throttle or backpressure mechanism.
 

--- a/pgvector/templates/prometheus-exporter-prometheusrule.yaml
+++ b/pgvector/templates/prometheus-exporter-prometheusrule.yaml
@@ -1,0 +1,1 @@
+../../pg/templates/prometheus-exporter-prometheusrule.yaml

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -727,12 +727,16 @@ prometheusExporter:
     scrapeTimeout: 10s
     additionalLabels: {}
 
-  # Example alert rules over the exporter's WAL metrics. Observability only. #305
+  # Example alert rules over the exporter's WAL metrics. Observability only. A
+  # no-op unless serviceMonitor.enabled (or an equivalent scrape) is also on. #305
   prometheusRule:
     enabled: false
     additionalLabels: {}
     staleArchiveSeconds: 900
     walSizeBytesThreshold: 5368709120 # 5Gi
+    archiveFailingFor: 5m
+    archiveStaleFor: 15m
+    sizeHighFor: 15m
 
 service:
   type: ClusterIP

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -727,6 +727,13 @@ prometheusExporter:
     scrapeTimeout: 10s
     additionalLabels: {}
 
+  # Example alert rules over the exporter's WAL metrics. Observability only. #305
+  prometheusRule:
+    enabled: false
+    additionalLabels: {}
+    staleArchiveSeconds: 900
+    walSizeBytesThreshold: 5368709120 # 5Gi
+
 service:
   type: ClusterIP
   port: 5432


### PR DESCRIPTION
## Summary
- New ungated `pg_wal_size` exporter metric group (`pg_wal_size_bytes`, `pg_wal_size_file_count` via `pg_ls_waldir()`) reporting actual pg_wal disk usage, regardless of why WAL is retained.
- New opt-in `prometheusExporter.prometheusRule` wiring the above plus the existing (previously unused) `pg_wal_archive` failure/staleness metrics to three alerts: `PGWALArchiveFailing`, `PGWALArchiveStale`, `PGWALSizeHigh`.
- Observability only, per scope decision on #305 -- no automatic write-throttle/backpressure. That mechanism is left for a follow-up issue.
- pg/pgvector bumped 1.11.0 -> 1.12.0 (templates stay byte-identical; default render is byte-stable aside from the chart-version label).

Closes #305

## Test plan
- [x] `make -C pg test-template` (1135/1135 passing, including new #305 assertions)
- [x] `bash scripts/helm-unittest-charts.sh` (new PrometheusRule/pg_wal_size cases pass for pg; pgvector/redis unaffected)
- [x] `helm lint pg && helm lint pgvector`
- [x] `diff -r pg/templates pgvector/templates` (empty)
- [x] `make -C pg byte-stable REF=master` (only the chart-version label differs)
- [ ] `bash scripts/kubeconform-charts.sh` / `bash scripts/kube-linter-charts.sh` (tools not installed locally; CI gates these)