### PR TITLE
fix(pg,pgvector): bump repmgr.image.tag to trixie-5.5.0-32 (#314)

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,22 @@
 # pg chart changelog
 
+## 1.13.1 - 2026-08-21
+
+### Fixed
+
+- **`repmgr.image.tag` default (`trixie-5.5.0-31`) predated the #311 agent changes
+  (#314).** `trixie-5.5.0-31` was tagged before `dbname` primary_conninfo patching and
+  `synchronized_standby_slots` reconciliation (#308/#311) landed, so a fresh 1.13.0
+  install with `repmgr.agent.syncReplicationSlots: true` set `wal_level`/
+  `sync_replication_slots` correctly via ConfigMap, but ran an agent binary that never
+  patched `primary_conninfo` or reconciled `synchronized_standby_slots` -- the feature
+  documented in the 1.13.0 release notes silently did nothing on the default image.
+  Bumped the default to `trixie-5.5.0-32`, built from current `master` (confirmed via
+  `grep -a` on the shipped binary: it now contains `synchronized_standby_slots` and
+  `EnsurePrimaryConninfoDBName`/`dbNameReloadPending`). `etcd.rbac.bootstrapImage.tag`
+  moves in lockstep, as always. No template or values-schema changes; existing
+  `repmgr.image.tag` overrides are unaffected.
+
 ## 1.13.0 - 2026-08-21
 
 ### Added

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with repmgr replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 1.13.0
+version: 1.13.1
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/README.md
+++ b/pg/README.md
@@ -310,7 +310,7 @@ These three values are validated at render time, so a mistake fails `helm instal
 |-----------|-------------|---------|
 | `repmgr.enabled` | Enable repmgr | `true` |
 | `repmgr.image.repository` | Repmgr image repository | `cagriekin/repmgr` |
-| `repmgr.image.tag` | Repmgr image tag. Unsuffixed = the default major (18); `-pg18` / `-pg17` select one explicitly | `trixie-5.5.0-31` |
+| `repmgr.image.tag` | Repmgr image tag. Unsuffixed = the default major (18); `-pg18` / `-pg17` select one explicitly | `trixie-5.5.0-32` |
 | `repmgr.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `repmgr.image.majorVersion` | PostgreSQL major bundled in the repmgr image. In repmgr mode the server always runs this major; `postgresql.majorVersion` must match or the chart fails to render. Move it together with `repmgr.image.tag` (`17` ⇄ `-pg17`) — see [Choosing the PostgreSQL major](#choosing-the-postgresql-major). | `"18"` |
 | `repmgr.username` | Repmgr database user | `repmgr` |
@@ -357,7 +357,7 @@ postgresql:
     tag: 17.10-trixie      # only used in standalone mode / for the extension copy
 repmgr:
   image:
-    tag: trixie-5.5.0-31-pg17
+    tag: trixie-5.5.0-32-pg17
     majorVersion: "17"
 ```
 
@@ -2093,7 +2093,8 @@ Each chart is tagged `<chart>-<version>` (e.g. `pg-1.1.0`); `pg` and `pgvector` 
 
 | `pg` / `pgvector` | repmgr image | PostgreSQL | Kubernetes |
 |-------------------|--------------|-----------|-----------|
-| 1.11.0 *(current)* | `trixie-5.5.0-31` (`-pg18` / `-pg17`) | 18.x (default) or 17.x — see [Choosing the PostgreSQL major](#choosing-the-postgresql-major) | ≥ 1.21 (PDB `policy/v1`); ≥ 1.27 for the agent-mode PDB `unhealthyPodEvictionPolicy` |
+| 1.13.1 *(current)* | `trixie-5.5.0-32` (`-pg18` / `-pg17`) | 18.x (default) or 17.x — see [Choosing the PostgreSQL major](#choosing-the-postgresql-major) | ≥ 1.21 (PDB `policy/v1`); ≥ 1.27 for the agent-mode PDB `unhealthyPodEvictionPolicy` |
+| 1.11.0 – 1.13.0 | `trixie-5.5.0-31` | 18.x (default) or 17.x | as above |
 | 1.10.1 – 1.10.2 | `trixie-5.5.0-30` | 18.x (default) or 17.x | as above |
 | 1.8.1 – 1.10.0 | `trixie-5.5.0-29` | 18.x (default) or 17.x | as above |
 | 1.5.0 – 1.8.0 | `trixie-5.5.0-28` | 18.x | as above |
@@ -2112,7 +2113,7 @@ helm repo update
 helm upgrade my-postgres cagriekin/pg   # add -f your-values.yaml
 ```
 
-Within the 1.x line the default is agent mode, and successive releases (e.g. `1.0.0` → `1.11.0`) are backward-compatible: `helm upgrade` rolls the pods once for the new image (`trixie-5.5.0-31` at 1.11.0) and the agent re-establishes leadership with no manual step. **Read every `Migrating from X.Y.Z` entry in [`CHANGELOG.md`](CHANGELOG.md) between your current version and the target** — some releases (credential, `pg_hba`, or image changes) carry one-time steps. The CHANGELOG keeps an unbroken trail back through the 0.x line.
+Within the 1.x line the default is agent mode, and successive releases (e.g. `1.0.0` → `1.13.1`) are backward-compatible: `helm upgrade` rolls the pods once for the new image (`trixie-5.5.0-32` at 1.13.1) and the agent re-establishes leadership with no manual step. **Read every `Migrating from X.Y.Z` entry in [`CHANGELOG.md`](CHANGELOG.md) between your current version and the target** — some releases (credential, `pg_hba`, or image changes) carry one-time steps. The CHANGELOG keeps an unbroken trail back through the 0.x line.
 
 ### Crossing the 0.x → 1.x boundary (agent mode is now the default)
 

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -338,7 +338,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-31
+    tag: trixie-5.5.0-32
     # Optional digest pin (e.g. "sha256:..."). When set it is appended as
     # repository:tag@digest, so the cosign-signed / provenance-attested image is
     # pinned at deploy time and a mutable-tag repush cannot silently change it.
@@ -1219,4 +1219,4 @@ etcd:
   # silently ignored, which left the Job on the subchart's older default (#269 review).
   rbac:
     bootstrapImage:
-      tag: trixie-5.5.0-31
+      tag: trixie-5.5.0-32

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,13 @@
 # pgvector chart changelog
 
+## 1.13.1 - 2026-08-21
+
+### Fixed
+
+- **`repmgr.image.tag` default (`trixie-5.5.0-31`) predated the #311 agent changes
+  (#314).** Bumped to `trixie-5.5.0-32`, built from current `master`. See the
+  [pg 1.13.1 changelog](../pg/CHANGELOG.md) for the full detail.
+
 ## 1.13.0 - 2026-08-21
 
 Inherited from pg's symlinked templates (`postgresql-configmap.yaml`, `statefulset.yaml`,

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus repmgr replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 1.13.0
+version: 1.13.1
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -222,7 +222,7 @@ When `repmgr.enabled` is true, `additionalCommands` automatically discover the c
 |-----------|-------------|---------|
 | `repmgr.enabled` | Enable repmgr | `true` |
 | `repmgr.image.repository` | Repmgr image repository | `cagriekin/repmgr` |
-| `repmgr.image.tag` | Repmgr image tag. Unsuffixed = the default major (18); `-pg18` / `-pg17` select one explicitly | `trixie-5.5.0-31` |
+| `repmgr.image.tag` | Repmgr image tag. Unsuffixed = the default major (18); `-pg18` / `-pg17` select one explicitly | `trixie-5.5.0-32` |
 | `repmgr.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `repmgr.image.majorVersion` | PostgreSQL major bundled in the repmgr image. In repmgr mode the server always runs this major; `postgresql.majorVersion` must match or the chart fails to render. Move it together with `repmgr.image.tag` (`17` ⇄ `-pg17`) — see [Choosing the PostgreSQL major](#choosing-the-postgresql-major). | `"18"` |
 | `repmgr.username` | Repmgr database user | `repmgr` |
@@ -259,7 +259,7 @@ postgresql:
     tag: pg17-trixie           # the pgvector image for the SAME major
 repmgr:
   image:
-    tag: trixie-5.5.0-31-pg17
+    tag: trixie-5.5.0-32-pg17
     majorVersion: "17"
 ```
 
@@ -1168,7 +1168,7 @@ helm repo update
 helm upgrade my-pgvector cagriekin/pgvector   # add -f your-values.yaml
 ```
 
-`pgvector` tracks `pg` in lockstep — same version, image, and agent; the earlier 0.6.x ↔ 0.5.x split unified at `1.0.0` (current: `1.13.0`, image `trixie-5.5.0-31`). Within the 1.x line `helm upgrade` rolls the pods once and needs no manual step. The default failover mode is `agent` since `1.0.0` (it was `repmgrd` through 0.x); **only when crossing from a 0.x release** does adopting the agent default need the one-time `--cascade=orphan` recreate — pin `repmgr.failoverMode: repmgrd` to defer. Read the `Migrating from X.Y.Z` entries in [`CHANGELOG.md`](CHANGELOG.md) between your version and the target. For the **compatibility matrix, the version model, and the full 0.x → 1.x migration runbook**, see the [pg chart README — Upgrade and migration](../pg/README.md#upgrade-and-migration) (this chart shares pg's templates and agent).
+`pgvector` tracks `pg` in lockstep — same version, image, and agent; the earlier 0.6.x ↔ 0.5.x split unified at `1.0.0` (current: `1.13.1`, image `trixie-5.5.0-32`). Within the 1.x line `helm upgrade` rolls the pods once and needs no manual step. The default failover mode is `agent` since `1.0.0` (it was `repmgrd` through 0.x); **only when crossing from a 0.x release** does adopting the agent default need the one-time `--cascade=orphan` recreate — pin `repmgr.failoverMode: repmgrd` to defer. Read the `Migrating from X.Y.Z` entries in [`CHANGELOG.md`](CHANGELOG.md) between your version and the target. For the **compatibility matrix, the version model, and the full 0.x → 1.x migration runbook**, see the [pg chart README — Upgrade and migration](../pg/README.md#upgrade-and-migration) (this chart shares pg's templates and agent).
 
 ## pgvector Resources
 

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -275,7 +275,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-31
+    tag: trixie-5.5.0-32
     # Optional digest pin (e.g. "sha256:..."). When set it is appended as
     # repository:tag@digest, so the cosign-signed / provenance-attested image is
     # pinned at deploy time and a mutable-tag repush cannot silently change it.
@@ -1105,4 +1105,4 @@ etcd:
   # silently ignored, which left the Job on the subchart's older default (#269 review).
   rbac:
     bootstrapImage:
-      tag: trixie-5.5.0-31
+      tag: trixie-5.5.0-32


### PR DESCRIPTION
## Summary
- Closes #314: `repmgr.image.tag` defaulted to `trixie-5.5.0-31`, an image tagged **before** the #311 agent changes (`dbname` primary_conninfo patching, `synchronized_standby_slots` reconciliation) landed on master. A 1.13.0 install with `repmgr.agent.syncReplicationSlots: true` therefore set `wal_level`/`sync_replication_slots` correctly via ConfigMap, but ran an agent binary that silently never did the actual slot-sync work the release documents.
- Published `trixie-5.5.0-32` (+ `-pg18`/`-pg17`) from current `master`, gated on the same tests the automated publish workflow runs (`images/repmgr/test/scripts-test.sh`, `go vet`/`go test`). Confirmed via `grep -a` on the shipped binary that it contains `synchronized_standby_slots` and `EnsurePrimaryConninfoDBName`/`dbNameReloadPending`.
- Bumped `repmgr.image.tag` (and `etcd.rbac.bootstrapImage.tag`, which tracks it in lockstep) to `trixie-5.5.0-32` in both charts, patch version bump (1.13.0 -> 1.13.1), CHANGELOG entries, and corrected the README compatibility matrix (was stale at "1.11.0 (current)").

## Test plan
- [x] `make -C pg test-template` (1155/1155)
- [x] `bash scripts/helm-unittest-charts.sh` (all 5 charts pass)
- [x] `helm lint pg && helm lint pgvector`
- [x] `bash scripts/check-vendored-subcharts.sh`
- [x] `make -C pg byte-stable REF=master` — diff is exactly the version bump + tag bump everywhere the repmgr image is referenced
- [x] Verified the published `trixie-5.5.0-32` image (all 3 tags, multi-arch) is live on Docker Hub and contains the #311 agent code