### PR TITLE
chore(pg,pgvector): release 2.0.1 (#339)

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,6 +1,6 @@
 # pg chart changelog
 
-## 2.0.1 - unreleased
+## 2.0.1 - 2026-09-02
 
 ### Fixed
 

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with streaming replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -516,7 +516,7 @@ postgresql:
 ha:
   image:
     repository: cagriekin/pg-ha
-    tag: 2.0.0-pg18
+    tag: 2.0.1-pg18
     # Optional digest pin (e.g. "sha256:..."). When set it is appended as
     # repository:tag@digest, so the cosign-signed / provenance-attested image is
     # pinned at deploy time and a mutable-tag repush cannot silently change it.
@@ -1520,4 +1520,4 @@ etcd:
   rbac:
     bootstrapImage:
       repository: cagriekin/pg-ha
-      tag: 2.0.0-pg18
+      tag: 2.0.1-pg18

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,6 +1,6 @@
 # pgvector chart changelog
 
-## 2.0.1 - unreleased
+## 2.0.1 - 2026-09-02
 
 ### Fixed
 

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus streaming replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -348,7 +348,7 @@ postgresql:
 ha:
   image:
     repository: cagriekin/pg-ha
-    tag: 2.0.0-pg18
+    tag: 2.0.1-pg18
     # Optional digest pin (e.g. "sha256:..."). When set it is appended as
     # repository:tag@digest, so the cosign-signed / provenance-attested image is
     # pinned at deploy time and a mutable-tag repush cannot silently change it.
@@ -1230,4 +1230,4 @@ etcd:
   rbac:
     bootstrapImage:
       repository: cagriekin/pg-ha
-      tag: 2.0.0-pg18
+      tag: 2.0.1-pg18


### PR DESCRIPTION
Chart 2.0.1: bumps `ha.image.tag` (and the matching etcd RBAC-bootstrap image) to `2.0.1-pg18`, chart `version` to 2.0.1, and dates the CHANGELOG. Ships the #339 fix (fresh pause re-read before a restore stop) built into pg-ha 2.0.1. Follows the two-step image contract: pg-ha-2.0.1 images are published from the tag pushed at merge-base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 2.0.1 for the PostgreSQL and pgvector Helm charts, dated September 2, 2026.
  * Updated bundled HA and etcd bootstrap images to the 2.0.1 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->