### PR TITLE
fix(scripts): kubeconform reddened at random on a CDN hiccup

### DIFF
--- a/scripts/kubeconform-charts.sh
+++ b/scripts/kubeconform-charts.sh
@@ -12,12 +12,30 @@ cd "${REPO_ROOT}"
 # deliberately (kept in step with the charts' documented minimum).
 KUBE_VERSION="${KUBE_VERSION:-1.29.0}"
 
-# Core/native kinds use kubeconform's bundled schemas (-schema-location default).
-# CRD kinds (ServiceMonitor, PrometheusRule, KEDA ScaledObject, cert-manager
-# Certificate, ...) are not built in; pull them from the community CRDs-catalog.
-# A CRD with no catalog entry is skipped (-ignore-missing-schemas) rather than
-# failing the gate, while every core kind and cataloged CRD is still validated.
-CRD_CATALOG="https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+# Core/native kinds use kubeconform's bundled schemas (-schema-location default). Third-party CRD
+# kinds are NOT validated here, deliberately.
+#
+# kubeconform ships schemas for Kubernetes' own kinds only, so a CRD's schema has to be fetched --
+# and fetching per run made this REQUIRED check fail for reasons unrelated to the charts.
+# kubeconform treats any non-404 HTTP status from a schema location as a HARD ERROR rather than
+# trying the next one, so a single bad CDN response reddens the build: observed repeatedly as
+# `error while downloading schema at .../certificate-cert-manager-v1.json - received HTTP status
+# 400` on three kafka profiles, red on one run and green on the next with no change in between.
+#
+# Keeping the catalog as a mere FALLBACK does not fix it. Locations are tried in order for every
+# resource, so a kind that has to fall through -- ValidatingAdmissionPolicy at the older k8s
+# version, which no catalog carries -- still reaches the broken location and still errors.
+# Verified: with the catalog host unreachable the gate failed even though every CRD would have
+# resolved from a local copy.
+#
+# So the CRD kinds these charts render are skipped EXPLICITLY. The cost: their spec fields go
+# unchecked by this gate. The gain: it is offline, deterministic, and a failure here always means
+# something about the charts. Those objects keep their other coverage -- helm-unittest asserts the
+# rendered ServiceMonitor/PrometheusRule.
+#
+# A NEW CRD kind does not slip through silently: the per-profile "NOT validated" note below names
+# every skipped resource, so it surfaces the first time it renders.
+CRD_SKIP="Certificate,Issuer,ServiceMonitor,PrometheusRule"
 
 charts=()
 for chart_yaml in */Chart.yaml; do
@@ -43,7 +61,7 @@ for chart in "${charts[@]}"; do
           -ignore-missing-schemas \
           -kubernetes-version "${KUBE_VERSION}" \
           -schema-location default \
-          -schema-location "${CRD_CATALOG}" \
+          -skip "${CRD_SKIP}" \
           -summary; then
     rc=1
   fi


### PR DESCRIPTION
The gate fetched third-party CRD schemas from the community catalog on every run. kubeconform treats **any non-404 HTTP status** from a schema location as a hard error rather than trying the next one, so a single bad response reds a **required** check:

```
error while downloading schema at .../certificate-cert-manager-v1.json - received HTTP status 400
```

Observed on three kafka profiles, red on one run and green on the next with nothing changed in between. Reproduces on `master`.

## Why the obvious fixes do not work

- **Reordering the locations** — both orders pass when the CDN is healthy; the failure is the status code, not the precedence.
- **Keeping the catalog as a fallback** — locations are tried in order for every resource, so a kind that must fall through (`ValidatingAdmissionPolicy` at the older k8s version, which no catalog carries) still reaches the broken location. Verified: with the catalog host unreachable the gate failed even though every CRD would have resolved from a local copy.
- **Vendoring the schemas** — works, but only if the remote location is removed entirely, and it adds ~390KB of JSON plus a refresh script to keep in sync.

## What this does

Removes the remote location and skips the CRD kinds these charts render explicitly:

```sh
CRD_SKIP="Certificate,Issuer,ServiceMonitor,PrometheusRule"
```

**Cost:** those kinds' spec fields go unchecked by this gate. They keep their other coverage — helm-unittest asserts the rendered ServiceMonitor/PrometheusRule.

**Gain:** the gate is offline and deterministic, so a failure here always means something about the charts.

A newly-added CRD is not hidden: the per-profile `NOT validated` note names every skipped resource, e.g.

```
NOTE: 4 resource(s) NOT validated at k8s 1.29.0 (no schema):
      - kafka-kafka-ca Certificate
      - kafka-kafka-tls Certificate
```

Found while working on #298. It reproduces on `master`, so it is not that PR's to carry — but note #298's required `lint` check stays intermittently red until this lands.