### PR TITLE
fix(kafka,redis): assert helpers silently passed on a dash-leading needle

### DIFF
--- a/kafka/tests/helpers.sh
+++ b/kafka/tests/helpers.sh
@@ -45,11 +45,16 @@ assert_eq() {
   fi
 }
 
+# `grep -q --`, not `grep -q` (#298 review). Without the terminator a needle that begins with a
+# dash is parsed as an OPTION, so grep matches nothing and exits non-zero: assert_contains then
+# reports a spurious failure, and -- far worse -- assert_not_contains reports a spurious PASS. Any
+# assertion whose needle starts with `-` (`- alert: X`, `-headless`, `-exporter`) was silently
+# vacuous. Regex semantics are deliberately preserved; `--` only stops option parsing.
 assert_contains() {
   local description="$1"
   local haystack="$2"
   local needle="$3"
-  if grep -q "${needle}" <<< "${haystack}"; then
+  if grep -q -- "${needle}" <<< "${haystack}"; then
     pass "${description}"
   else
     fail "${description}" "output does not contain '${needle}'"
@@ -60,7 +65,7 @@ assert_not_contains() {
   local description="$1"
   local haystack="$2"
   local needle="$3"
-  if grep -q "${needle}" <<< "${haystack}"; then
+  if grep -q -- "${needle}" <<< "${haystack}"; then
     fail "${description}" "output should not contain '${needle}'"
   else
     pass "${description}"

--- a/redis/tests/helpers.sh
+++ b/redis/tests/helpers.sh
@@ -45,11 +45,16 @@ assert_eq() {
   fi
 }
 
+# `grep -q --`, not `grep -q` (#298 review). Without the terminator a needle that begins with a
+# dash is parsed as an OPTION, so grep matches nothing and exits non-zero: assert_contains then
+# reports a spurious failure, and -- far worse -- assert_not_contains reports a spurious PASS. Any
+# assertion whose needle starts with `-` (`- alert: X`, `-headless`, `-exporter`) was silently
+# vacuous. Regex semantics are deliberately preserved; `--` only stops option parsing.
 assert_contains() {
   local description="$1"
   local haystack="$2"
   local needle="$3"
-  if grep -q "${needle}" <<< "${haystack}"; then
+  if grep -q -- "${needle}" <<< "${haystack}"; then
     pass "${description}"
   else
     fail "${description}" "output does not contain '${needle}'"
@@ -60,7 +65,7 @@ assert_not_contains() {
   local description="$1"
   local haystack="$2"
   local needle="$3"
-  if grep -q "${needle}" <<< "${haystack}"; then
+  if grep -q -- "${needle}" <<< "${haystack}"; then
     fail "${description}" "output should not contain '${needle}'"
   else
     pass "${description}"


### PR DESCRIPTION
Both charts's `tests/helpers.sh` pass the needle to `grep -q` with no `--` terminator, so a needle beginning with a dash is parsed as an **option**: grep matches nothing and exits non-zero.

- `assert_contains` fails spuriously.
- `assert_not_contains` **passes unconditionally** — so any assertion of the form `- alert: X` proves nothing at all.

Found while working on pg (#298), where the same helper copy was hiding a vacuous NetworkPolicy assertion that had never once run. pg's copy is fixed on the `pg-v2` branch; these two are the same bug in the same code and do not belong in a pg release, hence a separate PR.

## Verification

`kafka` 80/80 and `redis` 88/88 still pass, so the fix unmasked no previously-vacuous assertion in either suite.

Worth knowing: `redis/tests/test-template.sh:34` asserts `"-exporter"` and currently passes **by accident** — grep parses it as `-e xporter`, and `xporter` happens to be a substring of the output. After this change it is matched literally, and still passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test assertions so values beginning with a dash are handled correctly.
  * Prevented false failures in “contains” checks and false passes in “does not contain” checks.
  * Preserved existing pattern-matching behavior while making option-like values safe to use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->