### PR TITLE
feat(pg,pgvector): record pgbackrest info after each backup (#343)

### DIFF
--- a/pg/CHANGELOG.md
+++ b/pg/CHANGELOG.md
@@ -1,5 +1,21 @@
 # pg chart changelog
 
+## 2.1.0 - 2026-09-08
+
+### Added
+
+- **The backup CronJob records the repository state (#343).** After every successful backup it
+  patches `pgbackrest info --output=json` verbatim into `configmap/<fullname>-pgbackrest-info`
+  (data key `info.json`, plus `pg-ha/recorded-at`, `pg-ha/backup-type`, `pg-ha/stanza`,
+  `pg-ha/primary` and `pg-ha/status-code` annotations), so a controller can read backup sets,
+  sizes and the PITR floor with no pgBackRest credentials, exec grant or control-API
+  certificate. The verdict is the JSON's `status.code`, not the exit status — `pgbackrest info`
+  exits 0 on a repository it cannot read — and a non-zero code now fails the backup Job, where
+  the old trailing human-format `info` passed silently. The ConfigMap is rendered empty so the
+  pgbackrest ServiceAccount needs only `get`/`patch` on that one name; `helm upgrade --force`
+  empties the record until the next backup. Opt out with `pgbackrest.info.enabled=false`.
+  `INFO_CONFIGMAP` joins the names `pgbackrest.extraEnv` may not reuse.
+
 ## 2.0.2 - 2026-09-06
 
 ### Changed

--- a/pg/Chart.yaml
+++ b/pg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg
 description: Highly-available PostgreSQL with streaming replication, automatic agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, pgBackRest S3 backups, TLS, and Prometheus metrics
 type: application
-version: 2.0.2
+version: 2.1.0
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pg
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pg/README.md
+++ b/pg/README.md
@@ -2240,7 +2240,7 @@ helm install my-postgres cagriekin/pg \
 - **Full backups**: Weekly (default Sunday 1am) via a CronJob that execs into the pgbackrest sidecar on the current primary.
 - **Differential backups**: Daily (default Mon-Sat 1am) via a separate CronJob. Only changed blocks since the last full backup are stored.
 - **Failover**: After the agent promotes a standby, the new primary starts archiving WAL and running backups automatically.
-- **Verification**: After each backup, `pgbackrest info` confirms the backup was recorded in the repository.
+- **Record**: After each backup, the CronJob writes `pgbackrest info --output=json` into `configmap/<fullname>-pgbackrest-info` and fails the Job if the JSON says the repository is unreadable — see [Check Backup Status](#check-backup-status) (#343).
 
 ### pgBackRest Parameters
 
@@ -2285,6 +2285,7 @@ helm install my-postgres cagriekin/pg \
 | `pgbackrest.cronjob.resources.limits.memory` | CronJob memory limit | `128Mi` |
 | `pgbackrest.cronjob.podSecurityContext` | Pod securityContext for the pgBackRest CronJob | `runAsNonRoot: true`, `runAsUser: 65534`, `seccompProfile: RuntimeDefault` |
 | `pgbackrest.cronjob.containerSecurityContext` | Container securityContext for the pgBackRest CronJob | `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]` |
+| `pgbackrest.info.enabled` | Record `pgbackrest info --output=json` in `configmap/<fullname>-pgbackrest-info` after every successful backup, and fail the backup Job when its `status.code` is non-zero ([#343](#check-backup-status)); grants the pgbackrest SA `get`/`patch` on that one ConfigMap | `true` |
 | `pgbackrest.validation.enabled` | Enable the automated PITR restore-validation CronJob (#38) — restores the repo into a throwaway PostgreSQL, replays WAL, validates, exits | `false` |
 | `pgbackrest.validation.schedule` | Cron schedule for the validation job | `` `0 4 * * 0` `` |
 | `pgbackrest.validation.targetType` | PITR target type (`pgbackrest --type`): `""` (latest) \| `time` \| `xid` \| `name` \| `lsn`. `target` is required when set | `""` |
@@ -2405,8 +2406,46 @@ postgresql:
 
 ### Check Backup Status
 
+After every successful backup the CronJob records `pgbackrest info --output=json` in
+`configmap/<fullname>-pgbackrest-info` (#343), so a controller or dashboard can read the backup
+sets, their sizes and the PITR floor without pgBackRest credentials, a `kubectl exec` grant or a
+control-API certificate:
+
 ```bash
-kubectl exec -it my-postgres-pg-0 -- pgbackrest --stanza=db info
+# The document, verbatim from pgBackRest.
+kubectl get configmap my-postgres-pg-pgbackrest-info -o jsonpath='{.data.info\.json}' | jq .
+# The essentials without parsing it.
+kubectl get configmap my-postgres-pg-pgbackrest-info \
+  -o go-template='{{index .metadata.annotations "pg-ha/recorded-at"}} {{index .metadata.annotations "pg-ha/backup-type"}} status={{index .metadata.annotations "pg-ha/status-code"}}{{"\n"}}'
+```
+
+- `data."info.json"` is pgBackRest's own JSON, unmodelled — its schema is the contract, same as
+  `GET /v1/backups`. Note it is an **array of stanzas** (one entry, `.[0]` or
+  `.[] | select(.name == "db")`), each carrying its own `backup[]`, `archive[]` and `status`.
+  Annotations: `pg-ha/recorded-at` (RFC 3339 UTC), `pg-ha/backup-type`
+  (`full`/`diff`), `pg-ha/stanza`, `pg-ha/primary` (the pod the backup ran on),
+  `pg-ha/status-code`.
+- **Trust `status.code`, never an exit status.** `pgbackrest info` exits 0 on a repository it
+  cannot read (`status: error (missing stanza data)`, `code: 3`, `backup: []`), and `verify`
+  prints `completed successfully` on the same repository. The CronJob records the document
+  whatever the code — an unreadable repository must stay distinguishable from an empty one —
+  and then **fails the Job** on a non-zero code, so whatever alerts on a failed backup alerts on
+  this too.
+- `info.size` is the **database** size; `info.repository.size` is what the backup **occupies**
+  in the repository (compressed). They differ by ~8× on an empty database; a "backup size"
+  shown to a human is the repository one.
+- The record is refreshed only when a backup completes. A `recorded-at` older than the schedule
+  means backups have stopped; look at the CronJob's Jobs. The ConfigMap is rendered empty by the
+  chart and stays empty until the first backup; `helm upgrade --force` empties it again.
+- `pgbackrest info` reads the **repository**, not the node — any pod answers the same. It is
+  recorded from the backup CronJob because that is the one moment that knows a backup just
+  completed, not because the primary's answer is more correct. For an on-demand, authenticated
+  read use `GET /v1/backups` on the [control API](#control-rest-api-agent-mode--haagentcontrol).
+- Opt out with `pgbackrest.info.enabled=false`; the Job then prints the human `pgbackrest info`
+  to its log as before. A one-off read still works from any pod:
+
+```bash
+kubectl exec -it my-postgres-pg-0 -c pgbackrest -- pgbackrest --stanza=db info
 ```
 
 ### Point-in-Time Recovery

--- a/pg/templates/_helpers.tpl
+++ b/pg/templates/_helpers.tpl
@@ -1265,7 +1265,7 @@ GRANT {{ $privs }} ON DATABASE "{{ $g.database }}" TO "{{ $role }}"
        (repoEncryption, s3.keyType=shared) -- so a passthrough that works today cannot start
        silently shadowing a chart value after a later `helm upgrade` enables that feature. */ -}}
 {{- $chartEnv := list
-      "NAMESPACE" "PRIMARY_SVC" "STANZA" "BACKUP_TYPE" "HOME"
+      "NAMESPACE" "PRIMARY_SVC" "STANZA" "BACKUP_TYPE" "INFO_CONFIGMAP" "HOME"
       "PGBACKREST_STANZA" "PGDATA" "PGBACKREST_PG1_PATH"
       "PGBACKREST_LOG_PATH" "PGBACKREST_LOCK_PATH"
       "TARGET_TYPE" "TARGET" "BACKUP_SET" "FORCE" "RESTORE_REQUESTED_BY"

--- a/pg/templates/pgbackrest-cronjob.yaml
+++ b/pg/templates/pgbackrest-cronjob.yaml
@@ -68,6 +68,15 @@ spec:
                   # the actionable error below instead of aborting with a bare trace.
                   # Sorted so selection is deterministic across runs and independent of
                   # EndpointSlice list order (matters only in the rare multi-endpoint case).
+{{- if $root.Values.pgbackrest.info.enabled }}
+                  # The #343 record needs jq (alpine/k8s ships it). Check before the backup, so
+                  # a custom pgbackrest.cronjob.image without it fails here with the fix named
+                  # rather than after a successful backup it then reports as failed.
+                  command -v jq >/dev/null 2>&1 || {
+                    echo "ERROR: jq is not in the CronJob image but pgbackrest.info.enabled=true needs it to record the repository state; use an image that has jq (the default alpine/k8s does) or set pgbackrest.info.enabled=false" >&2
+                    exit 1
+                  }
+{{- end }}
                   CANDIDATES=$(kubectl -n "$NAMESPACE" get endpointslices \
                     -l "kubernetes.io/service-name=$PRIMARY_SVC" \
                     -o jsonpath='{.items[*].endpoints[?(@.conditions.ready==true)].targetRef.name}' \
@@ -140,9 +149,51 @@ spec:
                   kubectl -n "$NAMESPACE" exec "$PRIMARY" -c pgbackrest -- \
                     pgbackrest --stanza="$STANZA" --type="$BACKUP_TYPE" backup
 
-                  echo "$BACKUP_TYPE backup completed. Repository state:"
+                  echo "$BACKUP_TYPE backup completed."
+{{- if $root.Values.pgbackrest.info.enabled }}
+
+                  # Record the repository state where a controller can read it without
+                  # pgbackrest credentials or a control-API certificate (#343). `info` reads
+                  # the REPOSITORY, not the node, so any pod would answer the same -- it runs
+                  # in the sidecar that just backed up only because this is the one moment
+                  # that knows a backup completed. Console logging off so nothing interleaves
+                  # with the JSON; the sed drops anything pgBackRest prints to stdout BEFORE
+                  # logging is configured (an unknown PGBACKREST_* option arriving through
+                  # pgbackrest.extraEnv earns a WARN there); jq -e requires one valid document
+                  # (empty input is exit 4, not an empty record), so a non-JSON answer fails
+                  # here and the previous record stays intact. Files live under $HOME: that is
+                  # the /tmp emptyDir here, and it lets the template test point it elsewhere.
+                  kubectl -n "$NAMESPACE" exec "$PRIMARY" -c pgbackrest -- \
+                    pgbackrest --stanza="$STANZA" --output=json --log-level-console=off info \
+                    | sed -n '/^[[{]/,$p' | jq -ce . > "$HOME/info.json"
+                  # The exit status is NOT the verdict: `pgbackrest info` exits 0 on a
+                  # repository it cannot read (status "missing stanza data", code 3) and
+                  # `verify` prints "completed successfully" on the same repository; only the
+                  # JSON's status.code tells. Record first, whatever the code, so an unreadable
+                  # repository stays distinguishable from an empty one -- then fail the Job on
+                  # a non-zero code, so whatever alerts on a failed backup alerts on this too.
+                  # The document is an ARRAY of stanzas (one here, --stanza filters), each with its
+                  # own status; select ours by name rather than trusting the position.
+                  INFO_STANZA='first(.[] | select(.name == $s))'
+                  INFO_CODE=$(jq -r --arg s "$STANZA" "($INFO_STANZA | .status.code) // \"absent\"" "$HOME/info.json")
+                  jq -n --arg type "$BACKUP_TYPE" --arg stanza "$STANZA" --arg primary "$PRIMARY" \
+                    --arg code "$INFO_CODE" --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                    --rawfile info "$HOME/info.json" \
+                    '{ metadata: { annotations: {
+                         "pg-ha/recorded-at": $at, "pg-ha/backup-type": $type, "pg-ha/stanza": $stanza,
+                         "pg-ha/primary": $primary, "pg-ha/status-code": $code } },
+                       data: { "info.json": ($info | rtrimstr("\n")) } }' > "$HOME/info-patch.json"
+                  kubectl -n "$NAMESPACE" patch configmap "$INFO_CONFIGMAP" --type merge --patch-file "$HOME/info-patch.json"
+                  echo "Recorded repository state in configmap/$INFO_CONFIGMAP: $(jq -r --arg s "$STANZA" "$INFO_STANZA"' | "status=\(.status.code) (\(.status.message)) backups=\(.backup | length) latest=\(.backup[-1].label // "none") repo-size=\(.backup[-1].info.repository.size // 0)"' "$HOME/info.json")"
+                  if [ "$INFO_CODE" != "0" ]; then
+                    echo "ERROR: pgbackrest info reports status.code=$INFO_CODE ($(jq -r --arg s "$STANZA" "($INFO_STANZA | .status.message) // \"stanza not in the document\"" "$HOME/info.json")) for stanza $STANZA -- the repository is not restorable even though the backup command exited 0" >&2
+                    exit 1
+                  fi
+{{- else }}
+                  echo "Repository state:"
                   kubectl -n "$NAMESPACE" exec "$PRIMARY" -c pgbackrest -- \
                     pgbackrest --stanza="$STANZA" info
+{{- end }}
               env:
                 - name: NAMESPACE
                   valueFrom:
@@ -154,6 +205,10 @@ spec:
                   value: {{ $root.Values.pgbackrest.stanza | quote }}
                 - name: BACKUP_TYPE
                   value: {{ $type | quote }}
+{{- if $root.Values.pgbackrest.info.enabled }}
+                - name: INFO_CONFIGMAP
+                  value: {{ printf "%s-pgbackrest-info" (include "pg.fullname" $root) | quote }}
+{{- end }}
                 # kubectl writes its discovery/http cache under $HOME; point it at the
                 # writable /tmp emptyDir so the read-only root filesystem is enough (#117).
                 - name: HOME

--- a/pg/templates/pgbackrest-info-configmap.yaml
+++ b/pg/templates/pgbackrest-info-configmap.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.pgbackrest.enabled .Values.pgbackrest.info.enabled }}
+# Backup-state record (#343). The backup CronJob patches `pgbackrest info --output=json`
+# into this ConfigMap after every successful backup (data key `info.json`, plus
+# pg-ha/recorded-at, pg-ha/backup-type, pg-ha/stanza, pg-ha/primary and pg-ha/status-code
+# annotations), so a controller can read backup sets, sizes and the PITR floor without
+# pgbackrest credentials or a control-API certificate.
+#
+# Rendered EMPTY by the chart, on purpose. The writer is the pgbackrest ServiceAccount,
+# which can exec into the database pods (#134): letting it create the ConfigMap would need
+# an unscopable `create configmaps` grant, while patching one the chart already rendered
+# needs only get/patch on this name (pgbackrest-rbac.yaml). Helm's three-way merge leaves
+# `data` and the runner's annotations alone on upgrade because no manifest carries them;
+# `helm upgrade --force` resets the record until the next backup.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pg.fullname" . }}-pgbackrest-info
+  labels:
+    {{- include "pg.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pgbackrest
+  {{- with (include "pg.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/pg/templates/pgbackrest-rbac.yaml
+++ b/pg/templates/pgbackrest-rbac.yaml
@@ -53,6 +53,16 @@ rules:
       - {{ printf "%s-%d" (include "pg.fullname" $) $i | quote }}
       {{- end }}
     verbs: ["create"]
+{{- if .Values.pgbackrest.info.enabled }}
+  # Record `pgbackrest info --output=json` after each backup (#343). The ConfigMap is
+  # rendered by the chart (pgbackrest-info-configmap.yaml) precisely so this SA -- which
+  # can exec into the database pods -- needs only get/patch on that one name, never the
+  # unscopable `create configmaps`.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["{{ include "pg.fullname" . }}-pgbackrest-info"]
+    verbs: ["get", "patch"]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/pg/tests/test-backup-concurrent.sh
+++ b/pg/tests/test-backup-concurrent.sh
@@ -39,6 +39,35 @@ if [ "${full_rc}" -ne 0 ]; then
 fi
 assert_eq "initial full backup (stanza-create) succeeds" "0" "${full_rc}"
 
+# --- #343: the Job recorded the repository state where a controller can read it ---
+INFO_CM="${FULLNAME}-pgbackrest-info"
+info_json() { kubectl get configmap -n "${NAMESPACE}" "${INFO_CM}" -o jsonpath='{.data.info\.json}' 2>/dev/null || true; }
+info_ann() { kubectl get configmap -n "${NAMESPACE}" "${INFO_CM}" -o go-template="{{index .metadata.annotations \"pg-ha/$1\"}}" 2>/dev/null || true; }
+full_info=$(info_json)
+# pgBackRest's document is an array of stanzas; `st` is ours.
+st='.[] | select(.name == "'"${STANZA}"'")'
+assert_eq "#343: info.json is pgBackRest's stanza array" "true" "$(jq -e 'type == "array"' <<< "${full_info}" 2>/dev/null || echo false)"
+assert_eq "#343: status.code is 0 after the full backup" "0" "$(jq -r "${st} | .status.code" <<< "${full_info}" 2>/dev/null)"
+assert_eq "#343: one backup set recorded" "1" "$(jq -r "${st} | .backup | length" <<< "${full_info}" 2>/dev/null)"
+assert_eq "#343: the set is the full backup" "full" "$(jq -r "${st} | .backup[0].type" <<< "${full_info}" 2>/dev/null)"
+assert_gt "#343: repository size is recorded" "$(jq -r "${st} | .backup[0].info.repository.size // 0" <<< "${full_info}" 2>/dev/null)" "0"
+assert_eq "#343: backup-type annotation" "full" "$(info_ann backup-type)"
+assert_eq "#343: status-code annotation" "0" "$(info_ann status-code)"
+assert_eq "#343: primary annotation names the pod the backup ran on" "${POD}" "$(info_ann primary)"
+assert_eq "#343: stanza annotation" "${STANZA}" "$(info_ann stanza)"
+full_recorded_at=$(info_ann recorded-at)
+assert_contains "#343: recorded-at is RFC3339 UTC" "${full_recorded_at}" '^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z$'
+assert_contains "#343: the Job log carries the one-line summary" "$(kubectl logs -n "${NAMESPACE}" job/pgbr-full 2>/dev/null)" "Recorded repository state in configmap/${INFO_CM}: status=0 (ok) backups=1"
+# The grant is the smallest that can write the record: get/patch on this one ConfigMap, from
+# a ServiceAccount that can exec into the database pods (#134) and must get nothing wider.
+PGBR_SA="system:serviceaccount:${NAMESPACE}:${FULLNAME}-pgbackrest"
+sa_can() { kubectl auth can-i "$1" "$2" -n "${NAMESPACE}" --as="${PGBR_SA}" 2>/dev/null | tail -1; }
+assert_eq "#343 RBAC: pgbackrest SA can patch the info ConfigMap" "yes" "$(sa_can patch "configmaps/${INFO_CM}")"
+assert_eq "#343 RBAC: ... but not the pgbackrest config ConfigMap" "no" "$(sa_can patch "configmaps/${FULLNAME}-pgbackrest")"
+assert_eq "#343 RBAC: ... nor the primary marker" "no" "$(sa_can patch "configmaps/${FULLNAME}-primary")"
+assert_eq "#343 RBAC: ... and cannot create ConfigMaps" "no" "$(sa_can create configmaps)"
+assert_eq "#343 RBAC: ... nor update the record (patch is enough)" "no" "$(sa_can update "configmaps/${INFO_CM}")"
+
 # clean archiver stats so the concurrent-window failed_count baseline is the post-stanza
 # state (archive_command fails before the stanza exists; that is not what we measure here)
 pg_exec "${NAMESPACE}" "${POD}" "SELECT pg_stat_reset_shared('archiver')" "testuser" "testdb" >/dev/null 2>&1 || true
@@ -84,6 +113,15 @@ n_full=$(printf '%s\n' "${info}" | grep -c "full backup:" || true)
 n_diff=$(printf '%s\n' "${info}" | grep -c "diff backup:" || true)
 assert_gt "#34: repository has a full backup" "${n_full}" "0"
 assert_gt "#34: repository has the concurrent diff backup" "${n_diff}" "0"
+
+# --- #343: the diff run refreshed the record ---
+diff_info=$(info_json)
+assert_eq "#343: two backup sets recorded after the diff" "2" "$(jq -r "${st} | .backup | length" <<< "${diff_info}" 2>/dev/null)"
+assert_eq "#343: the newest set is the diff" "diff" "$(jq -r "${st} | .backup[-1].type" <<< "${diff_info}" 2>/dev/null)"
+assert_eq "#343: the diff names its prior full" "$(jq -r "${st} | .backup[0].label" <<< "${diff_info}" 2>/dev/null)" "$(jq -r "${st} | .backup[-1].prior" <<< "${diff_info}" 2>/dev/null)"
+assert_eq "#343: backup-type annotation follows the run" "diff" "$(info_ann backup-type)"
+assert_eq "#343: status.code still 0" "0" "$(info_ann status-code)"
+assert_not_eq "#343: recorded-at advanced" "${full_recorded_at}" "$(info_ann recorded-at)"
 
 # --- WAL archiving stayed healthy across the backup: no failed pushes, archiver advanced ---
 failed=$(pg_exec "${NAMESPACE}" "${POD}" "SELECT failed_count FROM pg_stat_archiver" "testuser" "testdb" 2>/dev/null || echo "")

--- a/pg/tests/test-template.sh
+++ b/pg/tests/test-template.sh
@@ -3009,6 +3009,107 @@ assert_contains "#155: pgbackrest CronJob no privilege escalation" "${pgbackrest
 assert_contains "pgbackrest: full CronJob carries full schedule" "${pgbackrest_cron}" 'schedule: "0 1 \* \* 0"'
 assert_contains "pgbackrest: diff CronJob carries diff schedule" "${pgbackrest_cron}" 'schedule: "0 1 \* \* 1-6"'
 
+# #343: after a successful backup the CronJob records `pgbackrest info --output=json` in
+# configmap/<fullname>-pgbackrest-info, keyed on the JSON's status.code (the exit status
+# lies: `info` exits 0 on a repository it cannot read). Render-level assertions first.
+assert_contains "#343: CronJob names the info ConfigMap" "${pgbackrest_cron}" 'name: INFO_CONFIGMAP'
+assert_contains "#343: CronJob env points at <fullname>-pgbackrest-info" "${pgbackrest_cron}" 'value: "test-pg-pgbackrest-info"'
+assert_contains_literal "#343: info is read as JSON with console logging off" "${pgbackrest_cron}" '--output=json --log-level-console=off info'
+assert_contains_literal "#343: verdict is the JSON status.code of OUR stanza" "${pgbackrest_cron}" "INFO_STANZA='first(.[] | select(.name == \$s))'"
+assert_contains_literal "#343: ... read with jq" "${pgbackrest_cron}" 'INFO_CODE=$(jq -r --arg s "$STANZA" "($INFO_STANZA | .status.code) // \"absent\"" "$HOME/info.json")'
+assert_contains_literal "#343: jq is checked before the backup runs" "${pgbackrest_cron}" 'command -v jq >/dev/null 2>&1 || {'
+assert_not_contains "#343: the record never touches a hard-coded /tmp (the test redirects HOME)" "${pgbackrest_cron}" "/tmp/info"
+assert_contains_literal "#343: record is written with a scoped patch" "${pgbackrest_cron}" 'patch configmap "$INFO_CONFIGMAP" --type merge'
+assert_not_contains "#343: info capture is not masked" "${pgbackrest_cron}" "info || true"
+assert_not_contains "#343: patch is not masked" "${pgbackrest_cron}" 'patch-file "$HOME/info-patch.json" || true'
+pgbackrest_info_cm=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-pgbackrest.yaml" --show-only templates/pgbackrest-info-configmap.yaml 2>&1)
+assert_contains "#343: info ConfigMap renders" "${pgbackrest_info_cm}" "name: test-pg-pgbackrest-info"
+assert_not_contains "#343: info ConfigMap renders without data (the CronJob owns it)" "${pgbackrest_info_cm}" "^data:"
+pgbackrest_rbac=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-pgbackrest.yaml" --show-only templates/pgbackrest-rbac.yaml 2>&1)
+assert_contains "#343: pgbackrest Role may patch the info ConfigMap" "${pgbackrest_rbac}" 'resourceNames: \["test-pg-pgbackrest-info"\]'
+assert_contains_literal "#343: ... with get/patch only" "${pgbackrest_rbac}" 'verbs: ["get", "patch"]'
+pgbackrest_cm_rules=$(grep -A2 'resources: \["configmaps"\]' <<< "${pgbackrest_rbac}")
+assert_not_contains "#343: pgbackrest Role never gets create on configmaps (unscopable)" "${pgbackrest_cm_rules}" "create"
+assert_not_contains "#343: pgbackrest Role never gets update on configmaps" "${pgbackrest_cm_rules}" "update"
+pgbackrest_noinfo=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-pgbackrest.yaml" --set pgbackrest.info.enabled=false 2>&1)
+assert_not_contains "#343: info.enabled=false drops the ConfigMap" "${pgbackrest_noinfo}" "pgbackrest-info"
+assert_not_contains "#343: info.enabled=false drops the JSON capture" "${pgbackrest_noinfo}" "output=json"
+assert_contains "#343: info.enabled=false keeps the human info print" "${pgbackrest_noinfo}" 'pgbackrest --stanza="\$STANZA" info$'
+pgbackrest_infoenv=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-pgbackrest.yaml" \
+  --set 'pgbackrest.extraEnv[0].name=INFO_CONFIGMAP' --set 'pgbackrest.extraEnv[0].value=x' 2>&1) && infoenv_rc=0 || infoenv_rc=$?
+assert_eq "#343: extraEnv may not shadow INFO_CONFIGMAP" "1" "${infoenv_rc}"
+assert_contains "#343: ... and the error names it" "${pgbackrest_infoenv}" "INFO_CONFIGMAP"
+
+# Run the rendered script against a kubectl shim: the only layer that can reach the
+# "backup exited 0 but the repository is unreadable" path (a MinIO repository broken enough
+# for status.code 3 fails stanza-create first, so KinD never gets there). The shim answers
+# the EndpointSlice lookup, the pg_is_in_recovery probe, stanza-create, backup and info from
+# canned output and captures the patch body.
+pgbr_shim_dir=$(mktemp -d)
+awk '/^                - \|$/{f=1;next} /^              env:$/{exit} f{sub(/^                  /,""); print}' \
+  <<< "${pgbackrest_cron}" > "${pgbr_shim_dir}/backup.sh"
+cat > "${pgbr_shim_dir}/kubectl" <<'SHIM'
+#!/bin/bash
+printf '%s\n' "$*" >> "${SHIM_LOG}"
+case "$*" in
+  *"get endpointslices"*) echo "test-pg-0" ;;
+  *"pg_is_in_recovery"*)  echo "f" ;;
+  *"stanza-create")       ;;
+  *"--output=json"*)      cat "${SHIM_INFO}" ;;
+  *" backup")             echo "backup ok" ;;
+  *"patch configmap"*)    a="$*"; cp "${a##*--patch-file }" "${SHIM_PATCH}" ;;
+  *) echo "shim: unexpected kubectl $*" >&2; exit 99 ;;
+esac
+SHIM
+chmod +x "${pgbr_shim_dir}/kubectl"
+pgbr_run() { # pgbr_run <info-file> -> sets pgbr_rc, pgbr_out; leaves the patch in $pgbr_shim_dir/patch.json
+  rm -f "${pgbr_shim_dir}/patch.json" "${pgbr_shim_dir}/log"
+  pgbr_out=$(PATH="${pgbr_shim_dir}:${PATH}" SHIM_LOG="${pgbr_shim_dir}/log" SHIM_INFO="$1" SHIM_PATCH="${pgbr_shim_dir}/patch.json" \
+    NAMESPACE=ns PRIMARY_SVC=test-pg STANZA=db BACKUP_TYPE=full INFO_CONFIGMAP=test-pg-pgbackrest-info HOME="${pgbr_shim_dir}" \
+    bash -eu -o pipefail "${pgbr_shim_dir}/backup.sh" 2>&1) && pgbr_rc=0 || pgbr_rc=$?
+}
+# Shape as pgBackRest 2.59 emits it: an ARRAY of stanzas (the issue's paste dropped the wrapper).
+pgbr_ok='[{"name":"db","backup":[{"label":"20260908-143406F","type":"full","error":false,"prior":null,"timestamp":{"start":1788878046,"stop":1788878049},"info":{"size":23200780,"repository":{"size":2996380,"delta":2996380}},"archive":{"start":"000000010000000000000002","stop":"000000010000000000000002"},"lsn":{"start":"0/2000028","stop":"0/2000120"}}],"archive":[{"id":"17-1","min":"000000010000000000000001","max":"000000010000000000000002"}],"status":{"code":0,"message":"ok"}}]'
+# A pre-logging WARN (an unknown PGBACKREST_* option from pgbackrest.extraEnv) lands on stdout
+# ahead of the document; the script must skip it.
+printf 'P00   WARN: environment contains invalid option '"'"'foo'"'"'\n%s\n' "${pgbr_ok}" > "${pgbr_shim_dir}/info-ok.json"
+pgbr_run "${pgbr_shim_dir}/info-ok.json"
+assert_eq "#343 shim: healthy repository -> Job exits 0" "0" "${pgbr_rc}"
+assert_eq "#343 shim: the pre-logging WARN line is stripped and the document recorded verbatim" \
+  "$(jq -c . <<< "${pgbr_ok}")" "$(jq -r '.data["info.json"]' "${pgbr_shim_dir}/patch.json" | jq -c .)"
+assert_eq "#343 shim: status-code annotation" "0" "$(jq -r '.metadata.annotations["pg-ha/status-code"]' "${pgbr_shim_dir}/patch.json")"
+assert_eq "#343 shim: backup-type annotation" "full" "$(jq -r '.metadata.annotations["pg-ha/backup-type"]' "${pgbr_shim_dir}/patch.json")"
+assert_eq "#343 shim: primary annotation" "test-pg-0" "$(jq -r '.metadata.annotations["pg-ha/primary"]' "${pgbr_shim_dir}/patch.json")"
+assert_contains "#343 shim: recorded-at is RFC3339 UTC" "$(jq -r '.metadata.annotations["pg-ha/recorded-at"]' "${pgbr_shim_dir}/patch.json")" '^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z$'
+assert_contains "#343 shim: log carries the one-line summary" "${pgbr_out}" "status=0 (ok) backups=1 latest=20260908-143406F repo-size=2996380"
+assert_eq "#343 shim: info is read exactly once (one S3 round-trip)" "1" "$(grep -c -- '--output=json' "${pgbr_shim_dir}/log")"
+# No jq in the image: fail before the backup, naming the fix, with no kubectl call made.
+mkdir -p "${pgbr_shim_dir}/nojq"; for b in bash sed date grep tr sort sleep cat cp; do ln -sf "$(command -v $b)" "${pgbr_shim_dir}/nojq/$b"; done
+ln -sf "${pgbr_shim_dir}/kubectl" "${pgbr_shim_dir}/nojq/kubectl"; rm -f "${pgbr_shim_dir}/log"
+pgbr_nojq_out=$(PATH="${pgbr_shim_dir}/nojq" SHIM_LOG="${pgbr_shim_dir}/log" NAMESPACE=ns PRIMARY_SVC=test-pg STANZA=db BACKUP_TYPE=full \
+  INFO_CONFIGMAP=test-pg-pgbackrest-info HOME="${pgbr_shim_dir}" bash -eu -o pipefail "${pgbr_shim_dir}/backup.sh" 2>&1) && pgbr_nojq_rc=0 || pgbr_nojq_rc=$?
+assert_eq "#343 shim: an image without jq fails the Job" "1" "${pgbr_nojq_rc}"
+assert_contains "#343 shim: ... naming the fix" "${pgbr_nojq_out}" "set pgbackrest.info.enabled=false"
+assert_eq "#343 shim: ... before any kubectl call (no backup was taken)" "absent" "$([ -f "${pgbr_shim_dir}/log" ] && echo present || echo absent)"
+# The issue's measured case: objects behind delete markers -> `info` exits 0, JSON says code 3.
+printf '%s\n' '[{"name":"db","backup":[],"archive":[],"status":{"code":3,"message":"missing stanza data"}}]' > "${pgbr_shim_dir}/info-bad.json"
+pgbr_run "${pgbr_shim_dir}/info-bad.json"
+assert_eq "#343 shim: unreadable repository -> Job FAILS despite info exiting 0" "1" "${pgbr_rc}"
+assert_eq "#343 shim: ... but the record is written first (unreadable != empty)" "3" "$(jq -r '.metadata.annotations["pg-ha/status-code"]' "${pgbr_shim_dir}/patch.json")"
+assert_contains "#343 shim: ... and the error names the code and message" "${pgbr_out}" "status.code=3 (missing stanza data)"
+# Our stanza missing from the document: the code is unknowable, so fail -- but record it.
+printf '%s\n' '[{"name":"other","backup":[],"archive":[],"status":{"code":0,"message":"ok"}}]' > "${pgbr_shim_dir}/info-other.json"
+pgbr_run "${pgbr_shim_dir}/info-other.json"
+assert_eq "#343 shim: a document without our stanza fails the Job" "1" "${pgbr_rc}"
+assert_eq "#343 shim: ... recording status-code=absent" "absent" "$(jq -r '.metadata.annotations["pg-ha/status-code"]' "${pgbr_shim_dir}/patch.json")"
+assert_contains "#343 shim: ... and saying so" "${pgbr_out}" "stanza not in the document"
+# No JSON at all (pgbackrest died before printing): fail, and record nothing.
+printf 'P00  ERROR: [041]: unable to connect\n' > "${pgbr_shim_dir}/info-none.json"
+pgbr_run "${pgbr_shim_dir}/info-none.json"
+assert_not_eq "#343 shim: non-JSON info output fails the Job" "0" "${pgbr_rc}"
+assert_eq "#343 shim: ... without writing a record" "absent" "$([ -f "${pgbr_shim_dir}/patch.json" ] && echo present || echo absent)"
+rm -rf "${pgbr_shim_dir}"
+
 # pgBackRest: RBAC for CronJob exec access.
 pgbackrest_rbac=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-pgbackrest.yaml" --show-only templates/pgbackrest-rbac.yaml 2>&1)
 assert_contains "pgbackrest rbac: ServiceAccount renders" "${pgbackrest_rbac}" "kind: ServiceAccount"
@@ -3021,9 +3122,10 @@ assert_contains "pgbackrest rbac: endpointslices list verb (#121)" "${pgbackrest
 # Role lets a leaked SA token exec into every pod in the namespace). Both pod
 # rules (pods, pods/exec) carry resourceNames. The EndpointSlice list (#121)
 # cannot be resourceName-scoped (slice names are auto-generated) and reads only
-# EndpointSlice metadata, so it is excluded from this count.
+# EndpointSlice metadata, so it is excluded from this count. The third is the #343 info
+# ConfigMap rule, scoped to its one name for the same reason.
 pgbackrest_rn_count=$(printf '%s\n' "${pgbackrest_rbac}" | grep -c 'resourceNames:')
-assert_eq "pgbackrest rbac: pods+pods/exec resourceName-scoped (#134)" "2" "${pgbackrest_rn_count}"
+assert_eq "pgbackrest rbac: pods+pods/exec+info configmap resourceName-scoped (#134, #343)" "3" "${pgbackrest_rn_count}"
 assert_contains "pgbackrest rbac: scoped to pod test-pg-0 (#134)" "${pgbackrest_rbac}" "\"test-pg-0\""
 assert_contains "pgbackrest rbac: scoped to pod test-pg-1 (#134)" "${pgbackrest_rbac}" "\"test-pg-1\""
 pgbackrest_rbac_n=$(helm template test-pg "${CHART_DIR}" -f "${SCRIPT_DIR}/values-pgbackrest.yaml" --set postgresql.replicaCount=2 --show-only templates/pgbackrest-rbac.yaml 2>&1)

--- a/pg/tests/unit/guards_test.yaml
+++ b/pg/tests/unit/guards_test.yaml
@@ -738,6 +738,19 @@ tests:
       - failedTemplate:
           errorMessage: "pgbackrest.extraEnv/extraVolumes/extraVolumeMounts are set but pgbackrest.enabled is false, so none of the pgbackrest containers they configure is rendered and nothing would use them. Set pgbackrest.enabled=true, or remove these values."
 
+  - it: pgbackrest.extraEnv reusing the #343 record name (INFO_CONFIGMAP) fails render
+    templates:
+      - templates/statefulset.yaml
+    values:
+      - ../values-pgbackrest.yaml
+    set:
+      pgbackrest.extraEnv:
+        - name: INFO_CONFIGMAP
+          value: elsewhere
+    asserts:
+      - failedTemplate:
+          errorPattern: 'pgbackrest.extraEnv\[0\]: "INFO_CONFIGMAP" is set by the chart or the HA agent'
+
   - it: pgbackrest.extraEnv reusing a chart-set name (PGBACKREST_STANZA) fails render
     templates:
       - templates/statefulset.yaml

--- a/pg/tests/unit/pgbackrest_info_test.yaml
+++ b/pg/tests/unit/pgbackrest_info_test.yaml
@@ -1,0 +1,108 @@
+suite: pgbackrest info record (#343)
+templates:
+  - templates/pgbackrest-info-configmap.yaml
+  - templates/pgbackrest-rbac.yaml
+  - templates/pgbackrest-cronjob.yaml
+tests:
+  - it: renders the info ConfigMap empty, for the CronJob to fill
+    values:
+      - ../values-pgbackrest.yaml
+    template: templates/pgbackrest-info-configmap.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-pg-pgbackrest-info
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: pgbackrest
+      # No data: the record is the CronJob's; Helm must never carry a `data` it would
+      # then reset on upgrade.
+      - notExists:
+          path: data
+
+  - it: grants the pgbackrest SA get/patch on that one ConfigMap and nothing wider
+    values:
+      - ../values-pgbackrest.yaml
+    template: templates/pgbackrest-rbac.yaml
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Role
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["configmaps"]
+            resourceNames: ["RELEASE-NAME-pg-pgbackrest-info"]
+            verbs: ["get", "patch"]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["configmaps"]
+            verbs: ["create"]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["configmaps"]
+            verbs: ["get", "update"]
+
+  - it: the backup CronJob names the ConfigMap and keys on status.code
+    values:
+      - ../values-pgbackrest.yaml
+    template: templates/pgbackrest-cronjob.yaml
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: INFO_CONFIGMAP
+            value: RELEASE-NAME-pg-pgbackrest-info
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: "--output=json --log-level-console=off info"
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: "INFO_STANZA='first\\(\\.\\[\\] \\| select\\(\\.name == \\$s\\)\\)'"
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: 'patch configmap "\$INFO_CONFIGMAP" --type merge'
+      # The record is written BEFORE the verdict, so an unreadable repository is recorded
+      # as such rather than leaving the previous record in place.
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: '(?s)patch configmap "\$INFO_CONFIGMAP".*if \[ "\$INFO_CODE" != "0" \]; then.*exit 1'
+
+  - it: info.enabled=false renders neither the ConfigMap nor the grant nor the capture
+    values:
+      - ../values-pgbackrest.yaml
+    set:
+      pgbackrest.info.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/pgbackrest-info-configmap.yaml
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["configmaps"]
+            resourceNames: ["RELEASE-NAME-pg-pgbackrest-info"]
+            verbs: ["get", "patch"]
+        template: templates/pgbackrest-rbac.yaml
+        documentIndex: 1
+      - notMatchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: "output=json"
+        template: templates/pgbackrest-cronjob.yaml
+        documentIndex: 0
+      - notContains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: INFO_CONFIGMAP
+            value: RELEASE-NAME-pg-pgbackrest-info
+        template: templates/pgbackrest-cronjob.yaml
+        documentIndex: 0

--- a/pg/values.schema.json
+++ b/pg/values.schema.json
@@ -510,6 +510,15 @@
             }
           }
         },
+        "info": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Record pgbackrest info --output=json into configmap/<fullname>-pgbackrest-info after every successful backup (#343)"
+            }
+          }
+        },
         "validation": {
           "type": "object",
           "properties": {

--- a/pg/values.yaml
+++ b/pg/values.yaml
@@ -1267,6 +1267,17 @@ pgbackrest:
     full: "0 1 * * 0"
     diff: "0 1 * * 1-6"
 
+  # Record `pgbackrest info --output=json` in configmap/<fullname>-pgbackrest-info after every
+  # successful backup (#343): data key info.json plus pg-ha/recorded-at, backup-type, stanza,
+  # primary and status-code annotations, readable by a controller with no pgbackrest
+  # credentials or control-API certificate (GET /v1/backups stays the authenticated read).
+  # The verdict is the JSON's status.code -- `pgbackrest info` exits 0 on a repository it
+  # cannot read -- and a non-zero code also fails the backup Job. Costs the pgbackrest
+  # ServiceAccount get/patch on that one ConfigMap; `helm upgrade --force` empties the record
+  # until the next backup.
+  info:
+    enabled: true
+
   # Sidecar container: keeps pgbackrest binary, config and credentials available
   # on every pg pod. CronJobs locate the current primary and `kubectl exec` into
   # this container to run the backup. The sidecar itself just sleeps.

--- a/pgvector/CHANGELOG.md
+++ b/pgvector/CHANGELOG.md
@@ -1,5 +1,21 @@
 # pgvector chart changelog
 
+## 2.1.0 - 2026-09-08
+
+### Added
+
+- **The backup CronJob records the repository state (#343).** After every successful backup it
+  patches `pgbackrest info --output=json` verbatim into `configmap/<fullname>-pgbackrest-info`
+  (data key `info.json`, plus `pg-ha/recorded-at`, `pg-ha/backup-type`, `pg-ha/stanza`,
+  `pg-ha/primary` and `pg-ha/status-code` annotations), so a controller can read backup sets,
+  sizes and the PITR floor with no pgBackRest credentials, exec grant or control-API
+  certificate. The verdict is the JSON's `status.code`, not the exit status — `pgbackrest info`
+  exits 0 on a repository it cannot read — and a non-zero code now fails the backup Job, where
+  the old trailing human-format `info` passed silently. The ConfigMap is rendered empty so the
+  pgbackrest ServiceAccount needs only `get`/`patch` on that one name; `helm upgrade --force`
+  empties the record until the next backup. Opt out with `pgbackrest.info.enabled=false`.
+  `INFO_CONFIGMAP` joins the names `pgbackrest.extraEnv` may not reuse.
+
 ## 2.0.2 - 2026-09-06
 
 ### Changed

--- a/pgvector/Chart.yaml
+++ b/pgvector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgvector
 description: PostgreSQL with the pgvector extension for vector search, plus streaming replication, agent failover (Kubernetes Lease or etcd-quorum DCS), optional PgPool-II, S3 backups, TLS, and metrics
 type: application
-version: 2.0.2
+version: 2.1.0
 appVersion: "18"
 home: https://github.com/cagriekin/charts/tree/master/pgvector
 icon: https://wiki.postgresql.org/images/a/a4/PostgreSQL_logo.3colors.svg

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -951,6 +951,7 @@ helm install my-pgvector cagriekin/pgvector \
 | `pgbackrest.cronjob.resources.limits.memory` | CronJob memory limit | `128Mi` |
 | `pgbackrest.cronjob.podSecurityContext` | Pod securityContext for the pgBackRest CronJob | `runAsNonRoot: true`, `runAsUser: 65534`, `seccompProfile: RuntimeDefault` |
 | `pgbackrest.cronjob.containerSecurityContext` | Container securityContext for the pgBackRest CronJob | `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]` |
+| `pgbackrest.info.enabled` | Record `pgbackrest info --output=json` in `configmap/<fullname>-pgbackrest-info` after every successful backup and fail the Job on a non-zero `status.code` (#343). See the [pg chart README](../pg/README.md#check-backup-status) | `true` |
 | `pgbackrest.validation.enabled` | Enable the automated PITR restore-validation CronJob (#38) — restores the repo into a throwaway PostgreSQL, replays WAL, validates, exits. See the [pg chart README](../pg/README.md#automated-pitr-restore-validation-38) | `false` |
 | `pgbackrest.validation.schedule` | Cron schedule for the validation job | `` `0 4 * * 0` `` |
 | `pgbackrest.validation.targetType` | PITR target type (`pgbackrest --type`): `""` (latest) \| `time` \| `xid` \| `name` \| `lsn`; `target` required when set | `""` |

--- a/pgvector/templates/pgbackrest-info-configmap.yaml
+++ b/pgvector/templates/pgbackrest-info-configmap.yaml
@@ -1,0 +1,1 @@
+../../pg/templates/pgbackrest-info-configmap.yaml

--- a/pgvector/values.schema.json
+++ b/pgvector/values.schema.json
@@ -510,6 +510,15 @@
             }
           }
         },
+        "info": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Record pgbackrest info --output=json into configmap/<fullname>-pgbackrest-info after every successful backup (#343)"
+            }
+          }
+        },
         "validation": {
           "type": "object",
           "properties": {

--- a/pgvector/values.yaml
+++ b/pgvector/values.yaml
@@ -978,6 +978,11 @@ pgbackrest:
     full: "0 1 * * 0"
     diff: "0 1 * * 1-6"
 
+  # Record `pgbackrest info --output=json` into configmap/<fullname>-pgbackrest-info after
+  # every successful backup (#343); the Job fails on a non-zero status.code. See pg/values.yaml.
+  info:
+    enabled: true
+
   # Sidecar container: keeps pgbackrest binary, config and credentials available
   # on every pg pod. CronJobs locate the current primary and `kubectl exec` into
   # this container to run the backup. The sidecar itself just sleeps.


### PR DESCRIPTION
Closes #343.

After every successful backup the pgbackrest CronJob now patches `pgbackrest info --output=json` verbatim into `configmap/<fullname>-pgbackrest-info` (data key `info.json`) with `pg-ha/recorded-at`, `pg-ha/backup-type`, `pg-ha/stanza`, `pg-ha/primary` and `pg-ha/status-code` annotations, so a controller can read backup sets, sizes and the PITR floor with no pgBackRest credentials, exec grant or control-API certificate.

**The verdict is `status.code`, not the exit status.** `pgbackrest info` exits 0 on a repository it cannot read; the script records the document whatever the code (an unreadable repository stays distinguishable from an empty one) and then fails the Job on a non-zero code, so whatever alerts on a failed backup alerts on this too. The old trailing human-format `info` passed silently on the same repository.

**RBAC.** The ConfigMap is rendered empty by the chart precisely so the pgbackrest ServiceAccount, which can exec into the database pods (#134), needs only `get`/`patch` scoped to that one name and never the unscopable `create configmaps`. Helm's three-way merge leaves the record alone on upgrade; `helm upgrade --force` empties it until the next backup.

**Surface.** `pgbackrest.info.enabled` (default `true`); `INFO_CONFIGMAP` joins the reserved `pgbackrest.extraEnv` names. No image or agent change: `GET /v1/backups` stays the on-demand authenticated read. `jq` comes from the existing `alpine/k8s` runner image.

Note on the issue's premise: `pgbackrest info` reads the repository, not the node, so the primary-resolution argument does not apply to the read. The CronJob is still the right writer because it is the one moment that knows a backup completed; the README says so, so nobody later "fixes" `/v1/backups` to be leader-only.

**Tests**
- helm-unittest: `pgbackrest_info_test.yaml` (ConfigMap without `data`, Role verbs exactly `get`/`patch` on the one name, CronJob env + script, `info.enabled=false` renders none of it), guard case for `INFO_CONFIGMAP` in `pgbackrest.extraEnv`.
- `test-template.sh`: render assertions plus the rendered script run against a `kubectl` shim: healthy repo records the document verbatim with the pre-logging WARN line stripped and exits 0; `status.code: 3` writes the record and exits 1; non-JSON output exits non-zero and writes nothing. This is the only layer that can reach the "backup exited 0, repository unreadable" path.
- KinD `backup-concurrent`: after the full and the diff run, the ConfigMap content, annotations, one-line Job log summary, and `kubectl auth can-i` for the pgbackrest SA (patch on the record yes; patch on the config ConfigMap and the primary marker, create configmaps, update, all no).

pg and pgvector → 2.1.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Backup jobs now record verbatim `pgBackRest` JSON status and metadata in a dedicated ConfigMap after successful backups.
  - Backup status is determined by the reported JSON status code, improving detection of unreadable or incomplete repositories.
  - Added `pgbackrest.info.enabled`, enabled by default, with an option to disable status recording.
  - Added documentation for backup status records, metadata, and configuration.

- **Bug Fixes**
  - Backup jobs now fail when `pgBackRest` reports a non-zero status, even if the command itself completes successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->