### PR TITLE
fix(pg,pgvector): bump repmgr.image.tag to trixie-5.5.0-33 (#317)

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,56 @@
 # pg chart changelog
 
+## 1.14.1 - 2026-08-22
+
+### Changed
+
+- **`repmgr.image.tag` -> `trixie-5.5.0-33` (#317).** The agent now honours `KUBECONFIG`,
+  so its apiserver traffic can be routed through an in-cluster proxy. Chart-only change is
+  the pinned tag; the behaviour ships in the image.
+
+  Why it exists: the agent reads its primary marker and publishes gossip through the
+  apiserver, so on a cluster whose egress policy denies pod traffic to the apiserver **no
+  leader is elected and the cluster never gets a serving primary** -- while every pod,
+  Service and policy looks correctly configured. Such a policy is not always fixable from
+  the policy side: on Cilium deny wins within a tier (no allow rule re-opens the apiserver
+  for one namespace) and reserved identities are compound (`reserved:host` and
+  `reserved:kube-apiserver` sit on the same identity), so any topology reaching the
+  apiserver via a real node IP cannot admit apiserver traffic for one workload without
+  admitting node traffic for it. What remains is an in-cluster TCP proxy, which needs a
+  different **address** while still verifying the apiserver's own **certificate** -- its
+  SANs cover `kubernetes.default.svc` and the apiserver IPs, not the proxy Service.
+  Overriding `KUBERNETES_SERVICE_HOST` retargets the dial but leaves no way to set
+  `ServerName`, trading a routing failure for a verification failure; `server:` +
+  `tls-server-name:` is the pair only a kubeconfig can express.
+
+  **No new value.** Set the variable with `postgresql.extraEnv` and mount the kubeconfig
+  with `postgresql.extraVolumes`/`extraVolumeMounts`, both of which already exist. Keep
+  `tokenFile`/`certificate-authority` pointed at the ServiceAccount mount so the identity
+  stays the pod's ServiceAccount and the chart's RBAC applies unchanged -- only the address
+  moves. See the README ["Routing the agent's apiserver traffic"](README.md#routing-the-agents-apiserver-traffic--kubeconfig-317).
+
+  Both apiserver clients take the route: the mutation client (write-Service selector,
+  `pg-role` labels, primary marker) **and** the Lease-backed leader election when
+  `repmgr.agent.dcs.backend=kubernetes`. Reaching one but not the other would elect a
+  leader that cannot publish. `backend=etcd` is unaffected -- leadership never touches the
+  apiserver in that mode.
+
+  A `KUBECONFIG` that is set but unreadable, malformed, or contextless is a **startup
+  failure naming the file**, not a silent fall back to in-cluster: falling back would
+  reproduce the exact hang this escapes, with a kubeconfig mounted and apparently in
+  effect. `~/.kube/config` is deliberately **not** consulted, so a stray file cannot
+  silently redirect a production cluster. Note `kubectl` is not as strict -- its deferred
+  loader does fall back -- so a broken mount degrades the entrypoint's #170 settle guard to
+  its fail-open fast path while the agent refuses to boot; mount the kubeconfig from a
+  ConfigMap that cannot vanish. The boot log's new `apiserver=` field records which route
+  was taken (`kubeconfig <path>` or `in-cluster`), because a denied-egress hang and a
+  misrouted kubeconfig otherwise log the same dial timeout.
+
+**Migrating from 1.14.0:** nothing to do. With `KUBECONFIG` unset -- the default, and what
+the chart renders -- the agent takes the in-cluster ServiceAccount path exactly as before;
+the default render is byte-identical apart from the image tag, so `helm upgrade` rolls the
+pods once for the new image and the agent re-establishes leadership with no manual step.
+
 ## 1.14.0 - 2026-08-21
 
 ### Added

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with repmgr replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 1.14.0
+version: 1.14.1
 appVersion: "18.1"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/README.md
+++ b/pg/README.md
@@ -372,7 +372,7 @@ These three values are validated at render time, so a mistake fails `helm instal
 |-----------|-------------|---------|
 | `repmgr.enabled` | Enable repmgr | `true` |
 | `repmgr.image.repository` | Repmgr image repository | `cagriekin/repmgr` |
-| `repmgr.image.tag` | Repmgr image tag. Unsuffixed = the default major (18); `-pg18` / `-pg17` select one explicitly | `trixie-5.5.0-32` |
+| `repmgr.image.tag` | Repmgr image tag. Unsuffixed = the default major (18); `-pg18` / `-pg17` select one explicitly | `trixie-5.5.0-33` |
 | `repmgr.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `repmgr.image.majorVersion` | PostgreSQL major bundled in the repmgr image. In repmgr mode the server always runs this major; `postgresql.majorVersion` must match or the chart fails to render. Move it together with `repmgr.image.tag` (`17` ⇄ `-pg17`) — see [Choosing the PostgreSQL major](#choosing-the-postgresql-major). | `"18"` |
 | `repmgr.username` | Repmgr database user | `repmgr` |
@@ -419,7 +419,7 @@ postgresql:
     tag: 17.10-trixie      # only used in standalone mode / for the extension copy
 repmgr:
   image:
-    tag: trixie-5.5.0-32-pg17
+    tag: trixie-5.5.0-33-pg17
     majorVersion: "17"
 ```
 
@@ -959,7 +959,7 @@ level=INFO msg="reconcile decision" hold_lease=false action=Wait reason="... no 
 
 Some policies cannot be re-opened from the policy side. On Cilium, deny wins within a tier — so no allow rule admits the apiserver for one namespace — and reserved identities are compound (`reserved:host` and `reserved:kube-apiserver` sit on the same identity), so any topology that reaches the apiserver via a real node IP cannot admit apiserver traffic for one workload without admitting node traffic for it. What remains is an in-cluster TCP proxy.
 
-The agent therefore honours **`KUBECONFIG`**, from the first repmgr image tag published after #317 onwards (`trixie-5.5.0-32` and earlier do not have it; the tag this chart pins is in `repmgr.image.tag`). No new chart value is involved — set the variable and mount the file with the passthrough that already exists:
+The agent therefore honours **`KUBECONFIG`** (repmgr image `trixie-5.5.0-33` or newer, pinned by this chart since 1.14.1). No new chart value is involved — set the variable and mount the file with the passthrough that already exists:
 
 ```yaml
 postgresql:
@@ -2217,8 +2217,8 @@ Each chart is tagged `<chart>-<version>` (e.g. `pg-1.1.0`); `pg` and `pgvector` 
 
 | `pg` / `pgvector` | repmgr image | PostgreSQL | Kubernetes |
 |-------------------|--------------|-----------|-----------|
-| 1.14.0 *(current)* | `trixie-5.5.0-32` (`-pg18` / `-pg17`) | 18.x (default) or 17.x — see [Choosing the PostgreSQL major](#choosing-the-postgresql-major) | ≥ 1.21 (PDB `policy/v1`); ≥ 1.27 for the agent-mode PDB `unhealthyPodEvictionPolicy` |
-| 1.13.1 | `trixie-5.5.0-32` | 18.x (default) or 17.x | as above |
+| 1.14.1 *(current)* | `trixie-5.5.0-33` (`-pg18` / `-pg17`) | 18.x (default) or 17.x — see [Choosing the PostgreSQL major](#choosing-the-postgresql-major) | ≥ 1.21 (PDB `policy/v1`); ≥ 1.27 for the agent-mode PDB `unhealthyPodEvictionPolicy` |
+| 1.13.1 – 1.14.0 | `trixie-5.5.0-32` | 18.x (default) or 17.x | as above |
 | 1.11.0 – 1.13.0 | `trixie-5.5.0-31` | 18.x (default) or 17.x | as above |
 | 1.10.1 – 1.10.2 | `trixie-5.5.0-30` | 18.x (default) or 17.x | as above |
 | 1.8.1 – 1.10.0 | `trixie-5.5.0-29` | 18.x (default) or 17.x | as above |
@@ -2238,7 +2238,7 @@ helm repo update
 helm upgrade my-postgres cagriekin/pg   # add -f your-values.yaml
 ```
 
-Within the 1.x line the default is agent mode, and successive releases (e.g. `1.0.0` → `1.14.0`) are backward-compatible: `helm upgrade` rolls the pods once for the new image (`trixie-5.5.0-32` at 1.14.0) and the agent re-establishes leadership with no manual step. **Read every `Migrating from X.Y.Z` entry in [`CHANGELOG.md`](CHANGELOG.md) between your current version and the target** — some releases (credential, `pg_hba`, or image changes) carry one-time steps. The CHANGELOG keeps an unbroken trail back through the 0.x line.
+Within the 1.x line the default is agent mode, and successive releases (e.g. `1.0.0` → `1.14.1`) are backward-compatible: `helm upgrade` rolls the pods once for the new image (`trixie-5.5.0-33` at 1.14.1) and the agent re-establishes leadership with no manual step. **Read every `Migrating from X.Y.Z` entry in [`CHANGELOG.md`](CHANGELOG.md) between your current version and the target** — some releases (credential, `pg_hba`, or image changes) carry one-time steps. The CHANGELOG keeps an unbroken trail back through the 0.x line.
 
 ### Crossing the 0.x → 1.x boundary (agent mode is now the default)
 

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -373,7 +373,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-32
+    tag: trixie-5.5.0-33
     # Optional digest pin (e.g. "sha256:..."). When set it is appended as
     # repository:tag@digest, so the cosign-signed / provenance-attested image is
     # pinned at deploy time and a mutable-tag repush cannot silently change it.
@@ -1254,4 +1254,4 @@ etcd:
   # silently ignored, which left the Job on the subchart's older default (#269 review).
   rbac:
     bootstrapImage:
-      tag: trixie-5.5.0-32
+      tag: trixie-5.5.0-33

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,30 @@
 # pgvector chart changelog
 
+## 1.14.1 - 2026-08-22
+
+Inherited from pg: same agent and image. See the [pg 1.14.1 changelog](../pg/CHANGELOG.md)
+for the full detail.
+
+### Changed
+
+- **`repmgr.image.tag` -> `trixie-5.5.0-33` (#317).** The agent now honours `KUBECONFIG`,
+  so its apiserver traffic can be routed through an in-cluster proxy -- for clusters whose
+  egress policy denies pod traffic to the apiserver outright, where the agent otherwise
+  never elects a leader and the cluster never gets a serving primary. Reaching a proxy
+  needs a different **address** while still verifying the apiserver's own **certificate**,
+  which only a kubeconfig can express (`server:` + `tls-server-name:`); overriding
+  `KUBERNETES_SERVICE_HOST` breaks verification instead. **No new value**: set it with
+  `postgresql.extraEnv` and mount the file with `postgresql.extraVolumes`/
+  `extraVolumeMounts`. Both apiserver clients take the route -- the mutation client and the
+  Lease-backed leader election. A set-but-unusable `KUBECONFIG` is a startup failure naming
+  the file, never a silent fall back to in-cluster; `~/.kube/config` is not consulted. The
+  boot log's new `apiserver=` field records the route. See the
+  [pg chart README](../pg/README.md#routing-the-agents-apiserver-traffic--kubeconfig-317).
+
+**Migrating from 1.14.0:** nothing to do. With `KUBECONFIG` unset -- the default -- the
+in-cluster path is used exactly as before; `helm upgrade` rolls the pods once for the new
+image.
+
 ## 1.14.0 - 2026-08-21
 
 Inherited from pg's symlinked templates (`_helpers.tpl`, `statefulset.yaml`) and mirrored

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus repmgr replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 1.14.0
+version: 1.14.1
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -224,7 +224,7 @@ When `repmgr.enabled` is true, `additionalCommands` automatically discover the c
 |-----------|-------------|---------|
 | `repmgr.enabled` | Enable repmgr | `true` |
 | `repmgr.image.repository` | Repmgr image repository | `cagriekin/repmgr` |
-| `repmgr.image.tag` | Repmgr image tag. Unsuffixed = the default major (18); `-pg18` / `-pg17` select one explicitly | `trixie-5.5.0-32` |
+| `repmgr.image.tag` | Repmgr image tag. Unsuffixed = the default major (18); `-pg18` / `-pg17` select one explicitly | `trixie-5.5.0-33` |
 | `repmgr.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `repmgr.image.majorVersion` | PostgreSQL major bundled in the repmgr image. In repmgr mode the server always runs this major; `postgresql.majorVersion` must match or the chart fails to render. Move it together with `repmgr.image.tag` (`17` ⇄ `-pg17`) — see [Choosing the PostgreSQL major](#choosing-the-postgresql-major). | `"18"` |
 | `repmgr.username` | Repmgr database user | `repmgr` |
@@ -261,7 +261,7 @@ postgresql:
     tag: pg17-trixie           # the pgvector image for the SAME major
 repmgr:
   image:
-    tag: trixie-5.5.0-32-pg17
+    tag: trixie-5.5.0-33-pg17
     majorVersion: "17"
 ```
 
@@ -291,7 +291,7 @@ Must satisfy `leaseDuration > renewDeadline > retryPeriod`; widen for managed cl
 
 ### Routing the agent's apiserver traffic — `KUBECONFIG` (#317)
 
-The agent honours `KUBECONFIG`, from the first repmgr image tag published after #317 onwards (`trixie-5.5.0-32` and earlier do not have it), so its apiserver traffic can be sent through an in-cluster proxy on clusters whose egress policy denies pod traffic to the apiserver outright — where it otherwise never elects a leader and the cluster never gets a serving primary. No new value is involved: set the variable with `postgresql.extraEnv` and mount the kubeconfig with `postgresql.extraVolumes`/`extraVolumeMounts`. With it unset the in-cluster ServiceAccount path is used, unchanged. This chart shares pg's agent — see the [pg chart README](../pg/README.md#routing-the-agents-apiserver-traffic--kubeconfig-317) for the example kubeconfig, why `KUBERNETES_SERVICE_HOST` cannot express it, and the failure modes.
+The agent honours `KUBECONFIG` (repmgr image `trixie-5.5.0-33` or newer, pinned by this chart since 1.14.1), so its apiserver traffic can be sent through an in-cluster proxy on clusters whose egress policy denies pod traffic to the apiserver outright — where it otherwise never elects a leader and the cluster never gets a serving primary. No new value is involved: set the variable with `postgresql.extraEnv` and mount the kubeconfig with `postgresql.extraVolumes`/`extraVolumeMounts`. With it unset the in-cluster ServiceAccount path is used, unchanged. This chart shares pg's agent — see the [pg chart README](../pg/README.md#routing-the-agents-apiserver-traffic--kubeconfig-317) for the example kubeconfig, why `KUBERNETES_SERVICE_HOST` cannot express it, and the failure modes.
 
 ### PGPool-II Parameters
 
@@ -1174,7 +1174,7 @@ helm repo update
 helm upgrade my-pgvector cagriekin/pgvector   # add -f your-values.yaml
 ```
 
-`pgvector` tracks `pg` in lockstep — same version, image, and agent; the earlier 0.6.x ↔ 0.5.x split unified at `1.0.0` (current: `1.14.0`, image `trixie-5.5.0-32`). Within the 1.x line `helm upgrade` rolls the pods once and needs no manual step. The default failover mode is `agent` since `1.0.0` (it was `repmgrd` through 0.x); **only when crossing from a 0.x release** does adopting the agent default need the one-time `--cascade=orphan` recreate — pin `repmgr.failoverMode: repmgrd` to defer. Read the `Migrating from X.Y.Z` entries in [`CHANGELOG.md`](CHANGELOG.md) between your version and the target. For the **compatibility matrix, the version model, and the full 0.x → 1.x migration runbook**, see the [pg chart README — Upgrade and migration](../pg/README.md#upgrade-and-migration) (this chart shares pg's templates and agent).
+`pgvector` tracks `pg` in lockstep — same version, image, and agent; the earlier 0.6.x ↔ 0.5.x split unified at `1.0.0` (current: `1.14.1`, image `trixie-5.5.0-33`). Within the 1.x line `helm upgrade` rolls the pods once and needs no manual step. The default failover mode is `agent` since `1.0.0` (it was `repmgrd` through 0.x); **only when crossing from a 0.x release** does adopting the agent default need the one-time `--cascade=orphan` recreate — pin `repmgr.failoverMode: repmgrd` to defer. Read the `Migrating from X.Y.Z` entries in [`CHANGELOG.md`](CHANGELOG.md) between your version and the target. For the **compatibility matrix, the version model, and the full 0.x → 1.x migration runbook**, see the [pg chart README — Upgrade and migration](../pg/README.md#upgrade-and-migration) (this chart shares pg's templates and agent).
 
 ## pgvector Resources
 

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -291,7 +291,7 @@ postgresql:
 repmgr:
   image:
     repository: cagriekin/repmgr
-    tag: trixie-5.5.0-32
+    tag: trixie-5.5.0-33
     # Optional digest pin (e.g. "sha256:..."). When set it is appended as
     # repository:tag@digest, so the cosign-signed / provenance-attested image is
     # pinned at deploy time and a mutable-tag repush cannot silently change it.
@@ -1121,4 +1121,4 @@ etcd:
   # silently ignored, which left the Job on the subchart's older default (#269 review).
   rbac:
     bootstrapImage:
-      tag: trixie-5.5.0-32
+      tag: trixie-5.5.0-33


### PR DESCRIPTION
Step two of #317: the agent fix landed in #318, image `trixie-5.5.0-33` is published, so the charts now pin it.

## Changes

- `repmgr.image.tag` -> `trixie-5.5.0-33` in both charts (main image + service-updater sidecar).
- `version:` 1.14.0 -> **1.14.1** in both — patch, matching the precedent set by #315 (1.13.0 -> 1.13.1 for the `-32` bump): no values added or removed, no rendered change beyond the tag.
- CHANGELOG entries in both charts, with the *why* (the Cilium compound-identity / deny-wins-in-tier reason a proxy is the only route, and why `KUBERNETES_SERVICE_HOST` cannot substitute for `tls-server-name`), the no-new-value recipe, and a `Migrating from 1.14.0` note.
- Docs now name the tag directly instead of the forward reference #318 shipped with, and the compatibility matrix gains a 1.14.1 row (the previous row becomes `1.13.1 – 1.14.0`, still `-32`).

## Verification

- `make -C pg byte-stable REF=master` — the **only** diffs across both charts are the 9 image references and the 10 `helm.sh/chart` labels. Nothing else in the render moved.
- `make -C pg test-template` 1236/1236; `helm-unittest` all suites; `helm lint pg`/`pgvector`; `diff -r pg/templates pgvector/templates` empty; `scripts/check-vendored-subcharts.sh` clean.
- No stale `trixie-5.5.0-32` references remain outside the historical CHANGELOG entries and the matrix row that legitimately describes 1.13.1–1.14.0. Test fixtures keep their deliberately older pins (CI overrides them with the locally built image).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for routing Kubernetes API requests through an in-cluster TCP proxy using `KUBECONFIG`.
  - Leader election and database configuration updates now use the configured API route.
  - Startup logs identify the selected API-server route.

- **Bug Fixes**
  - Prevents connectivity restrictions from leaving clusters without an active primary.
  - Invalid or unreadable Kubernetes configuration now causes a clear startup error.

- **Updates**
  - Released chart version 1.14.1 with updated repmgr and bootstrap images.
  - Updated documentation with configuration, upgrade, and compatibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->