### PR TITLE
fix(agent): re-read the pause marker fresh before a restore stop (#339)

### DIFF
--- a/images/pg-ha/agent/cmd/agent/control.go
+++ b/images/pg-ha/agent/cmd/agent/control.go
@@ -144,11 +144,27 @@ func (a *agent) runIntent(parent context.Context, req intentRequest) error {
 		// deadline. A restore requested while act() sat inside a multi-hour clone was
 		// accepted, timed out at the client with "no restore Job was created; retry", and
 		// the operator resumed the cluster -- then, hours later, this dequeued and gracefully
-		// stopped the now-serving primary for a restore nobody was still running. The loop's
-		// own last successful marker read is the cheapest honest answer here; if it says the
+		// stopped the now-serving primary for a restore nobody was still running. If the
 		// cluster is not paused, the reconcile loop would restart the postmaster on its next
 		// tick anyway, so stopping it buys nothing but an outage.
-		if !a.lastMarkerOK || !a.lastMarker.Paused {
+		//
+		// Read the marker FRESH here rather than trusting the loop's cached a.lastMarker
+		// (#339). a.lastMarker is only refreshed by observe() once per reconcile tick, but
+		// the documented runbook -- and the KinD suite -- pauses and IMMEDIATELY requests the
+		// restore: with no tick in between, a.lastMarker still reads unpaused and the stop is
+		// refused on a correctly-paused cluster, a race against ReconcileInterval that made
+		// POST /v1/restore intermittently 500. The handler already read the marker fresh
+		// before Submit; this second line of defense must be at least as current or it
+		// manufactures the very false negative it exists to prevent. observe() is the only
+		// writer of a.lastMarker (see below), so this reads into a local instead of touching
+		// it. A read error fails closed -- refuse rather than stop on an unconfirmed pause.
+		mctx, mcancel := context.WithTimeout(stopCtx, a.fenceBudget())
+		m, err := a.kube.ReadMarker(mctx, a.cfg.MarkerName)
+		mcancel()
+		if err != nil {
+			return fmt.Errorf("refusing to stop postgres for a restore: could not confirm the cluster is paused: %w", err)
+		}
+		if !m.Paused {
 			return fmt.Errorf("refusing to stop postgres for a restore: the cluster is no longer paused (the request outlived its pause); pause again and re-request")
 		}
 		if err := a.sup.Demote(stopCtx, false); err != nil {

--- a/images/pg-ha/agent/cmd/agent/control.go
+++ b/images/pg-ha/agent/cmd/agent/control.go
@@ -63,26 +63,35 @@ func (a *agent) runIntent(parent context.Context, req intentRequest) error {
 	kind := req.kind
 	// Only the stop is deadline-bounded. Start and Reload do not block on the child, and
 	// bounding them would add nothing but a way to fail.
-	stopCtx, cancelStop := parent, context.CancelFunc(func() {})
-	if !req.deadline.IsZero() {
-		// FLOORED, not used raw (#298 review). req.deadline is copied from the HTTP request
-		// context and the request deliberately stays queued after the caller gives up ("if
-		// ctx expires after the intent was accepted, the loop still performs it") -- so by
-		// the time the loop dequeues it, the deadline is routinely in the PAST. A past
-		// deadline makes context.WithDeadline return an already-cancelled context, and
-		// ChildPostmaster.Stop then takes its `case <-ctx.Done()` arm on the first select:
-		// SIGKILL immediately after the SIGINT, with zero grace. An operator POSTing
-		// /v1/node/restart while act() sits in a 60s pg_ctl promote therefore got a 504 and,
-		// a moment later, a SIGKILLed read-write primary forced into crash recovery -- on the
-		// restart they asked to be graceful. IntentStop likewise reported a failure nobody
-		// saw. The floor keeps the wedge bounded (which is all the deadline is for) while
-		// guaranteeing a real shutdown attempt.
+	// deriveStopCtx builds the graceful-shutdown window for a Demote.
+	//
+	// FLOORED, not used raw (#298 review). req.deadline is copied from the HTTP request
+	// context and the request deliberately stays queued after the caller gives up ("if
+	// ctx expires after the intent was accepted, the loop still performs it") -- so by
+	// the time the loop dequeues it, the deadline is routinely in the PAST. A past
+	// deadline makes context.WithDeadline return an already-cancelled context, and
+	// ChildPostmaster.Stop then takes its `case <-ctx.Done()` arm on the first select:
+	// SIGKILL immediately after the SIGINT, with zero grace. An operator POSTing
+	// /v1/node/restart while act() sits in a 60s pg_ctl promote therefore got a 504 and,
+	// a moment later, a SIGKILLed read-write primary forced into crash recovery -- on the
+	// restart they asked to be graceful. IntentStop likewise reported a failure nobody
+	// saw. The floor keeps the wedge bounded (which is all the deadline is for) while
+	// guaranteeing a real shutdown attempt.
+	//
+	// It is a closure, not a once-computed context, because IntentStop must re-derive it
+	// AFTER its fresh marker read (#339): the floor measures the graceful window from the
+	// moment the stop actually begins, so a slow apiserver read cannot eat into it.
+	deriveStopCtx := func() (context.Context, context.CancelFunc) {
+		if req.deadline.IsZero() {
+			return parent, func() {}
+		}
 		budget := time.Until(req.deadline)
 		if budget < minIntentStopBudget {
 			budget = minIntentStopBudget
 		}
-		stopCtx, cancelStop = context.WithTimeout(parent, budget)
+		return context.WithTimeout(parent, budget)
 	}
+	stopCtx, cancelStop := deriveStopCtx()
 	defer cancelStop()
 	switch kind {
 	case control.IntentReload:
@@ -158,7 +167,10 @@ func (a *agent) runIntent(parent context.Context, req intentRequest) error {
 		// manufactures the very false negative it exists to prevent. observe() is the only
 		// writer of a.lastMarker (see below), so this reads into a local instead of touching
 		// it. A read error fails closed -- refuse rather than stop on an unconfirmed pause.
-		mctx, mcancel := context.WithTimeout(stopCtx, a.fenceBudget())
+		// Parented on `parent`, NOT stopCtx: the read gets its own bound (fenceBudget, the
+		// same budget observe() reads the marker under) and must not be truncated by a near
+		// stop deadline into a false "could not confirm" (#339 review).
+		mctx, mcancel := context.WithTimeout(parent, a.fenceBudget())
 		m, err := a.kube.ReadMarker(mctx, a.cfg.MarkerName)
 		mcancel()
 		if err != nil {
@@ -167,7 +179,11 @@ func (a *agent) runIntent(parent context.Context, req intentRequest) error {
 		if !m.Paused {
 			return fmt.Errorf("refusing to stop postgres for a restore: the cluster is no longer paused (the request outlived its pause); pause again and re-request")
 		}
-		if err := a.sup.Demote(stopCtx, false); err != nil {
+		// Derive the stop window AFTER the read so the read's latency cannot erode the
+		// minIntentStopBudget floor #298 guarantees (#339 review).
+		sctx, scancel := deriveStopCtx()
+		defer scancel()
+		if err := a.sup.Demote(sctx, false); err != nil {
 			return fmt.Errorf("stop postgres: %w", err)
 		}
 		a.log.Warn("control: stopped postgres for a restore")

--- a/images/pg-ha/agent/cmd/agent/control_test.go
+++ b/images/pg-ha/agent/cmd/agent/control_test.go
@@ -142,11 +142,16 @@ func TestIntentBudgetScalesWithReconcileInterval(t *testing.T) {
 func newIntentAgent(t *testing.T, pm *fakePostmaster) *agent {
 	t.Helper()
 	return &agent{
-		cfg: &config.Config{PGDATA: t.TempDir(), PodName: "pg-0"},
+		cfg: &config.Config{PGDATA: t.TempDir(), PodName: "pg-0", MarkerName: "pg-primary"},
 		log: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		// A non-leader DCS, because runIntent's destructive verbs re-check holdership under
 		// opMu (#298 review) -- see TestRunIntentReinitializeRefusesOnceThisNodeIsPrimary.
-		dcs:     &fakeDCS{},
+		dcs: &fakeDCS{},
+		// A real k8s client over a fake clientset: IntentStop now re-reads the pause marker
+		// FRESH (#339), so it needs a working kube. An absent marker ConfigMap reads as
+		// Present:false / Paused:false, which is the correct "not paused" for tests that
+		// never create one.
+		kube:    k8s.NewWithClient(k8sfake.NewSimpleClientset(), "ns"),
 		sup:     process.NewSupervisor(pm),
 		metr:    observe.New(),
 		intents: make(chan intentRequest, 1),
@@ -177,7 +182,7 @@ func TestRunIntentRestartStopsAndStarts(t *testing.T) {
 func TestRunIntentStopRefusesOnceTheClusterIsNoLongerPaused(t *testing.T) {
 	pm := &fakePostmaster{running: true}
 	a := newIntentAgent(t, pm)
-	a.lastMarkerOK, a.lastMarker.Paused = true, false
+	// No paused marker written: the fresh re-read (#339) sees an unpaused cluster.
 	err := a.runIntent(context.Background(), intentRequest{kind: control.IntentStop})
 	if err == nil || !strings.Contains(err.Error(), "no longer paused") {
 		t.Fatalf("expected a refusal naming the lifted pause, got %v", err)
@@ -191,8 +196,16 @@ func TestRunIntentStopRefusesOnceTheClusterIsNoLongerPaused(t *testing.T) {
 func TestRunIntentStopLeavesPostgresDown(t *testing.T) {
 	pm := &fakePostmaster{running: true}
 	a := newIntentAgent(t, pm)
-	a.lastMarkerOK, a.lastMarker.Paused = true, true // the stop re-asserts the pause at dequeue (#298 review)
-	if err := a.runIntent(context.Background(), intentRequest{kind: control.IntentStop}); err != nil {
+	// The stop re-asserts the pause at dequeue with a FRESH read (#298 review, #339), so the
+	// paused state must live in the marker, not just a.lastMarker.
+	ctx := context.Background()
+	if err := a.kube.WriteMarker(ctx, a.cfg.MarkerName, "pg-0", 1); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+	if err := a.kube.SetPause(ctx, a.cfg.MarkerName, true, "dba"); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if err := a.runIntent(ctx, intentRequest{kind: control.IntentStop}); err != nil {
 		t.Fatalf("stop: %v", err)
 	}
 	if !pm.stopped {
@@ -200,6 +213,31 @@ func TestRunIntentStopLeavesPostgresDown(t *testing.T) {
 	}
 	if pm.started {
 		t.Error("stop must NOT start it again: the caller is about to restore over this data directory")
+	}
+}
+
+// #339 regression: the pause re-assertion must read the marker FRESH, not the reconcile
+// loop's cached a.lastMarker. The documented runbook pauses and IMMEDIATELY requests the
+// restore, so with no reconcile tick in between a.lastMarker still reads unpaused -- and the
+// stop was refused on a correctly-paused cluster, making POST /v1/restore intermittently 500.
+func TestRunIntentStopReadsThePauseFreshNotTheLoopCache(t *testing.T) {
+	pm := &fakePostmaster{running: true}
+	a := newIntentAgent(t, pm)
+	// The loop's cache is STALE: it last saw the cluster unpaused.
+	a.lastMarkerOK, a.lastMarker.Paused = true, false
+	// The operator has just paused it; the marker is fresh even though the loop has not ticked.
+	ctx := context.Background()
+	if err := a.kube.WriteMarker(ctx, a.cfg.MarkerName, "pg-0", 1); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+	if err := a.kube.SetPause(ctx, a.cfg.MarkerName, true, "dba"); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if err := a.runIntent(ctx, intentRequest{kind: control.IntentStop}); err != nil {
+		t.Fatalf("stop must proceed on a freshly-paused cluster despite a stale loop cache: %v", err)
+	}
+	if !pm.stopped {
+		t.Error("postgres should be stopped when the fresh marker reports paused")
 	}
 }
 
@@ -421,7 +459,14 @@ func TestDropRestoreRecordToleratesAMissingFile(t *testing.T) {
 func TestRunIntentStopIsBoundedByTheRequestDeadline(t *testing.T) {
 	pm := &fakePostmaster{running: true, stopErr: context.DeadlineExceeded}
 	a := newIntentAgent(t, pm)
-	a.lastMarkerOK, a.lastMarker.Paused = true, true // the stop re-asserts the pause at dequeue (#298 review)
+	// The stop re-asserts the pause at dequeue with a FRESH read (#298 review, #339).
+	ctx := context.Background()
+	if err := a.kube.WriteMarker(ctx, a.cfg.MarkerName, "pg-0", 1); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+	if err := a.kube.SetPause(ctx, a.cfg.MarkerName, true, "dba"); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
 	req := intentRequest{kind: control.IntentStop, deadline: time.Now().Add(50 * time.Millisecond)}
 	err := a.runIntent(context.Background(), req)
 	if err == nil {

--- a/images/pg-ha/agent/cmd/agent/control_test.go
+++ b/images/pg-ha/agent/cmd/agent/control_test.go
@@ -142,7 +142,14 @@ func TestIntentBudgetScalesWithReconcileInterval(t *testing.T) {
 func newIntentAgent(t *testing.T, pm *fakePostmaster) *agent {
 	t.Helper()
 	return &agent{
-		cfg: &config.Config{PGDATA: t.TempDir(), PodName: "pg-0", MarkerName: "pg-primary"},
+		// Realistic lease timings so fenceBudget() (LeaseDuration-RenewDeadline, floored to
+		// RetryPeriod) is POSITIVE: IntentStop's fresh ReadMarker (#339) runs under that
+		// budget, and a zero here would hand it an already-expired context -- masked today
+		// only because the fake clientset ignores deadlines.
+		cfg: &config.Config{
+			PGDATA: t.TempDir(), PodName: "pg-0", MarkerName: "pg-primary",
+			LeaseDuration: 15 * time.Second, RenewDeadline: 10 * time.Second, RetryPeriod: 2 * time.Second,
+		},
 		log: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		// A non-leader DCS, because runIntent's destructive verbs re-check holdership under
 		// opMu (#298 review) -- see TestRunIntentReinitializeRefusesOnceThisNodeIsPrimary.

--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,21 @@
 # pg chart changelog
 
+## 2.0.1 - unreleased
+
+### Fixed
+
+- **`POST /v1/restore` no longer intermittently returns 500 on a just-paused cluster (#339).**
+  Before stopping the postmaster, the agent re-asserts the pause a second time inside the
+  reconcile goroutine (a restore intent deliberately outlives its caller, so a resumed cluster
+  must not be stopped hours later). That re-assert read the loop's CACHED marker
+  (`a.lastMarker`, refreshed only once per reconcile tick) instead of a fresh one -- but the
+  break-glass runbook, and the KinD suite, pause and then IMMEDIATELY request the restore. With
+  no tick in between, the cached marker still read unpaused, so the stop was refused with "the
+  cluster is no longer paused", surfacing to the operator as a 500 with no restore Job created.
+  It now re-reads the marker fresh, exactly as the HTTP handler already does before submitting
+  the intent, so the guard still catches a genuinely lifted pause without rejecting a correctly
+  paused one. Ships in the pg-ha image at 2.0.1.
+
 ## 2.0.0 - 2026-09-02
 
 The failover agent is now the only HA mechanism. repmgrd, the repmgr CLI mechanism and their

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,21 @@
 # pgvector chart changelog
 
+## 2.0.1 - unreleased
+
+### Fixed
+
+- **`POST /v1/restore` no longer intermittently returns 500 on a just-paused cluster (#339).**
+  Before stopping the postmaster, the agent re-asserts the pause a second time inside the
+  reconcile goroutine (a restore intent deliberately outlives its caller, so a resumed cluster
+  must not be stopped hours later). That re-assert read the loop's CACHED marker
+  (`a.lastMarker`, refreshed only once per reconcile tick) instead of a fresh one -- but the
+  break-glass runbook, and the KinD suite, pause and then IMMEDIATELY request the restore. With
+  no tick in between, the cached marker still read unpaused, so the stop was refused with "the
+  cluster is no longer paused", surfacing to the operator as a 500 with no restore Job created.
+  It now re-reads the marker fresh, exactly as the HTTP handler already does before submitting
+  the intent, so the guard still catches a genuinely lifted pause without rejecting a correctly
+  paused one. Ships in the pg-ha image at 2.0.1.
+
 ## 2.0.0 - 2026-09-02
 
 The failover agent is now the only HA mechanism. repmgrd, the repmgr CLI mechanism and their


### PR DESCRIPTION
## What

`POST /v1/restore` intermittently returned **HTTP 500** ("could not stop postgres: the cluster is no longer paused") on a correctly-paused cluster, so no restore Job was created.

## Root cause

Before stopping the postmaster, `runIntent` re-asserts the pause a second time in the reconcile goroutine (a restore intent deliberately outlives its caller, so a *resumed* cluster must not be stopped later). That re-assert read the loop's **cached** marker (`a.lastMarker`, refreshed only once per reconcile tick) instead of a fresh one. The break-glass runbook — and the KinD suite — pause and then **immediately** request the restore; with no tick in between, the cached marker still read unpaused and the stop was refused → 500.

It's a race against `ReconcileInterval`; earlier CI runs happened to tick in time.

## Fix

Re-read the marker **fresh** (`a.kube.ReadMarker`), exactly as the HTTP handler already does before submitting the intent. The guard still catches a genuinely lifted pause without rejecting a correctly-paused one. Reads into a local (observe() remains the sole writer of `a.lastMarker`); a read error fails closed.

## How it surfaced

A Dependabot grpc bump (#339) tripped the race in CI. The failure is **pre-existing on the 2.0.0 line and unrelated to the dependency** — reproduced identically on master at grpc 1.82.1.

## Tests

- New `TestRunIntentStopReadsThePauseFreshNotTheLoopCache` encodes the race (stale cache unpaused, fresh marker paused → stop must proceed). Mutation-verified: fails against the old cached-marker check.
- Existing stop tests updated to seed the real marker; full agent `go vet ./... && go test ./...` green.
- Reproduced the original 500 on master via the KinD `test-agent-control-restore` suite, and confirmed the fix locally.

## Release follow-up (not in this PR)

Delivering the fix needs the standard two-step: publish the pg-ha image at 2.0.1, then bump `ha.image.tag` + chart version in both `pg`/`pgvector`. CHANGELOG entry added under `## 2.0.1 - unreleased`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an intermittent `500` response from `POST /v1/restore` when restoring a cluster that was just paused.
  - Restore operations now verify the cluster’s current pause state before proceeding, preventing stale status information from causing false refusals.
  - Restore requests continue to be refused when the cluster is no longer paused.
  - Correctly paused restore requests can now proceed without failing before a restore job is created.

- **Documentation**
  - Added unreleased 2.0.1 changelog entries describing the restore reliability fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->